### PR TITLE
fix: detect and warn when DOB is entered in US date format (MM/DD/YYYY)

### DIFF
--- a/apps/web/src/app/shared/forms/person-form/person-form.component.html
+++ b/apps/web/src/app/shared/forms/person-form/person-form.component.html
@@ -65,7 +65,10 @@
 
   <!-- Date of Birth -->
   <div class="field-group">
-    <div class="field-title">Date of birth</div>
+    <div class="field-title">
+      Date of birth
+      <span class="field-optional">DD / MM / YYYY</span>
+    </div>
     <div class="dob-fields">
       <div class="field dob-field">
         <input
@@ -105,7 +108,15 @@
         />
       </div>
     </div>
-    @if (showErrors && dobError()) {
+    @if (dobSwapWarning()) {
+    <div class="dob-swap-warning">
+      It looks like you may have entered month/day in US format. The order is
+      <strong>Day / Month / Year</strong>.
+      <button type="button" class="swap-btn" (click)="SwapDobDayMonth()">
+        Swap day &amp; month
+      </button>
+    </div>
+    } @if (showErrors && dobError()) {
     <div class="error">{{ dobError() }}</div>
     }
   </div>

--- a/apps/web/src/app/shared/forms/person-form/person-form.component.scss
+++ b/apps/web/src/app/shared/forms/person-form/person-form.component.scss
@@ -57,6 +57,34 @@
   opacity: $dimmed-extra;
 }
 
+.dob-swap-warning {
+  margin-top: $spacing-small;
+  padding: $spacing-small;
+  font-size: $font-size-small;
+  color: #92400e;
+  background-color: #fffbeb;
+  border: 1px solid #fbbf24;
+  border-radius: $border-radius-small;
+  line-height: 1.5;
+
+  .swap-btn {
+    display: inline;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font-size: inherit;
+    color: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+    font-weight: 600;
+
+    &:hover {
+      opacity: $dimmed;
+    }
+  }
+}
+
 select {
   width: 100%;
 }

--- a/apps/web/src/app/shared/forms/person-form/person-form.component.ts
+++ b/apps/web/src/app/shared/forms/person-form/person-form.component.ts
@@ -76,6 +76,7 @@ export class PersonFormComponent implements OnInit, OnChanges {
   dobMonth: WritableSignal<number | null> = signal(null);
   dobYear: WritableSignal<number | null> = signal(null);
   dobError: WritableSignal<string> = signal('');
+  dobSwapWarning: WritableSignal<boolean> = signal(false);
 
   // Address fields
   addressLine1: WritableSignal<string> = signal('');
@@ -225,6 +226,7 @@ export class PersonFormComponent implements OnInit, OnChanges {
   OnDobDayChange(value: string): void {
     const numValue = value ? parseInt(value, 10) : null;
     this.dobDay.set(numValue);
+    this.CheckDobSwapWarning();
     this.ValidateDob();
     this.EmitFormChange();
   }
@@ -232,6 +234,7 @@ export class PersonFormComponent implements OnInit, OnChanges {
   OnDobMonthChange(value: string): void {
     const numValue = value ? parseInt(value, 10) : null;
     this.dobMonth.set(numValue);
+    this.CheckDobSwapWarning();
     this.ValidateDob();
     this.EmitFormChange();
   }
@@ -241,6 +244,24 @@ export class PersonFormComponent implements OnInit, OnChanges {
     this.dobYear.set(numValue);
     this.ValidateDob();
     this.EmitFormChange();
+  }
+
+  SwapDobDayMonth(): void {
+    const day = this.dobDay();
+    const month = this.dobMonth();
+    this.dobDay.set(month);
+    this.dobMonth.set(day);
+    this.dobSwapWarning.set(false);
+    this.ValidateDob();
+    this.EmitFormChange();
+  }
+
+  private CheckDobSwapWarning(): void {
+    const day = this.dobDay();
+    const month = this.dobMonth();
+    const looksSwapped =
+      day !== null && month !== null && day <= 12 && month > 12;
+    this.dobSwapWarning.set(looksSwapped);
   }
 
   // Address handlers


### PR DESCRIPTION
## Description

Detects & warns when a user has entered DOB in MM/DD/YYYY format and allows switching to DD/MM/YYYY.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?
- [x] Manual testing
