### PR TITLE
feat: expandable field system for products

### DIFF
--- a/apps/api/src/modules/Price.ts
+++ b/apps/api/src/modules/Price.ts
@@ -129,6 +129,30 @@ export class PriceModule {
   }
 
   /**
+   * Batch-load prices by id, scoped to a single platform account.
+   * Used by the expansion engine to avoid N+1 lookups.
+   */
+  async BatchGet(
+    ids: string[],
+    platformAccount: string
+  ): Promise<Map<string, PriceType>> {
+    if (ids.length === 0) return new Map();
+    const prices = await this.db.Query<PriceType>({
+      collection: 'Prices',
+      method: 'READ',
+      parameters: [
+        { key: 'id', operator: QueryOperators['in'], value: ids },
+        {
+          key: 'platform_account',
+          operator: QueryOperators['=='],
+          value: platformAccount,
+        },
+      ],
+    });
+    return new Map(prices.map((price) => [price.id, price]));
+  }
+
+  /**
    * Update a price.
    * Emits an 'price.updated' event if EventService is configured.
    *

--- a/apps/api/src/routes/products.routes.ts
+++ b/apps/api/src/routes/products.routes.ts
@@ -20,12 +20,21 @@ import {
   CreateProductSchema,
   UpdateProductSchema,
 } from '../schemas/ProductSchema';
+import { ApplyExpand, RegisterExpansions } from '../utils/Expand';
 
 const router = express.Router();
 
 const eventService = new EventService(db);
 const priceModule = new PriceModule(db, eventService); //Pass into product module to enable creating prices.
 const productModule = new ProductModule(db, eventService, priceModule);
+
+RegisterExpansions('product', {
+  default_price: {
+    sourcePath: 'default_price',
+    targetObject: 'price',
+    BatchLoad: (ids, ctx) => priceModule.BatchGet(ids, ctx.platformAccount),
+  },
+});
 
 /**
  * POST /v1/products
@@ -52,7 +61,7 @@ router.post(
       productId: product.id,
     });
 
-    res.status(201).json(product);
+    res.status(201).json(await ApplyExpand(req, product));
   })
 );
 
@@ -100,7 +109,7 @@ router.post(
       productId: updatedProduct.id,
     });
 
-    res.json(updatedProduct);
+    res.json(await ApplyExpand(req, updatedProduct));
   })
 );
 
@@ -134,7 +143,7 @@ router.get(
       );
     }
 
-    res.json(product);
+    res.json(await ApplyExpand(req, product));
   })
 );
 
@@ -224,7 +233,7 @@ router.get(
       hasMore: result.has_more,
     });
 
-    res.json(result);
+    res.json(await ApplyExpand(req, result));
   })
 );
 

--- a/apps/api/src/schemas/ExpandableSchema.ts
+++ b/apps/api/src/schemas/ExpandableSchema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const ExpandableSchema = z.object({
+  expand: z.array(z.string()).optional(),
+});

--- a/apps/api/src/schemas/ProductSchema.ts
+++ b/apps/api/src/schemas/ProductSchema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ExpandableSchema } from './ExpandableSchema';
 
 const PackageDimensionsSchema = z.object({
   height: z.number().min(0).max(100000),
@@ -12,144 +13,156 @@ const MarketingFeatureSchema = z.object({
 });
 
 /**
+ * Schema for retrieving a product.
+ */
+export const RetrieveProductSchema = ExpandableSchema;
+export type RetrieveProductInput = z.infer<typeof RetrieveProductSchema>;
+
+/**
  * Schema for creating a product. Only name is required.
  */
