### PR TITLE
feat: add test mode autofill for onboarding forms and dashboard testmode banner

### DIFF
--- a/apps/api/src/routes/config.routes.ts
+++ b/apps/api/src/routes/config.routes.ts
@@ -22,6 +22,7 @@ import { ERRORS } from '../utils/Errors';
 import { VerifyToken } from '../utils/Token';
 import { GetJwtSecret } from '../modules/AppConfig';
 import { SolanaExplorerUrl } from '../modules/chains/Solana';
+import { GetAppConfig } from '../modules/AppConfig';
 
 const router = express.Router();
 
@@ -34,6 +35,8 @@ const apiKeyModule = new ApiKeyModule(db);
  * Helper to build PublicConfig from a platform account.
  */
 function BuildPublicConfig(platformAccount: Account | null): PublicConfig {
+  const { livemode } = GetAppConfig();
+
   if (!platformAccount) {
     return {
       object: 'config',
@@ -41,6 +44,7 @@ function BuildPublicConfig(platformAccount: Account | null): PublicConfig {
       platform_logo_url: '',
       terms_url: '',
       privacy_url: '',
+      livemode,
     };
   }
 
@@ -53,6 +57,7 @@ function BuildPublicConfig(platformAccount: Account | null): PublicConfig {
     platform_logo_url: platformAccount.settings?.branding?.logo || '',
     terms_url: platformAccount.settings?.terms_url || '',
     privacy_url: platformAccount.settings?.privacy_url || '',
+    livemode,
   };
 }
 

--- a/apps/web/src/app/data/services/config.service.ts
+++ b/apps/web/src/app/data/services/config.service.ts
@@ -137,6 +137,13 @@ export class ConfigService {
   }
 
   /**
+   * Returns true if the platform is running in test mode (not live).
+   */
+  IsTestMode(): boolean {
+    return this.config()?.livemode === false;
+  }
+
+  /**
    * Clear the cached config. Useful when switching contexts.
    */
   ClearConfig(): void {

--- a/apps/web/src/app/features/account/account.component.html
+++ b/apps/web/src/app/features/account/account.component.html
@@ -1,6 +1,12 @@
 <div class="site-wrapper-dashboard">
   <app-page-loader [loading]="loading()"></app-page-loader>
 
+  @if (configService.IsTestMode()) {
+  <div class="test-mode-bar">
+    You're using test data. Transactions use the Solana devnet.
+  </div>
+  }
+
   <div class="account-content-wrapper">
     <div class="sidebar-wrapper">
       <app-side-menu

--- a/apps/web/src/app/features/account/account.component.scss
+++ b/apps/web/src/app/features/account/account.component.scss
@@ -1,6 +1,16 @@
 @use '../../styles/base.scss' as *;
 @use '../../styles/buttons.scss' as *;
 
+.test-mode-bar {
+  background-color: #f59e0b;
+  color: white;
+  text-align: center;
+  padding: $spacing-small $spacing;
+  font-size: $font-size;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
 .site-wrapper-dashboard {
   padding: 0;
   max-width: none;

--- a/apps/web/src/app/features/account/account.component.ts
+++ b/apps/web/src/app/features/account/account.component.ts
@@ -106,7 +106,7 @@ export class AccountComponent implements OnInit {
   private readonly authService = inject(AuthService);
   readonly accountService = inject(AccountService);
   private readonly balanceService = inject(BalanceService);
-  private readonly configService = inject(ConfigService);
+  readonly configService = inject(ConfigService);
   private readonly topupService = inject(TopupService);
   readonly personService = inject(PersonService);
   readonly externalWalletService = inject(ExternalWalletService);

--- a/apps/web/src/app/features/account/components/add-funds-panel/add-funds-panel.component.ts
+++ b/apps/web/src/app/features/account/components/add-funds-panel/add-funds-panel.component.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/core';
 import { DecimalPipe, DatePipe } from '@angular/common';
 
-import { TopupService } from '../../../../data';
+import { TopupService, ConfigService } from '../../../../data';
 import { LoaderComponent, StatusChipComponent } from '../../../../shared';
 import { DepositInfo, TopUp } from '@zoneless/shared-types';
 
@@ -30,6 +30,7 @@ type PanelState = 'loading' | 'info' | 'waiting' | 'success';
 })
 export class AddFundsPanelComponent implements OnChanges, OnDestroy {
   private readonly topupService = inject(TopupService);
+  private readonly configService = inject(ConfigService);
   private readonly elementRef = inject(ElementRef);
   private checkInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -108,8 +109,7 @@ export class AddFundsPanelComponent implements OnChanges, OnDestroy {
   }
 
   IsTestMode(): boolean {
-    const url = this.depositInfo()?.explorer_url || '';
-    return url.includes('cluster=devnet');
+    return this.configService.IsTestMode();
   }
 
   GetExplorerUrl(): string {

--- a/apps/web/src/app/shared/forms/external-wallet-form/external-wallet-form.component.html
+++ b/apps/web/src/app/shared/forms/external-wallet-form/external-wallet-form.component.html
@@ -1,4 +1,13 @@
 <div class="external-wallet-form">
+  <!-- Test Mode Banner -->
+  @if (mode === 'onboard' && configService.IsTestMode()) {
+  <app-test-mode-banner
+    message="You're using a test account."
+    actionLabel="Use test wallet"
+    (actionClicked)="FillTestData()"
+  ></app-test-mode-banner>
+  }
+
   <!-- Header (onboard mode only) -->
   @if (mode === 'onboard') {
   <h1>Add your payout wallet</h1>

--- a/apps/web/src/app/shared/forms/external-wallet-form/external-wallet-form.component.ts
+++ b/apps/web/src/app/shared/forms/external-wallet-form/external-wallet-form.component.ts
@@ -9,15 +9,20 @@ import {
   signal,
   WritableSignal,
   ChangeDetectionStrategy,
+  inject,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ExternalWallet } from '@zoneless/shared-types';
+
+import { TestModeBannerComponent } from '../../ui';
+import { ConfigService } from '../../../data';
 
 import {
   ValidateSolanaAddress,
   GetSolanaAddressError,
   SOLANA_NETWORK,
   SOLANA_CURRENCY,
+  TEST_WALLET_DATA,
 } from '../../../utils';
 
 export type ExternalWalletFormMode = 'onboard' | 'edit';
@@ -31,12 +36,14 @@ export interface ExternalWalletFormData {
 @Component({
   selector: 'app-external-wallet-form',
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, TestModeBannerComponent],
   templateUrl: './external-wallet-form.component.html',
   styleUrls: ['./external-wallet-form.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ExternalWalletFormComponent implements OnInit, OnChanges {
+  readonly configService = inject(ConfigService);
+
   @Input() mode: ExternalWalletFormMode = 'onboard';
   @Input() wallet: ExternalWallet | null = null;
   @Input() showErrors = false;
@@ -124,6 +131,12 @@ export class ExternalWalletFormComponent implements OnInit, OnChanges {
       network: this.network,
       currency: this.currency,
     };
+  }
+
+  FillTestData(): void {
+    this.walletAddress.set(TEST_WALLET_DATA.walletAddress);
+    this.ValidateWalletAddress();
+    this.EmitFormChange();
   }
 
   ToggleWalletGuide(): void {

--- a/apps/web/src/app/shared/forms/person-form/person-form.component.html
+++ b/apps/web/src/app/shared/forms/person-form/person-form.component.html
@@ -1,4 +1,13 @@
 <div class="person-form">
+  <!-- Test Mode Banner -->
+  @if (mode === 'onboard' && configService.IsTestMode()) {
+  <app-test-mode-banner
+    message="You're using a test account with test data."
+    actionLabel="Use test data"
+    (actionClicked)="FillTestData()"
+  ></app-test-mode-banner>
+  }
+
   <!-- Header (onboard mode only) -->
   @if (mode === 'onboard') {
   <h1>Verify your personal details</h1>

--- a/apps/web/src/app/shared/forms/person-form/person-form.component.ts
+++ b/apps/web/src/app/shared/forms/person-form/person-form.component.ts
@@ -12,13 +12,15 @@ import {
   inject,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-
 import { Person } from '@zoneless/shared-types';
+
+import { TestModeBannerComponent } from '../../ui';
 import {
   NAME_MIN_LENGTH,
   NAME_MAX_LENGTH,
   ISO_CODES,
   GetCountryDialCode,
+  TEST_PERSON_DATA,
 } from '../../../utils';
 import { ConfigService } from '../../../data';
 
@@ -43,7 +45,7 @@ export interface PersonFormData {
 @Component({
   selector: 'app-person-form',
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, TestModeBannerComponent],
   templateUrl: './person-form.component.html',
   styleUrls: ['./person-form.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -555,6 +557,32 @@ export class PersonFormComponent implements OnInit, OnChanges {
         country: this.addressCountry() || null,
       },
     };
+  }
+
+  FillTestData(): void {
+    this.firstName.set(TEST_PERSON_DATA.firstName);
+    this.lastName.set(TEST_PERSON_DATA.lastName);
+    this.email.set(TEST_PERSON_DATA.email);
+    this.dobDay.set(TEST_PERSON_DATA.dobDay);
+    this.dobMonth.set(TEST_PERSON_DATA.dobMonth);
+    this.dobYear.set(TEST_PERSON_DATA.dobYear);
+    this.addressLine1.set(TEST_PERSON_DATA.addressLine1);
+    this.addressLine2.set(TEST_PERSON_DATA.addressLine2);
+    this.addressCity.set(TEST_PERSON_DATA.addressCity);
+    this.addressState.set(TEST_PERSON_DATA.addressState);
+    this.addressPostalCode.set(TEST_PERSON_DATA.addressPostalCode);
+    this.addressCountry.set(TEST_PERSON_DATA.addressCountry);
+
+    const country = ISO_CODES.find(
+      (c) => c.code === TEST_PERSON_DATA.addressCountry
+    );
+    if (country) {
+      this.phoneCountryCode.set(country.code);
+    }
+    this.ParseAndSetPhone(TEST_PERSON_DATA.phone);
+
+    this.ValidateAll();
+    this.EmitFormChange();
   }
 
   private IsValidEmail(email: string): boolean {

--- a/apps/web/src/app/shared/ui/index.ts
+++ b/apps/web/src/app/shared/ui/index.ts
@@ -6,3 +6,4 @@ export * from './settings-card/settings-card.component';
 export * from './side-menu/side-menu.component';
 export * from './slide-panel/slide-panel.component';
 export * from './status-chip/status-chip.component';
+export * from './test-mode-banner/test-mode-banner.component';

--- a/apps/web/src/app/shared/ui/test-mode-banner/test-mode-banner.component.html
+++ b/apps/web/src/app/shared/ui/test-mode-banner/test-mode-banner.component.html
@@ -1,0 +1,28 @@
+<div class="test-mode-banner">
+  <div class="test-mode-banner-content">
+    <svg
+      class="test-mode-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" />
+      <line
+        x1="12"
+        y1="8"
+        x2="12"
+        y2="12"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+      />
+      <circle cx="12" cy="16" r="1" fill="currentColor" />
+    </svg>
+    <span class="test-mode-message">{{ message }}</span>
+  </div>
+  @if (actionLabel) {
+  <button type="button" class="test-mode-action" (click)="OnAction()">
+    {{ actionLabel }}
+  </button>
+  }
+</div>

--- a/apps/web/src/app/shared/ui/test-mode-banner/test-mode-banner.component.scss
+++ b/apps/web/src/app/shared/ui/test-mode-banner/test-mode-banner.component.scss
@@ -1,0 +1,52 @@
+@use '../../../styles/base.scss' as *;
+
+.test-mode-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing;
+  padding: $spacing;
+  background-color: #eff6ff;
+  border-radius: $border-radius-small;
+  font-size: $font-size;
+  color: #1e40af;
+  line-height: 1.4;
+}
+
+.test-mode-banner-content {
+  display: flex;
+  align-items: center;
+  gap: $spacing-small;
+  flex: 1;
+  min-width: 0;
+}
+
+.test-mode-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.test-mode-message {
+  flex: 1;
+}
+
+.test-mode-action {
+  flex-shrink: 0;
+  padding: $spacing-small $spacing;
+  background-color: white;
+  color: #1e40af;
+  border: 1px solid #bfdbfe;
+  border-radius: $border-radius-small;
+  font-family: $text-font;
+  font-size: $font-size;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color $transition-fast;
+  white-space: nowrap;
+
+  &:hover {
+    background-color: #dbeafe;
+  }
+}

--- a/apps/web/src/app/shared/ui/test-mode-banner/test-mode-banner.component.ts
+++ b/apps/web/src/app/shared/ui/test-mode-banner/test-mode-banner.component.ts
@@ -1,0 +1,24 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+
+@Component({
+  selector: 'app-test-mode-banner',
+  standalone: true,
+  templateUrl: './test-mode-banner.component.html',
+  styleUrls: ['./test-mode-banner.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TestModeBannerComponent {
+  @Input() message = "You're using a test account.";
+  @Input() actionLabel = '';
+  @Output() actionClicked = new EventEmitter<void>();
+
+  OnAction(): void {
+    this.actionClicked.emit();
+  }
+}

--- a/apps/web/src/app/utils/constants/index.ts
+++ b/apps/web/src/app/utils/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './config';
 export * from './country-codes';
 export * from './limits';
+export * from './test-data';

--- a/apps/web/src/app/utils/constants/test-data.ts
+++ b/apps/web/src/app/utils/constants/test-data.ts
@@ -1,0 +1,25 @@
+import { PersonFormData } from '../../shared/forms/person-form/person-form.component';
+import { ExternalWalletFormData } from '../../shared/forms/external-wallet-form/external-wallet-form.component';
+import { SOLANA_NETWORK, SOLANA_CURRENCY } from '../validation/solana';
+
+export const TEST_PERSON_DATA: PersonFormData = {
+  firstName: 'Tom',
+  lastName: 'Jones',
+  email: 'tom.jones@example.com',
+  phone: '+1 5551234567',
+  dobDay: 1,
+  dobMonth: 1,
+  dobYear: 1990,
+  addressLine1: '123 Test Street',
+  addressLine2: '',
+  addressCity: 'San Francisco',
+  addressState: 'CA',
+  addressPostalCode: '94111',
+  addressCountry: 'US',
+};
+
+export const TEST_WALLET_DATA: ExternalWalletFormData = {
+  walletAddress: 'D8VMZCmmTUUfhejNhNQKAmqvZCKfUq1qU6RqQKxQwXyX',
+  network: SOLANA_NETWORK,
+  currency: SOLANA_CURRENCY,
+};

--- a/apps/web/src/app/utils/validation/solana.ts
+++ b/apps/web/src/app/utils/validation/solana.ts
@@ -40,4 +40,4 @@ export function GetSolanaAddressError(address: string): string {
 }
 
 export const SOLANA_NETWORK = 'solana';
-export const SOLANA_CURRENCY = 'USDC';
+export const SOLANA_CURRENCY = 'usdc';

--- a/libs/shared-types/src/lib/Config.ts
+++ b/libs/shared-types/src/lib/Config.ts
@@ -48,6 +48,8 @@ export interface PublicConfig {
   terms_url: string;
   /** URL to the platform's Privacy Policy page (empty string if not set) */
   privacy_url: string;
+  /** True if running in live mode, false for test mode */
+  livemode: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description

Expose `livemode` on PublicConfig so the web app can detect test vs live mode from a single source of truth. Add reusable TestModeBannerComponent and FillTestData() methods to person and wallet forms for one-click autofill during onboarding. Show a persistent test mode bar on the dashboard. Also fixes SOLANA_CURRENCY casing inconsistency (USDC → usdc) to match backend convention, and refactors add-funds-panel to use the shared ConfigService.IsTestMode() instead of inferring from explorer URLs.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

Test mode banner correctly displays, and test mode auto fill buttons also correctly display when LIVEMODE is false, and are not present when LIVEMODE is true.

## Breaking Changes
### `PublicConfig` now includes `livemode` (API + Web)
The `GET /v1/config` endpoint now returns a `livemode: boolean` field on the `PublicConfig` object. The web app depends on this field to show test mode UI (autofill banners, dashboard test mode bar). **The API and web app must be deployed together** — the frontend will not show test mode indicators if paired with an older API that omits `livemode`.
If you consume the `/v1/config` endpoint directly, the new field is additive and should not break existing integrations.
### `SOLANA_CURRENCY` casing change (Web)
The frontend constant `SOLANA_CURRENCY` changed from `'USDC'` (uppercase) to `'usdc'` (lowercase) to match the backend convention. Any wallets created through the onboarding UI will now store `currency: 'usdc'` instead of `currency: 'USDC'`. Existing wallet records with uppercase `'USDC'` are unaffected — the currency field on wallets is not used in any backend comparisons.
### `AddFundsPanelComponent.IsTestMode()` (Web — internal)
Test mode detection in the add-funds panel now uses `ConfigService.IsTestMode()` instead of checking `explorer_url` for `cluster=devnet`. This requires `ConfigService.LoadConfig()` to have been called before the panel opens (already the case in the normal dashboard flow).

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
