### PR TITLE
feat: prices can create products and vice-versa

### DIFF
--- a/apps/api/src/__tests__/Price.spec.ts
+++ b/apps/api/src/__tests__/Price.spec.ts
@@ -1,6 +1,7 @@
 import { PriceModule } from '../modules/Price';
 import { Database } from '../modules/Database';
 import { Price, Product, QueryOperators } from '@zoneless/shared-types';
+import { ProductModule } from '../modules/Product';
 import { ListHelper } from '../utils/ListHelper';
 import {
   CreateMockDatabase,
@@ -27,12 +28,13 @@ jest.mock('../modules/AppConfig', () => ({
 describe('PriceModule', () => {
   let module: PriceModule;
   let mockDb: jest.Mocked<Database>;
-
+  let productModule: ProductModule;
   beforeEach(() => {
     jest.clearAllMocks();
     ResetIdCounter();
     mockDb = CreateMockDatabase();
-    module = new PriceModule(mockDb);
+    productModule = new ProductModule(mockDb);
+    module = new PriceModule(mockDb, null, productModule);
   });
 
   describe('PriceObject', () => {
@@ -84,10 +86,14 @@ describe('PriceModule', () => {
 
   describe('CreatePrice', () => {
     it('should persist the price to the database', async () => {
+      const product = await productModule.CreateProduct('acct_z_platform', {
+        name: 'Test Product',
+      });
+      mockDb.Get.mockResolvedValueOnce(product);
       const price = await module.CreatePrice('acct_z_platform', {
         unit_amount: 1000,
         currency: 'usdc',
-        product: 'prod_z_1',
+        product: product.id,
         tax_behavior: 'exclusive',
         billing_scheme: 'per_unit',
         currency_options: {
@@ -96,7 +102,8 @@ describe('PriceModule', () => {
           },
         },
       });
-      expect(mockDb.Set).toHaveBeenCalledTimes(1);
+      expect(mockDb.Set).toHaveBeenCalledTimes(2);
+      expect(mockDb.Set).toHaveBeenCalledWith('Products', product.id, product);
       expect(mockDb.Set).toHaveBeenCalledWith('Prices', price.id, price);
     });
   });

--- a/apps/api/src/modules/Price.ts
+++ b/apps/api/src/modules/Price.ts
@@ -11,6 +11,7 @@ import { GenerateId } from '../utils/IdGenerator';
 import { Price as PriceType, QueryOperators } from '@zoneless/shared-types';
 import { ValidateUpdate } from './Util';
 import { ExtractChangedFields } from './Event';
+import type { ProductModule } from './Product';
 import {
   CreatePriceSchema,
   CreatePriceInput,
@@ -27,8 +28,13 @@ export class PriceModule {
   private readonly db: Database;
   private readonly eventService: EventService | null;
   private readonly listHelper: ListHelper<PriceType>;
+  private readonly productModule: ProductModule | null;
 
-  constructor(db: Database, eventService?: EventService) {
+  constructor(
+    db: Database,
+    eventService?: EventService,
+    productModule?: ProductModule
+  ) {
     this.db = db;
     this.eventService = eventService || null;
     this.listHelper = new ListHelper<PriceType>(db, {
@@ -38,6 +44,7 @@ export class PriceModule {
       urlPath: '/v1/prices',
       accountField: 'platform_account',
     });
+    this.productModule = productModule || null;
   }
 
   /**
@@ -49,11 +56,56 @@ export class PriceModule {
    */
   async CreatePrice(
     platformAccountId: string,
-    input: CreatePriceInput
+    input: CreatePriceInput,
+    skipProductCheck: boolean = false
   ): Promise<PriceType> {
     const validatedInput = ValidateUpdate(CreatePriceSchema, input);
 
     const price = this.PriceObject(platformAccountId, validatedInput);
+
+    if (!validatedInput.product && !validatedInput.product_data) {
+      throw new AppError(
+        'product id or product_data is required',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    } else if (validatedInput.product_data) {
+      if (!this.productModule) {
+        throw new AppError(
+          'ProductModule not configured',
+          ERRORS.INVALID_REQUEST.status,
+          ERRORS.INVALID_REQUEST.type
+        );
+      }
+      //Create a product from the product_data supplied and link it to the price.
+      const product = await this.productModule.CreateProduct(
+        platformAccountId,
+        validatedInput.product_data
+      );
+      price.product = product.id;
+    } else if (validatedInput.product && !skipProductCheck) {
+      //Skip this check if creating a price via the product module, as the product is not yet created.
+      if (!this.productModule) {
+        throw new AppError(
+          'ProductModule not configured',
+          ERRORS.INVALID_REQUEST.status,
+          ERRORS.INVALID_REQUEST.type
+        );
+      }
+      //Get the product from the database and link it to the price.
+      const product = await this.productModule.GetProduct(
+        validatedInput.product
+      );
+      if (!product) {
+        throw new AppError(
+          ERRORS.PRODUCT_NOT_FOUND.message,
+          ERRORS.PRODUCT_NOT_FOUND.status,
+          ERRORS.PRODUCT_NOT_FOUND.type
+        );
+      }
+      price.product = product.id;
+    }
+
     await this.db.Set('Prices', price.id, price);
 
     if (this.eventService) {

--- a/apps/api/src/modules/Product.ts
+++ b/apps/api/src/modules/Product.ts
@@ -25,6 +25,7 @@ import {
 import { ListHelper, ListOptions, ListResult } from '../utils/ListHelper';
 import { Now } from '../utils/Timestamp';
 import { GetAppConfig } from './AppConfig';
+import type { PriceModule } from './Price';
 import { AppError } from '../utils/AppError';
 import { ERRORS } from '../utils/Errors';
 
@@ -32,8 +33,13 @@ export class ProductModule {
   private readonly db: Database;
   private readonly eventService: EventService | null;
   private readonly listHelper: ListHelper<ProductType>;
+  private readonly priceModule: PriceModule;
 
-  constructor(db: Database, eventService?: EventService) {
+  constructor(
+    db: Database,
+    eventService?: EventService,
+    priceModule?: PriceModule
+  ) {
     this.db = db;
     this.eventService = eventService || null;
     this.listHelper = new ListHelper<ProductType>(db, {
@@ -43,6 +49,7 @@ export class ProductModule {
       urlPath: '/v1/products',
       accountField: 'platform_account',
     });
+    this.priceModule = priceModule || null;
   }
 
   /**
@@ -59,6 +66,17 @@ export class ProductModule {
     const validatedInput = ValidateUpdate(CreateProductSchema, input);
 
     const product = this.ProductObject(platformAccountId, validatedInput);
+
+    if (validatedInput.default_price_data) {
+      validatedInput.default_price_data.product = product.id; //Put the product id here so CreatePrice doesn't return an erro.
+      const price = await this.priceModule.CreatePrice(
+        platformAccountId,
+        validatedInput.default_price_data,
+        true
+      ); //Skip product check as the product is not yet created.
+      product.default_price = price.id;
+    }
+
     await this.db.Set('Products', product.id, product);
 
     if (this.eventService) {
@@ -80,7 +98,7 @@ export class ProductModule {
       object: 'product',
       active: input.active ?? true,
       created: Now(),
-      default_price: input.default_price ?? null,
+      default_price: null,
       description: input.description ?? null,
       images: input.images ?? [],
       marketing_features: input.marketing_features ?? [],

--- a/apps/api/src/routes/prices.routes.ts
+++ b/apps/api/src/routes/prices.routes.ts
@@ -7,6 +7,7 @@ import { Logger } from '../utils/Logger';
 import { db } from '../modules/Database';
 import { EventService } from '../modules/EventService';
 import { PriceModule } from '../modules/Price';
+import { ProductModule } from '../modules/Product';
 
 import { ValidateRequest } from '../middleware/ValidateRequest';
 import { RequirePlatform } from '../middleware/Authorization';
@@ -20,7 +21,8 @@ import {
 const router = express.Router();
 
 const eventService = new EventService(db);
-const priceModule = new PriceModule(db, eventService);
+const productModule = new ProductModule(db, eventService); //Pass into price module to enable creating products.
+const priceModule = new PriceModule(db, eventService, productModule);
 
 /**
  * POST /v1/prices

--- a/apps/api/src/routes/products.routes.ts
+++ b/apps/api/src/routes/products.routes.ts
@@ -11,6 +11,7 @@ import {
 import { db } from '../modules/Database';
 import { EventService } from '../modules/EventService';
 import { ProductModule } from '../modules/Product';
+import { PriceModule } from '../modules/Price';
 
 import { ValidateRequest } from '../middleware/ValidateRequest';
 import { RequirePlatform } from '../middleware/Authorization';
@@ -23,7 +24,8 @@ import {
 const router = express.Router();
 
 const eventService = new EventService(db);
-const productModule = new ProductModule(db, eventService);
+const priceModule = new PriceModule(db, eventService); //Pass into product module to enable creating prices.
+const productModule = new ProductModule(db, eventService, priceModule);
 
 /**
  * POST /v1/products

--- a/apps/api/src/schemas/PriceSchema.ts
+++ b/apps/api/src/schemas/PriceSchema.ts
@@ -8,7 +8,7 @@ export const CreatePriceSchema = z.object({
   active: z.boolean().default(true).optional(),
   metadata: z.record(z.string(), z.string()).optional(),
   nickname: z.string().max(22).optional(),
-  product: z.string().min(1).max(32),
+  product: z.string().min(1).max(32).optional(),
   recurring: z
     .object({
       interval: z.enum(['day', 'week', 'month', 'year']),

--- a/apps/api/src/schemas/ProductSchema.ts
+++ b/apps/api/src/schemas/ProductSchema.ts
@@ -21,7 +21,83 @@ export const CreateProductSchema = z.object({
   id: z.string().min(1).max(32).optional(),
   metadata: z.record(z.string(), z.string()).optional(),
   tax_code: z.string().optional(),
-  default_price: z.any().optional(), //TODO: add price schema
+  tax_details: z
+    .object({
+      performance_locations: z.string().optional(),
+      tax_code: z.string().optional(),
+    })
+    .optional(),
+  default_price_data: z
+    .object({
+      currency: z.string().min(1).max(4),
+      product: z.string().min(1).max(32).optional(), //Used to set product id after creating product then creating price.
+      currency_options: z
+        .record(
+          z.string(),
+          z.object({
+            custom_unit_amount: z
+              .object({
+                enabled: z.boolean().default(true),
+                maximum: z.number().int().positive(),
+                minimum: z.number().int().positive(),
+                preset: z.number().int().positive(),
+              })
+              .optional(),
+            tax_behavior: z
+              .enum(['exclusive', 'inclusive', 'unspecified'])
+              .optional(),
+            tiers: z
+              .array(
+                z.object({
+                  flat_amount: z.number().int().positive(),
+                  flat_amount_decimal: z.string().optional(),
+                  unit_amount: z.number().int().positive().optional(),
+                  unit_amount_decimal: z.string().optional(),
+                  up_to: z.number().int().positive(),
+                })
+              )
+              .optional(),
+            unit_amount: z.number().int().positive().optional(),
+            unit_amount_decimal: z.string().optional(),
+          })
+        )
+        .optional(),
+      custom_unit_amount: z
+        .object({
+          enabled: z.boolean().default(true),
+          maximum: z.number().int().positive(),
+          minimum: z.number().int().positive(),
+          preset: z.number().int().positive(),
+        })
+        .optional(),
+      metadata: z.record(z.string(), z.string()).optional(),
+      recurring: z
+        .object({
+          interval: z.enum(['day', 'week', 'month', 'year']),
+          interval_count: z.number().int().positive().optional(),
+          trial_period_days: z.number().int().positive().optional(),
+          usage_type: z.enum(['metered', 'licensed']).optional(),
+          meter: z.string().optional(),
+        })
+        .optional(),
+      tax_behavior: z
+        .enum(['exclusive', 'inclusive', 'unspecified'])
+        .optional(),
+      unit_amount: z.number().int().positive(),
+      unit_amount_decimal: z.string().optional(),
+    })
+    .optional(),
+  identifiers: z
+    .object({
+      ean: z.string().max(500).optional(),
+      gtin: z.string().max(500).optional(),
+      isbn: z.string().max(500).optional(),
+      jan: z.string().max(500).optional(),
+      mpn: z.string().max(70).optional(),
+      nsn: z.string().max(500).optional(),
+      upc: z.string().max(500).optional(),
+    })
+    .optional(),
   images: z.array(z.string()).max(8).optional(),
   marketing_features: z.array(MarketingFeatureSchema).max(15).optional(),
   package_dimensions: PackageDimensionsSchema.optional(),
@@ -38,7 +114,7 @@ export type CreateProductInput = z.infer<typeof CreateProductSchema>;
  */
 export const UpdateProductSchema = z.object({
   active: z.boolean().optional(),
-  default_price: z.string().optional(), //TODO: add price schema
+  default_price: z.string().optional(),
   description: z.string().max(40000).optional(),
   metadata: z.record(z.string(), z.string()).optional(),
   name: z.string().min(1).max(200).optional(),


### PR DESCRIPTION
## Description

Allows the ability to supply `default_price_data` for products/create endpoint to automatically create an associated price: https://zoneless.com/docs/products/create#default_price_data

Allows the ability to supply `product_data` to prices/create to automatically create an associated product: https://zoneless.com/docs/products/create#default_price_data

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [ ] Breaking changes are documented above