-export const CreateProductSchema = z.object({
-  name: z.string().min(1).max(200),
-  active: z.boolean().default(true).optional(),
-  description: z.string().max(40000).optional(),
-  id: z.string().min(1).max(32).optional(),
-  metadata: z.record(z.string(), z.string()).optional(),
-  tax_code: z.string().optional(),
-  tax_details: z
-    .object({
-      performance_locations: z.string().optional(),
-      tax_code: z.string().optional(),
-    })
-    .optional(),
-  default_price_data: z
-    .object({
-      currency: z.string().min(1).max(4),
-      product: z.string().min(1).max(32).optional(), //Used to set product id after creating product then creating price.
-      currency_options: z
-        .record(
-          z.string(),
-          z.object({
-            custom_unit_amount: z
-              .object({
-                enabled: z.boolean().default(true),
-                maximum: z.number().int().positive(),
-                minimum: z.number().int().positive(),
-                preset: z.number().int().positive(),
-              })
-              .optional(),
-            tax_behavior: z
-              .enum(['exclusive', 'inclusive', 'unspecified'])
-              .optional(),
-            tiers: z
-              .array(
-                z.object({
-                  flat_amount: z.number().int().positive(),
-                  flat_amount_decimal: z.string().optional(),
-                  unit_amount: z.number().int().positive().optional(),
-                  unit_amount_decimal: z.string().optional(),
-                  up_to: z.number().int().positive(),
+export const CreateProductSchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    active: z.boolean().default(true).optional(),
+    description: z.string().max(40000).optional(),
+    id: z.string().min(1).max(32).optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+    tax_code: z.string().optional(),
+    tax_details: z
+      .object({
+        performance_locations: z.string().optional(),
+        tax_code: z.string().optional(),
+      })
+      .optional(),
+    default_price_data: z
+      .object({
+        currency: z.string().min(1).max(4),
+        product: z.string().min(1).max(32).optional(), //Used to set product id after creating product then creating price.
+        currency_options: z
+          .record(
+            z.string(),
+            z.object({
+              custom_unit_amount: z
+                .object({
+                  enabled: z.boolean().default(true),
+                  maximum: z.number().int().positive(),
+                  minimum: z.number().int().positive(),
+                  preset: z.number().int().positive(),
                 })
-              )
-              .optional(),
-            unit_amount: z.number().int().positive().optional(),
-            unit_amount_decimal: z.string().optional(),
+                .optional(),
+              tax_behavior: z
+                .enum(['exclusive', 'inclusive', 'unspecified'])
+                .optional(),
+              tiers: z
+                .array(
+                  z.object({
+                    flat_amount: z.number().int().positive(),
+                    flat_amount_decimal: z.string().optional(),
+                    unit_amount: z.number().int().positive().optional(),
+                    unit_amount_decimal: z.string().optional(),
+                    up_to: z.number().int().positive(),
+                  })
+                )
+                .optional(),
+              unit_amount: z.number().int().positive().optional(),
+              unit_amount_decimal: z.string().optional(),
+            })
+          )
+          .optional(),
+        custom_unit_amount: z
+          .object({
+            enabled: z.boolean().default(true),
+            maximum: z.number().int().positive(),
+            minimum: z.number().int().positive(),
+            preset: z.number().int().positive(),
           })
-        )
-        .optional(),
-      custom_unit_amount: z
-        .object({
-          enabled: z.boolean().default(true),
-          maximum: z.number().int().positive(),
-          minimum: z.number().int().positive(),
-          preset: z.number().int().positive(),
-        })
-        .optional(),
-      metadata: z.record(z.string(), z.string()).optional(),
-      recurring: z
-        .object({
-          interval: z.enum(['day', 'week', 'month', 'year']),
-          interval_count: z.number().int().positive().optional(),
-          trial_period_days: z.number().int().positive().optional(),
-          usage_type: z.enum(['metered', 'licensed']).optional(),
-          meter: z.string().optional(),
-        })
-        .optional(),
-      tax_behavior: z
-        .enum(['exclusive', 'inclusive', 'unspecified'])
-        .optional(),
-      unit_amount: z.number().int().positive(),
-      unit_amount_decimal: z.string().optional(),
-    })
-    .optional(),
-  identifiers: z
-    .object({
-      ean: z.string().max(500).optional(),
-      gtin: z.string().max(500).optional(),
-      isbn: z.string().max(500).optional(),
-      jan: z.string().max(500).optional(),
-      mpn: z.string().max(70).optional(),
-      nsn: z.string().max(500).optional(),
-      upc: z.string().max(500).optional(),
-    })
-    .optional(),
-  images: z.array(z.string()).max(8).optional(),
-  marketing_features: z.array(MarketingFeatureSchema).max(15).optional(),
-  package_dimensions: PackageDimensionsSchema.optional(),
-  shippable: z.boolean().optional(),
-  statement_descriptor: z.string().max(22).optional(),
-  unit_label: z.string().optional(),
-  url: z.string().url().optional(),
-});
+          .optional(),
+        metadata: z.record(z.string(), z.string()).optional(),
+        recurring: z
+          .object({
+            interval: z.enum(['day', 'week', 'month', 'year']),
+            interval_count: z.number().int().positive().optional(),
+            trial_period_days: z.number().int().positive().optional(),
+            usage_type: z.enum(['metered', 'licensed']).optional(),
+            meter: z.string().optional(),
+          })
+          .optional(),
+        tax_behavior: z
+          .enum(['exclusive', 'inclusive', 'unspecified'])
+          .optional(),
+        unit_amount: z.number().int().positive(),
+        unit_amount_decimal: z.string().optional(),
+      })
+      .optional(),
+    identifiers: z
+      .object({
+        ean: z.string().max(500).optional(),
+        gtin: z.string().max(500).optional(),
+        isbn: z.string().max(500).optional(),
+        jan: z.string().max(500).optional(),
+        mpn: z.string().max(70).optional(),
+        nsn: z.string().max(500).optional(),
+        upc: z.string().max(500).optional(),
+      })
+      .optional(),
+    images: z.array(z.string()).max(8).optional(),
+    marketing_features: z.array(MarketingFeatureSchema).max(15).optional(),
+    package_dimensions: PackageDimensionsSchema.optional(),
+    shippable: z.boolean().optional(),
+    statement_descriptor: z.string().max(22).optional(),
+    unit_label: z.string().optional(),
+    url: z.string().url().optional(),
+  })
+  .merge(ExpandableSchema);
 
 export type CreateProductInput = z.infer<typeof CreateProductSchema>;
 
 /**
  * Schema for updating a product.
  */
-export const UpdateProductSchema = z.object({
-  active: z.boolean().optional(),
-  default_price: z.string().optional(),
-  description: z.string().max(40000).optional(),
-  metadata: z.record(z.string(), z.string()).optional(),
-  name: z.string().min(1).max(200).optional(),
-  tax_code: z.string().optional(),
-  images: z.array(z.string()).max(8).optional(),
-  marketing_features: z.array(MarketingFeatureSchema).max(15).optional(),
-  package_dimensions: PackageDimensionsSchema.optional(),
-  shippable: z.boolean().optional(),
-  statement_descriptor: z.string().max(22).optional(),
-  unit_label: z.string().optional(),
-  url: z.string().url().optional(),
-});
+export const UpdateProductSchema = z
+  .object({
+    active: z.boolean().optional(),
+    default_price: z.string().optional(),
+    description: z.string().max(40000).optional(),
+    metadata: z.record(z.string(), z.string()).optional(),
+    name: z.string().min(1).max(200).optional(),
+    tax_code: z.string().optional(),
+    images: z.array(z.string()).max(8).optional(),
+    marketing_features: z.array(MarketingFeatureSchema).max(15).optional(),
+    package_dimensions: PackageDimensionsSchema.optional(),
+    shippable: z.boolean().optional(),
+    statement_descriptor: z.string().max(22).optional(),
+    unit_label: z.string().optional(),
+    url: z.string().url().optional(),
+  })
+  .merge(ExpandableSchema);
 
 export type UpdateProductInput = z.infer<typeof UpdateProductSchema>;
 
 /**
  * Schema for listing products
  */
-export const ListProductsSchema = z.object({
-  active: z.boolean().optional(),
-  created: z
-    .object({
-      gt: z.number().int().optional(),
-      gte: z.number().int().optional(),
-      lt: z.number().int().optional(),
-      lte: z.number().int().optional(),
-    })
-    .optional(),
-  ending_before: z.string().optional(),
-  ids: z.array(z.string()).optional(),
-  limit: z.number().int().min(1).max(100).optional(),
-  shippable: z.boolean().optional(),
-  starting_after: z.string().optional(),
-  url: z.string().url().optional(),
-});
+export const ListProductsSchema = z
+  .object({
+    active: z.boolean().optional(),
+    created: z
+      .object({
+        gt: z.number().int().optional(),
+        gte: z.number().int().optional(),
+        lt: z.number().int().optional(),
+        lte: z.number().int().optional(),
+      })
+      .optional(),
+    ending_before: z.string().optional(),
+    ids: z.array(z.string()).optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+    shippable: z.boolean().optional(),
+    starting_after: z.string().optional(),
+    url: z.string().url().optional(),
+  })
+  .merge(ExpandableSchema);
 export type ListProductsInput = z.infer<typeof ListProductsSchema>;
 
 export const ListProductsFiltersSchema = z.object({

--- a/apps/api/src/utils/Expand.ts
+++ b/apps/api/src/utils/Expand.ts
@@ -1,0 +1,258 @@
+/**
+ * @fileOverview Stripe-style expandable fields.
+ *
+ * Resources register expansion descriptors keyed by their `object` string.
+ * Routes call `ApplyExpand(req, result)` after fetching to hydrate any
+ * `expand[]=...` paths in the request.
+ *
+ * @module Expand
+ */
+
+import * as express from 'express';
+import { AppError } from './AppError';
+import { ERRORS } from '../utils/Errors';
+
+const MAX_EXPAND_DEPTH = 4;
+
+export interface ExpandContext {
+  platformAccount: string;
+  cache: Map<string, unknown>;
+}
+
+export interface ExpansionField {
+  /** Field on the parent object that holds the id (and where we write the hydrated object). */
+  sourcePath: string;
+  /** `object` string of the linked resource. Used to recurse via the registry. */
+  targetObject: string;
+  /** Batch-load ids → records, scoped to the requesting platform. */
+  BatchLoad: (
+    ids: string[],
+    ctx: ExpandContext
+  ) => Promise<Map<string, unknown>>;
+}
+
+export type ResourceExpansions = Record<string, ExpansionField>;
+
+const registry = new Map<string, ResourceExpansions>();
+
+export function RegisterExpansions(
+  objectType: string,
+  fields: ResourceExpansions
+): void {
+  const existing = registry.get(objectType) ?? {};
+  registry.set(objectType, { ...existing, ...fields });
+}
+
+function GetExpansion(
+  objectType: string,
+  fieldName: string
+): ExpansionField | undefined {
+  return registry.get(objectType)?.[fieldName];
+}
+
+/**
+ * Pull `expand` from query (`?expand[]=foo`, `?expand=foo`) or JSON body.
+ */
+export function ParseExpand(req: express.Request): string[] {
+  const raw = (req.query?.expand ?? req.body?.expand) as unknown;
+  if (raw === undefined || raw === null) return [];
+
+  const list = Array.isArray(raw) ? raw : [raw];
+  const paths: string[] = [];
+  for (const entry of list) {
+    if (typeof entry !== 'string') continue;
+    for (const part of entry.split(',')) {
+      const trimmed = part.trim();
+      if (trimmed && !paths.includes(trimmed)) paths.push(trimmed);
+    }
+  }
+  return paths;
+}
+
+/**
+ * Validate every path: depth cap, list-prefix rule, and field-by-field
+ * resolution through the registry.
+ */
+function ValidateExpandPaths(
+  paths: string[],
+  rootObject: string,
+  isList: boolean
+): void {
+  for (const path of paths) {
+    const segments = path.split('.');
+    if (segments.length === 0 || segments.some((s) => s.length === 0)) {
+      throw InvalidExpand(path);
+    }
+    if (segments.length > MAX_EXPAND_DEPTH) {
+      throw InvalidExpand(
+        path,
+        `Expand paths cannot exceed ${MAX_EXPAND_DEPTH} levels`
+      );
+    }
+
+    let cursor = rootObject;
+    let cursorIsList = isList;
+
+    for (const segment of segments) {
+      if (cursorIsList) {
+        if (segment !== 'data') {
+          throw InvalidExpand(
+            path,
+            `Expand paths on a list must start with 'data'`
+          );
+        }
+        cursorIsList = false;
+        continue;
+      }
+
+      const field = GetExpansion(cursor, segment);
+      if (!field) {
+        throw InvalidExpand(
+          path,
+          `'${segment}' is not an expandable field of '${cursor}'`
+        );
+      }
+      cursor = field.targetObject;
+    }
+  }
+}
+
+function InvalidExpand(path: string, detail?: string): AppError {
+  const message = detail
+    ? `${detail} (path: '${path}')`
+    : `Invalid expand path: '${path}'`;
+  return new AppError(
+    message,
+    ERRORS.INVALID_REQUEST.status,
+    ERRORS.INVALID_REQUEST.type
+  );
+}
+
+type AnyObject = Record<string, unknown>;
+
+/**
+ * Resolve `expand` paths on a fetched response (single object or list) and
+ * return the hydrated result. No-op when no paths are present.
+ */
+export async function ApplyExpand<T>(
+  req: express.Request,
+  result: T
+): Promise<T> {
+  const paths = ParseExpand(req);
+  if (paths.length === 0) return result;
+
+  const root = result as unknown as AnyObject;
+  const rootObject = root?.object as string | undefined;
+  if (!rootObject) return result;
+
+  const isList = rootObject === 'list';
+  const innerObject = isList ? FirstListObject(root) : rootObject;
+  if (!innerObject) return result;
+
+  ValidateExpandPaths(paths, innerObject, isList);
+
+  const ctx: ExpandContext = {
+    platformAccount: req.user.account,
+    cache: new Map(),
+  };
+
+  if (isList) {
+    const data = (root.data as AnyObject[]) ?? [];
+    await ExpandObjects(data, paths.map(StripDataPrefix), ctx);
+  } else {
+    await ExpandObjects([root], paths, ctx);
+  }
+
+  return result;
+}
+
+function FirstListObject(list: AnyObject): string | undefined {
+  const data = list.data as AnyObject[] | undefined;
+  return data?.[0]?.object as string | undefined;
+}
+
+function StripDataPrefix(path: string): string {
+  return path.startsWith('data.') ? path.slice('data.'.length) : path;
+}
+
+/**
+ * Core engine. Mutates the given items in place, hydrating registered fields
+ * and recursing into nested paths. Uses a per-request cache to dedupe loads
+ * across items and paths.
+ */
+async function ExpandObjects(
+  items: AnyObject[],
+  paths: string[],
+  ctx: ExpandContext
+): Promise<void> {
+  if (items.length === 0 || paths.length === 0) return;
+
+  const groups = new Map<string, string[]>();
+  for (const path of paths) {
+    const dot = path.indexOf('.');
+    const head = dot === -1 ? path : path.slice(0, dot);
+    const tail = dot === -1 ? '' : path.slice(dot + 1);
+    const list = groups.get(head) ?? [];
+    if (tail) list.push(tail);
+    groups.set(head, list);
+  }
+
+  for (const [head, tails] of groups) {
+    const sampleObject = items[0].object as string | undefined;
+    if (!sampleObject) continue;
+
+    if (head === 'data') {
+      const nested: AnyObject[] = [];
+      for (const item of items) {
+        const data = item.data;
+        if (Array.isArray(data)) nested.push(...(data as AnyObject[]));
+      }
+      await ExpandObjects(nested, tails, ctx);
+      continue;
+    }
+
+    const field = GetExpansion(sampleObject, head);
+    if (!field) continue;
+
+    const idToParents = new Map<string, AnyObject[]>();
+    for (const item of items) {
+      const value = item[field.sourcePath];
+      if (typeof value !== 'string') continue;
+      const parents = idToParents.get(value) ?? [];
+      parents.push(item);
+      idToParents.set(value, parents);
+    }
+
+    const missingIds: string[] = [];
+    for (const id of idToParents.keys()) {
+      if (!ctx.cache.has(CacheKey(field.targetObject, id))) {
+        missingIds.push(id);
+      }
+    }
+    if (missingIds.length > 0) {
+      const loaded = await field.BatchLoad(missingIds, ctx);
+      for (const [id, obj] of loaded) {
+        ctx.cache.set(CacheKey(field.targetObject, id), obj);
+      }
+    }
+
+    const nextItems: AnyObject[] = [];
+    for (const [id, parents] of idToParents) {
+      const expanded = ctx.cache.get(CacheKey(field.targetObject, id)) ?? null;
+      for (const parent of parents) {
+        parent[field.sourcePath] = expanded;
+      }
+      if (expanded && tails.length > 0) {
+        nextItems.push(expanded as AnyObject);
+      }
+    }
+
+    if (tails.length > 0 && nextItems.length > 0) {
+      await ExpandObjects(nextItems, tails, ctx);
+    }
+  }
+}
+
+function CacheKey(objectType: string, id: string): string {
+  return `${objectType}:${id}`;
+}

--- a/apps/web/src/app/features/account/views/product-catalogue/product-catalogue.component.html
+++ b/apps/web/src/app/features/account/views/product-catalogue/product-catalogue.component.html
@@ -64,6 +64,7 @@
   [columns]="productColumns"
   [limit]="10"
   [queryParams]="productsQueryParams()"
+  [expand]="productsExpand()"
   (rowClick)="OnProductListClick($event)"
 ></app-paginated-list>
 }

--- a/apps/web/src/app/features/account/views/product-catalogue/product-catalogue.component.ts
+++ b/apps/web/src/app/features/account/views/product-catalogue/product-catalogue.component.ts
@@ -13,7 +13,7 @@ import {
   ProductFormComponent,
   ConfirmDialogComponent,
 } from '../../../../shared';
-import type { Product } from '@zoneless/shared-types';
+import type { Product, Price } from '@zoneless/shared-types';
 
 import { ProductService } from '../../../../data';
 
@@ -66,6 +66,31 @@ export class ProductCatalogueComponent {
       placeholderIcon: 'package_outline.svg',
     },
     {
+      header: 'Pricing',
+      field: 'default_price.unit_amount',
+      type: 'text',
+      formatter: (item: unknown) => {
+        const product = item as Product;
+        if (product.default_price === null) {
+          return 'No prices';
+        }
+        const unitAmount = (product.default_price as Price)?.unit_amount ?? 0;
+        if ((product.default_price as Price)?.recurring) {
+          const recurringData = (product.default_price as Price)?.recurring;
+          if (recurringData?.interval === 'day') {
+            return `$${(unitAmount / 100).toFixed(2)} / day`;
+          }
+          if (recurringData?.interval === 'week') {
+            return `$${(unitAmount / 100).toFixed(2)} / week`;
+          }
+          if (recurringData?.interval === 'month') {
+            return `$${(unitAmount / 100).toFixed(2)} / month`;
+          }
+        }
+        return `$${(unitAmount / 100).toFixed(2)}`;
+      },
+    },
+    {
       header: 'Status',
       field: 'active',
       type: 'status',
@@ -114,6 +139,7 @@ export class ProductCatalogueComponent {
   productsQueryParams: WritableSignal<Record<string, string>> = signal({
     active: 'true',
   });
+  productsExpand: WritableSignal<string[]> = signal(['default_price']);
 
   SetProductsTab(tab: 'all'): void {
     this.productsTab.set(tab);

--- a/apps/web/src/app/shared/ui/paginated-list/paginated-list.component.ts
+++ b/apps/web/src/app/shared/ui/paginated-list/paginated-list.component.ts
@@ -100,6 +100,9 @@ export class PaginatedListComponent<T extends ListItem>
   /** Additional query parameters for filtering */
   @Input() queryParams: Record<string, string> = {};
 
+  /** Which fields to expand */
+  @Input() expand: string[] = [];
+
   /** Emits when a row is clicked */
   @Output() rowClick = new EventEmitter<T>();
 
@@ -176,7 +179,18 @@ export class PaginatedListComponent<T extends ListItem>
         }
       }
 
+      // Add expand info
+      if (this.expand.length > 0) {
+        url += `&expand[]=`;
+        for (const expand of this.expand) {
+          url += `data.${expand},`;
+        }
+        url = url.slice(0, -1);
+      }
+
       const response = await this.api.Call<ListResponse<T>>('GET', url);
+
+      console.log(response);
 
       this.items.set(response.data);
       this.hasMore.set(response.has_more);
@@ -261,16 +275,28 @@ export class PaginatedListComponent<T extends ListItem>
   }
 
   GetItemValue(item: T, field: string): unknown {
+    if (field.includes('.')) {
+      for (const part of field.split('.')) {
+        item = item[part] as T;
+      }
+      return item;
+    }
+    if (field.includes('[')) {
+      const [key, index] = field.split('[');
+      const indexNumber = parseInt(index.replace(']', ''));
+      const value = item[key] as unknown[];
+      return value[indexNumber] ?? '';
+    }
     return item[field];
   }
 
   GetItemNumber(item: T, field: string): number {
-    const value = item[field];
+    const value = this.GetItemValue(item, field);
     return typeof value === 'number' ? value / 100 : 0;
   }
 
   GetItemDate(item: T, field: string): number {
-    const value = item[field];
+    const value = this.GetItemValue(item, field);
     // API returns Unix timestamps in seconds, DatePipe expects milliseconds
     return typeof value === 'number' ? value * 1000 : 0;
   }
@@ -280,7 +306,7 @@ export class PaginatedListComponent<T extends ListItem>
     if (column.formatter) {
       return column.formatter(item);
     }
-    const value = item[column.field];
+    const value = this.GetItemValue(item, column.field);
     return String(value ?? '');
   }
 
@@ -293,11 +319,12 @@ export class PaginatedListComponent<T extends ListItem>
       return String(value[indexNumber] ?? '');
     }
     //A single field, e.g. "imageUrl"
-    return String(item[field] ?? '');
+    const value = this.GetItemValue(item, field);
+    return String(value ?? '');
   }
 
   GetItemCurrency(item: T, field: string): string {
-    const value = item[field];
+    const value = this.GetItemValue(item, field);
     return String(value ?? 'usdc').toUpperCase();
   }
 

