### PR TITLE
fix: handle transient API failures during onboarding initialization

### DIFF
--- a/apps/web/src/app/features/onboard/onboard.component.html
+++ b/apps/web/src/app/features/onboard/onboard.component.html
@@ -65,7 +65,10 @@
         <div class="right-panel-content">
           @if(initError()){
           <h1>Something went wrong</h1>
-          <p>We couldn't load your account. This can happen due to a temporary connection issue.</p>
+          <p>
+            We couldn't load your account. This can happen due to a temporary
+            connection issue.
+          </p>
           <button
             type="button"
             class="action-button action-button-wide"
@@ -241,8 +244,7 @@
           >
             Finish Setup
           </button>
-          }
-          }
+          } }
         </div>
       </div>
     </div>

--- a/apps/web/src/app/features/onboard/onboard.component.html
+++ b/apps/web/src/app/features/onboard/onboard.component.html
@@ -63,6 +63,17 @@
       <!-- Right Panel - Form Content -->
       <div class="right-panel">
         <div class="right-panel-content">
+          @if(initError()){
+          <h1>Something went wrong</h1>
+          <p>We couldn't load your account. This can happen due to a temporary connection issue.</p>
+          <button
+            type="button"
+            class="action-button action-button-wide"
+            (click)="RetryInit()"
+          >
+            Try again
+          </button>
+          } @else {
           <!-- Step 1: Person Details -->
           @if(step() === STEPS.PERSON){
           <app-person-form
@@ -230,6 +241,7 @@
           >
             Finish Setup
           </button>
+          }
           }
         </div>
       </div>

--- a/apps/web/src/app/features/onboard/onboard.component.ts
+++ b/apps/web/src/app/features/onboard/onboard.component.ts
@@ -124,8 +124,8 @@ export class OnboardComponent implements OnInit {
       if (account) {
         await this.externalWalletService.GetExternalWallets(account.id);
       }
-			
-			// Check: may fail loading data due to network error after token exchange, allows for retries.
+
+      // Check: may fail loading data due to network error after token exchange, allows for retries.
       if (!this.accountService.account() || !this.personService.person()) {
         this.initError.set(true);
         this.loading.set(false);

--- a/apps/web/src/app/features/onboard/onboard.component.ts
+++ b/apps/web/src/app/features/onboard/onboard.component.ts
@@ -80,6 +80,7 @@ export class OnboardComponent implements OnInit {
   loading: WritableSignal<boolean> = signal(true);
   nextLoading: WritableSignal<boolean> = signal(false);
   apiError: WritableSignal<string> = signal('');
+  initError: WritableSignal<boolean> = signal(false);
 
   showPersonErrors: WritableSignal<boolean> = signal(false);
   showWalletErrors: WritableSignal<boolean> = signal(false);
@@ -96,6 +97,10 @@ export class OnboardComponent implements OnInit {
   editWalletLoading: WritableSignal<boolean> = signal(false);
   editWalletShowErrors: WritableSignal<boolean> = signal(false);
 
+  private tokenExchanged = false;
+  private initRetries = 0;
+  private readonly MAX_INIT_RETRIES = 3;
+
   async ngOnInit(): Promise<void> {
     this.meta.SetMeta(this.seo);
     try {
@@ -106,9 +111,10 @@ export class OnboardComponent implements OnInit {
       // Load platform config for branding (pass token for correct platform context)
       await this.configService.LoadConfig(token || undefined);
 
-      // Exchange token for session if present
-      if (token) {
+      // Exchange token for session if present (only on first load, not retries)
+      if (token && !this.tokenExchanged) {
         await this.accountLinkService.ExchangeToken(token);
+        this.tokenExchanged = true;
       }
 
       const account = await this.accountService.GetAccount();
@@ -118,17 +124,36 @@ export class OnboardComponent implements OnInit {
       if (account) {
         await this.externalWalletService.GetExternalWallets(account.id);
       }
+			
+			// Check: may fail loading data due to network error after token exchange, allows for retries.
+      if (!this.accountService.account() || !this.personService.person()) {
+        this.initError.set(true);
+        this.loading.set(false);
+        return;
+      }
+
       this.DetermineInitialStep();
       this.loading.set(false);
     } catch (error) {
       console.error(error);
-      // Redirect to session expired page on any auth error
       if (this.accountLinkService.linkError()) {
         this.router.navigateByUrl('/session-expired?reason=link_expired');
         return;
       }
+      this.initError.set(true);
       this.loading.set(false);
     }
+  }
+
+  async RetryInit(): Promise<void> {
+    this.initRetries++;
+    if (this.initRetries >= this.MAX_INIT_RETRIES) {
+      this.router.navigateByUrl('/session-expired?reason=load_failed');
+      return;
+    }
+    this.initError.set(false);
+    this.loading.set(true);
+    await this.ngOnInit();
   }
 
   CheckUrlParams(): void {


### PR DESCRIPTION
## Description

When GetAccount or LoadConfig fails due to network issues, the onboard page was rendering an interactive form with null account/person data, causing "Account or person not found" errors on submit. Now shows a retry screen instead, with a fallback redirect after 3 attempts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

Test onboarding several users, forcing failure via early returns in `account.service.ts GetAccount()`

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
