### PR TITLE
fix: update updated timestamp field on products when making updates

### DIFF
--- a/apps/api/src/modules/Product.ts
+++ b/apps/api/src/modules/Product.ts
@@ -146,7 +146,9 @@ export class ProductModule {
       ? await this.GetProduct(id)
       : null;
 
-    await this.db.Update<ProductType>('Products', id, validatedUpdate);
+    const updatePayload = { ...validatedUpdate, updated: Now() };
+
+    await this.db.Update<ProductType>('Products', id, updatePayload);
 
     const product = await this.GetProduct(id);
     if (!product) {
@@ -157,7 +159,7 @@ export class ProductModule {
     if (this.eventService && previousProduct) {
       const previousAttributes = ExtractChangedFields(
         previousProduct as unknown as Record<string, unknown>,
-        validatedUpdate as Record<string, unknown>
+        updatePayload as Record<string, unknown>
       );
 
       await this.eventService.Emit(

--- a/apps/web/src/app/core/services/meta.service.ts
+++ b/apps/web/src/app/core/services/meta.service.ts
@@ -11,7 +11,8 @@ export class MetaService {
 
   SetMetaTitle(title: string): void {
     const platformName = this.configService.GetPlatformName();
-    const platformString = platformName === 'Zoneless' ? '' : `– ${platformName}`;
+    const platformString =
+      platformName === 'Zoneless' ? '' : `– ${platformName}`;
     let fullTitle = `${title} ${platformString} – Zoneless`;
     if (this.configService.IsTestMode()) {
       fullTitle += ` [Test]`;


### PR DESCRIPTION
## Description

Sets the updated timestamp when making any edits to products.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