--- a/apps/web/src/app/shared/ui/paginated-list/paginated-list.component.ts
+++ b/apps/web/src/app/shared/ui/paginated-list/paginated-list.component.ts
@@ -190,8 +190,6 @@ export class PaginatedListComponent<T extends ListItem>
 
       const response = await this.api.Call<ListResponse<T>>('GET', url);
 
-      console.log(response);
-
       this.items.set(response.data);
       this.hasMore.set(response.has_more);
       // Estimate total count based on page data

--- a/libs/shared-types/src/lib/Product.ts
+++ b/libs/shared-types/src/lib/Product.ts
@@ -1,3 +1,5 @@
+import { Price } from './Price';
+
 /**
  * Stripe-compatible Balance Product object for Zoneless.
  * Represents a product that can be sold.
@@ -14,7 +16,7 @@ export interface Product {
   /** Time at which the object was created. Measured in seconds since the Unix epoch.*/
   created: number;
   /** The ID of the Price object that is the default price for this product.*/
-  default_price: string | null;
+  default_price: string | Price | null;
   /** The product’s description, meant to be displayable to the customer. Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.*/
   description: string | null;
   /** A list of up to 8 URLs of images for this product, meant to be displayable to the customer.*/


### PR DESCRIPTION
## Description

Adds a flexible system like Stripe to expand certain fields from responses to full-blown objects, and adds a PoC implementation on the products object to expand default_price initially. This is used in the product catalogue to show a prices column.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
