### PR TITLE
feat: initial one-time payment flow

### DIFF
--- a/apps/api/src/modules/CheckoutPayment.ts
+++ b/apps/api/src/modules/CheckoutPayment.ts
@@ -8,19 +8,24 @@
 
 import { ClientSession } from 'mongoose';
 import { Database } from './Database';
+import { AccountModule } from './Account';
 import { CheckoutSessionModule } from './CheckoutSession';
 import { ExternalWalletModule } from './ExternalWallet';
 import { BalanceModule } from './Balance';
 import { BalanceTransactionModule } from './BalanceTransaction';
+import { ProductModule } from './Product';
 import { Solana, SolanaExplorerUrl } from './chains/Solana';
 import { AppError } from '../utils/AppError';
 import { ERRORS } from '../utils/Errors';
 import { Logger } from '../utils/Logger';
 import { Now } from '../utils/Timestamp';
 import {
+  Account,
   BalanceTransaction,
   CheckoutSession,
   ExternalWallet,
+  Price,
+  Product,
 } from '@zoneless/shared-types';
 
 /** Unsigned payment transaction bundle returned by PreparePayment. */
@@ -38,8 +43,10 @@ export interface PreparedCheckoutPayment {
 
 export class CheckoutPaymentModule {
   private readonly db: Database;
+  private readonly accountModule: AccountModule;
   private readonly checkoutSessionModule: CheckoutSessionModule;
   private readonly externalWalletModule: ExternalWalletModule;
+  private readonly productModule: ProductModule;
   private readonly balanceModule: BalanceModule;
   private readonly balanceTransactionModule: BalanceTransactionModule;
   private readonly solana: Solana;
@@ -48,11 +55,14 @@ export class CheckoutPaymentModule {
     db: Database,
     checkoutSessionModule: CheckoutSessionModule,
     externalWalletModule: ExternalWalletModule,
+    productModule: ProductModule,
     solana?: Solana
   ) {
     this.db = db;
+    this.accountModule = new AccountModule(db);
     this.checkoutSessionModule = checkoutSessionModule;
     this.externalWalletModule = externalWalletModule;
+    this.productModule = productModule;
     this.balanceModule = new BalanceModule(db);
     this.balanceTransactionModule = new BalanceTransactionModule(db);
     this.solana = solana || new Solana();
@@ -60,25 +70,97 @@ export class CheckoutPaymentModule {
 
   /**
    * Bootstrap the hosted checkout page: the sanitized session enriched with
-   * the merchant's receiving wallet so the page can build the payment.
-   *
-   * @param id - The checkout session ID
-   * @returns The public checkout session with merchant wallet details
+   * the merchant's receiving wallet, display details, and expanded products.
    */
   async GetPaymentPageSession(id: string): Promise<CheckoutSession> {
     const session = await this.GetSessionOrThrow(id);
-    const merchantWallet = await this.ResolveMerchantWallet(
-      session.platform_account
-    );
+    const [merchantWallet, account, expandedSession] = await Promise.all([
+      this.ResolveMerchantWallet(session.platform_account),
+      this.accountModule.GetAccount(session.platform_account),
+      this.ExpandLineItemProducts(session),
+    ]);
 
     return {
-      ...this.SanitizeCheckoutSession(session),
+      ...this.SanitizeCheckoutSession(expandedSession),
       merchant_wallet: {
         wallet_address: merchantWallet.wallet_address,
         network: merchantWallet.network,
         currency: merchantWallet.currency,
         usdc_mint: this.solana.GetUSDCMintAddress(),
       },
+      merchant: this.ResolveMerchant(session, account),
+    };
+  }
+
+  private async ExpandLineItemProducts(
+    session: CheckoutSession
+  ): Promise<CheckoutSession> {
+    const lineItems = session.line_items?.data ?? [];
+    const productIds = [
+      ...new Set(
+        lineItems
+          .map((item) => item.price?.product)
+          .filter((product): product is string => typeof product === 'string')
+      ),
+    ];
+
+    if (productIds.length === 0) return session;
+
+    const products = await this.productModule.BatchGet(
+      productIds,
+      session.platform_account
+    );
+
+    return {
+      ...session,
+      line_items: session.line_items
+        ? {
+            ...session.line_items,
+            data: lineItems.map((item) => {
+              const price = item.price as Price | null;
+              if (!price || typeof price.product !== 'string') return item;
+
+              const product = products.get(price.product);
+              if (!product) return item;
+
+              return {
+                ...item,
+                price: {
+                  ...price,
+                  product: product as Product,
+                },
+              };
+            }),
+          }
+        : null,
+    };
+  }
+
+  private ResolveMerchant(
+    session: CheckoutSession,
+    account: Account | null
+  ): NonNullable<CheckoutSession['merchant']> {
+    const brandingName = session.branding_settings?.display_name?.trim();
+    const displayName =
+      brandingName ||
+      account?.business_profile?.name?.trim() ||
+      account?.settings?.dashboard?.display_name?.trim() ||
+      'Merchant';
+
+    const brandingIcon =
+      session.branding_settings?.icon?.url ??
+      session.branding_settings?.logo?.url ??
+      null;
+
+    return {
+      display_name: displayName,
+      terms_url: account?.settings?.terms_url ?? null,
+      privacy_url: account?.settings?.privacy_url ?? null,
+      icon_url:
+        brandingIcon ||
+        account?.settings?.branding?.icon ||
+        account?.settings?.branding?.logo ||
+        null,
     };
   }
 

--- a/apps/api/src/modules/CheckoutPayment.ts
+++ b/apps/api/src/modules/CheckoutPayment.ts
@@ -1,0 +1,412 @@
+/**
+ * @fileOverview Methods for the public hosted checkout payment flow:
+ * bootstrapping the payment page, preparing the unsigned USDC payment
+ * transaction, and confirming/completing the payment on-chain.
+ *
+ * @module CheckoutPayment
+ */
+
+import { ClientSession } from 'mongoose';
+import { Database } from './Database';
+import { CheckoutSessionModule } from './CheckoutSession';
+import { ExternalWalletModule } from './ExternalWallet';
+import { BalanceModule } from './Balance';
+import { BalanceTransactionModule } from './BalanceTransaction';
+import { Solana, SolanaExplorerUrl } from './chains/Solana';
+import { AppError } from '../utils/AppError';
+import { ERRORS } from '../utils/Errors';
+import { Logger } from '../utils/Logger';
+import { Now } from '../utils/Timestamp';
+import {
+  BalanceTransaction,
+  CheckoutSession,
+  ExternalWallet,
+} from '@zoneless/shared-types';
+
+/** Unsigned payment transaction bundle returned by PreparePayment. */
+export interface PreparedCheckoutPayment {
+  object: 'checkout.payment_transaction';
+  checkout_session: string;
+  amount_total: number;
+  currency: string | null;
+  merchant_wallet_address: string;
+  unsigned_transaction: string;
+  estimated_fee_lamports: number;
+  blockhash: string;
+  last_valid_block_height: number;
+}
+
+export class CheckoutPaymentModule {
+  private readonly db: Database;
+  private readonly checkoutSessionModule: CheckoutSessionModule;
+  private readonly externalWalletModule: ExternalWalletModule;
+  private readonly balanceModule: BalanceModule;
+  private readonly balanceTransactionModule: BalanceTransactionModule;
+  private readonly solana: Solana;
+
+  constructor(
+    db: Database,
+    checkoutSessionModule: CheckoutSessionModule,
+    externalWalletModule: ExternalWalletModule,
+    solana?: Solana
+  ) {
+    this.db = db;
+    this.checkoutSessionModule = checkoutSessionModule;
+    this.externalWalletModule = externalWalletModule;
+    this.balanceModule = new BalanceModule(db);
+    this.balanceTransactionModule = new BalanceTransactionModule(db);
+    this.solana = solana || new Solana();
+  }
+
+  /**
+   * Bootstrap the hosted checkout page: the sanitized session enriched with
+   * the merchant's receiving wallet so the page can build the payment.
+   *
+   * @param id - The checkout session ID
+   * @returns The public checkout session with merchant wallet details
+   */
+  async GetPaymentPageSession(id: string): Promise<CheckoutSession> {
+    const session = await this.GetSessionOrThrow(id);
+    const merchantWallet = await this.ResolveMerchantWallet(
+      session.platform_account
+    );
+
+    return {
+      ...this.SanitizeCheckoutSession(session),
+      merchant_wallet: {
+        wallet_address: merchantWallet.wallet_address,
+        network: merchantWallet.network,
+        currency: merchantWallet.currency,
+        usdc_mint: this.solana.GetUSDCMintAddress(),
+      },
+    };
+  }
+
+  /**
+   * Build an unsigned USDC payment transaction transferring the session
+   * total from the customer's wallet to the merchant's wallet. The customer
+   * signs and broadcasts it via their wallet.
+   *
+   * @param id - The checkout session ID
+   * @param payerWallet - The customer's wallet address
+   * @param email - Optional customer email to record on the session
+   * @returns The unsigned transaction bundle
+   */
+  async PreparePayment(
+    id: string,
+    payerWallet: string | undefined,
+    email?: string
+  ): Promise<PreparedCheckoutPayment> {
+    if (!payerWallet || typeof payerWallet !== 'string') {
+      throw new AppError(
+        'payer_wallet is required',
+        ERRORS.VALIDATION_ERROR.status,
+        ERRORS.VALIDATION_ERROR.type
+      );
+    }
+
+    const session = await this.GetSessionOrThrow(id);
+    this.AssertSessionPayable(session);
+
+    const merchantWallet = await this.ResolveMerchantWallet(
+      session.platform_account
+    );
+
+    if (email && typeof email === 'string') {
+      await this.checkoutSessionModule.SetCustomerEmail(session.id, email);
+    }
+
+    Logger.info('Preparing checkout payment transaction', {
+      checkoutSessionId: session.id,
+      amountTotal: session.amount_total,
+    });
+
+    const prepared = await this.solana.BuildCheckoutPaymentTransaction(
+      payerWallet,
+      merchantWallet.wallet_address,
+      session.amount_total!,
+      session.id
+    );
+
+    return {
+      object: 'checkout.payment_transaction',
+      checkout_session: session.id,
+      amount_total: session.amount_total!,
+      currency: session.currency,
+      merchant_wallet_address: merchantWallet.wallet_address,
+      ...prepared,
+    };
+  }
+
+  /**
+   * Verify a broadcast payment transaction on-chain and complete the
+   * checkout session, emitting 'checkout.session.completed'. Idempotent: if
+   * the session was already completed with the same signature, it is
+   * returned as-is.
+   *
+   * @param id - The checkout session ID
+   * @param signature - The Solana transaction signature of the payment
+   * @returns The completed public checkout session
+   */
+  async ConfirmPayment(
+    id: string,
+    signature: string | undefined
+  ): Promise<CheckoutSession> {
+    if (!signature || typeof signature !== 'string') {
+      throw new AppError(
+        'signature is required',
+        ERRORS.VALIDATION_ERROR.status,
+        ERRORS.VALIDATION_ERROR.type
+      );
+    }
+
+    const session = await this.GetSessionOrThrow(id);
+
+    // Idempotency: the session was already completed with this signature.
+    // Re-run the ledger recording (a no-op when already recorded) so a
+    // retry can heal a confirm that failed between completion and ledgering.
+    if (
+      session.status === 'complete' &&
+      session.payment_details?.transaction_signature === signature
+    ) {
+      await this.RecordPaymentOnLedger(
+        session,
+        session.amount_total!,
+        session.payment_details.payer_wallet,
+        signature
+      );
+      return this.SanitizeCheckoutSession(session);
+    }
+
+    this.AssertSessionPayable(session);
+
+    // A transaction can only ever complete one checkout session
+    const existingSession =
+      await this.checkoutSessionModule.GetCheckoutSessionByTransactionSignature(
+        signature
+      );
+    if (existingSession) {
+      throw new AppError(
+        'This transaction has already been used for another Checkout Session',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const merchantWallet = await this.ResolveMerchantWallet(
+      session.platform_account
+    );
+
+    Logger.info('Verifying checkout payment transaction', {
+      checkoutSessionId: session.id,
+      signature,
+    });
+
+    const verification = await this.solana.VerifyCheckoutPayment(signature, {
+      merchantWalletAddress: merchantWallet.wallet_address,
+      amountInCents: session.amount_total!,
+      checkoutSessionId: session.id,
+    });
+
+    if (!verification.verified) {
+      throw new AppError(
+        verification.failure_reason || 'Payment verification failed',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const completedSession =
+      await this.checkoutSessionModule.CompleteCheckoutSession(session.id, {
+        transaction_signature: signature,
+        payer_wallet: verification.payer_address,
+      });
+
+    await this.RecordPaymentOnLedger(
+      completedSession,
+      verification.amount_cents,
+      verification.payer_address,
+      signature
+    );
+
+    Logger.info('Checkout session completed via payment', {
+      checkoutSessionId: completedSession.id,
+      signature,
+    });
+
+    return this.SanitizeCheckoutSession(completedSession);
+  }
+
+  /**
+   * Record a completed checkout payment on the merchant's internal ledger:
+   * creates a 'payment' balance transaction sourced from the session and
+   * credits the merchant's available balance, atomically.
+   *
+   * Mirrors the pattern used by TopUpModule.CreateFromDeposit: the funds are
+   * already confirmed on-chain, so the balance transaction is immediately
+   * available.
+   *
+   * Idempotent: if a payment balance transaction already exists for this
+   * session, it is returned without crediting the balance again.
+   */
+  private async RecordPaymentOnLedger(
+    session: CheckoutSession,
+    amountCents: number,
+    payerWallet: string | null,
+    signature: string
+  ): Promise<BalanceTransaction> {
+    const existing = await this.db.Find2Custom<BalanceTransaction>(
+      'BalanceTransactions',
+      'source',
+      '==',
+      session.id,
+      'type',
+      '==',
+      'payment'
+    );
+    if (existing.length > 0) return existing[0];
+
+    const merchantAccountId = session.platform_account;
+    const timestamp = Now();
+
+    const balanceTransaction =
+      this.balanceTransactionModule.BalanceTransactionObject({
+        amount: amountCents,
+        currency: session.currency ?? 'usdc',
+        account: merchantAccountId,
+        platformAccountId: merchantAccountId,
+        type: 'payment',
+        source: session.id,
+        description: `Payment for Checkout Session ${session.id}`,
+        metadata: {
+          blockchain_tx: signature,
+          network: 'solana',
+          sender_address: payerWallet ?? '',
+          explorer_url: SolanaExplorerUrl('tx', signature),
+        },
+        status: 'available',
+        available_on: timestamp,
+      });
+
+    // The merchant may not have a ledger balance yet (e.g. fresh setup)
+    const balanceData =
+      (await this.balanceModule.GetBalance(merchantAccountId)) ??
+      (await this.balanceModule.CreateBalance(merchantAccountId));
+
+    await this.db.RunTransaction(async (mongoSession: ClientSession) => {
+      await this.db.Set(
+        'BalanceTransactions',
+        balanceTransaction.id,
+        balanceTransaction,
+        mongoSession
+      );
+
+      const updatedBalance = this.balanceModule.UpdateBalance(
+        balanceData,
+        amountCents,
+        balanceTransaction.currency,
+        'available'
+      );
+      await this.db.Update(
+        'Balances',
+        updatedBalance.id,
+        { available: updatedBalance.available },
+        mongoSession
+      );
+    });
+
+    Logger.info('Recorded checkout payment on ledger', {
+      checkoutSessionId: session.id,
+      balanceTransactionId: balanceTransaction.id,
+      amountCents,
+    });
+
+    return balanceTransaction;
+  }
+
+  /**
+   * Strips platform-internal fields before serving a session to an
+   * unauthenticated customer.
+   */
+  private SanitizeCheckoutSession(session: CheckoutSession): CheckoutSession {
+    return {
+      ...session,
+      metadata: null,
+      line_items: session.line_items
+        ? {
+            ...session.line_items,
+            data: session.line_items.data.map((item) => ({
+              ...item,
+              metadata: {},
+            })),
+          }
+        : null,
+    };
+  }
+
+  private async GetSessionOrThrow(id: string): Promise<CheckoutSession> {
+    const session = await this.checkoutSessionModule.GetCheckoutSession(id);
+
+    if (!session) {
+      throw new AppError(
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.message,
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.status,
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.type
+      );
+    }
+
+    return session;
+  }
+
+  /**
+   * Resolve the merchant's receiving wallet for a checkout session: the
+   * platform account's default external wallet.
+   */
+  private async ResolveMerchantWallet(
+    platformAccountId: string
+  ): Promise<ExternalWallet> {
+    const merchantWallet = await this.externalWalletModule.GetDefaultWallet(
+      platformAccountId
+    );
+
+    if (!merchantWallet) {
+      throw new AppError(
+        'The merchant has no wallet configured to receive payments',
+        ERRORS.VALIDATION_ERROR.status,
+        'no_wallet_configured'
+      );
+    }
+
+    return merchantWallet;
+  }
+
+  /**
+   * Ensure a checkout session can accept a payment: it must be open, unpaid,
+   * and not past its expiry time.
+   */
+  private AssertSessionPayable(session: CheckoutSession): void {
+    if (session.status !== 'open' || session.payment_status !== 'unpaid') {
+      throw new AppError(
+        'This Checkout Session is no longer accepting payments',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    if (session.expires_at && session.expires_at < Now()) {
+      throw new AppError(
+        'This Checkout Session has expired',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    if (!session.amount_total || session.amount_total <= 0) {
+      throw new AppError(
+        'This Checkout Session has no amount due',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/CheckoutSession.ts
+++ b/apps/api/src/modules/CheckoutSession.ts
@@ -540,6 +540,114 @@ export class CheckoutSessionModule {
   }
 
   /**
+   * Complete a checkout session after a verified payment. Only sessions with
+   * an `open` status can be completed. Records the on-chain payment details
+   * and emits a 'checkout.session.completed' event if EventService is
+   * configured.
+   *
+   * @param id - The checkout session ID
+   * @param paymentDetails - The verified on-chain payment details
+   * @returns The completed CheckoutSession
+   */
+  async CompleteCheckoutSession(
+    id: string,
+    paymentDetails: {
+      transaction_signature: string;
+      payer_wallet: string | null;
+    }
+  ): Promise<CheckoutSessionType> {
+    const previousSession = await this.GetCheckoutSession(id);
+    if (!previousSession) {
+      throw new AppError(
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.message,
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.status,
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.type
+      );
+    }
+
+    if (previousSession.status !== 'open') {
+      throw new AppError(
+        'Only Checkout Sessions with an `open` status can be completed',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    // The session url is only present while the session is active.
+    await this.db.Update<CheckoutSessionType>('CheckoutSessions', id, {
+      status: 'complete',
+      payment_status: 'paid',
+      url: null,
+      payment_details: paymentDetails,
+    });
+
+    const session = await this.GetCheckoutSession(id);
+    if (!session) {
+      throw new AppError(
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.message,
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.status,
+        ERRORS.CHECKOUT_SESSION_NOT_FOUND.type
+      );
+    }
+
+    if (this.eventService) {
+      await this.eventService.Emit(
+        'checkout.session.completed',
+        session.platform_account,
+        session
+      );
+    }
+
+    return session;
+  }
+
+  /**
+   * Record the customer's email on an open checkout session. Collected on
+   * the hosted checkout page before payment.
+   *
+   * @param id - The checkout session ID
+   * @param email - The customer's email address
+   */
+  async SetCustomerEmail(id: string, email: string): Promise<void> {
+    const session = await this.GetCheckoutSession(id);
+    if (!session || session.status !== 'open') return;
+
+    await this.db.Update<CheckoutSessionType>('CheckoutSessions', id, {
+      customer_email: email,
+      customer_details: {
+        address: session.customer_details?.address ?? null,
+        business_name: session.customer_details?.business_name ?? null,
+        email,
+        individual_name: session.customer_details?.individual_name ?? null,
+        name: session.customer_details?.name ?? null,
+        phone: session.customer_details?.phone ?? null,
+        tax_exempt: session.customer_details?.tax_exempt ?? 'none',
+        tax_ids: session.customer_details?.tax_ids ?? null,
+      },
+    });
+  }
+
+  /**
+   * Find the checkout session that recorded a given payment transaction
+   * signature. Used to prevent the same on-chain payment from completing
+   * more than one session.
+   *
+   * @param signature - The Solana transaction signature
+   * @returns The CheckoutSession if one recorded this signature, null otherwise
+   */
+  async GetCheckoutSessionByTransactionSignature(
+    signature: string
+  ): Promise<CheckoutSessionType | null> {
+    const sessions = await this.db.FindCustom<CheckoutSessionType>(
+      'CheckoutSessions',
+      'payment_details.transaction_signature',
+      '==',
+      signature
+    );
+    return sessions?.[0] ?? null;
+  }
+
+  /**
    * List checkout sessions
    */
   async ListCheckoutSessions(

--- a/apps/api/src/modules/ExternalWallet.ts
+++ b/apps/api/src/modules/ExternalWallet.ts
@@ -242,6 +242,18 @@ export class ExternalWalletModule {
   }
 
   /**
+   * Get the account's default receiving wallet: the wallet marked
+   * default_for_currency, falling back to the first active wallet.
+   *
+   * @param account - The account ID to get the default wallet for
+   * @returns The default external wallet, or null if none is configured
+   */
+  async GetDefaultWallet(account: string): Promise<ExternalWalletType | null> {
+    const wallets = await this.GetExternalWalletsByAccount(account);
+    return wallets.find((w) => w.default_for_currency) ?? wallets[0] ?? null;
+  }
+
+  /**
    * List external wallets for an account with cursor-based pagination.
    *
    * @param account - The account ID to list wallets for

--- a/apps/api/src/modules/chains/Solana.ts
+++ b/apps/api/src/modules/chains/Solana.ts
@@ -22,10 +22,27 @@ import bs58 from 'bs58';
 import {
   getAssociatedTokenAddress,
   createTransferInstruction,
+  createTransferCheckedInstruction,
   createAssociatedTokenAccountIdempotentInstruction,
   createApproveCheckedInstruction,
   TOKEN_PROGRAM_ID,
 } from '@solana/spl-token';
+
+/** SPL Memo program, used to bind a payment transaction to a checkout session. */
+const MEMO_PROGRAM_ID = new PublicKey(
+  'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'
+);
+
+/** Result of verifying a checkout payment transaction on-chain */
+export interface CheckoutPaymentVerification {
+  verified: boolean;
+  /** Total USDC (in cents) transferred to the merchant in this transaction */
+  amount_cents: number;
+  /** The payer's wallet address (transfer authority) */
+  payer_address: string | null;
+  /** Reason verification failed, if it did */
+  failure_reason?: string;
+}
 
 /** Represents a single recipient in a batch USDC transfer */
 export interface TransferRecipient {
@@ -580,6 +597,235 @@ export class Solana {
     }
 
     return null;
+  }
+
+  /**
+   * Build an unsigned one-time USDC payment transaction for a checkout session.
+   * Transfers the session total from the payer to the merchant wallet and
+   * attaches an SPL Memo with the checkout session ID so the payment can be
+   * unambiguously matched to the session during verification.
+   *
+   * @param payerPublicKey - The customer's wallet public key (fee payer and source)
+   * @param merchantWalletAddress - The merchant's wallet address (destination)
+   * @param amountInCents - Payment amount in cents (1 cent = 10,000 USDC atomic units)
+   * @param checkoutSessionId - The checkout session ID to embed in the memo
+   * @returns Object containing the unsigned transaction (base64), fee estimate, and blockhash
+   */
+  async BuildCheckoutPaymentTransaction(
+    payerPublicKey: string,
+    merchantWalletAddress: string,
+    amountInCents: number,
+    checkoutSessionId: string
+  ): Promise<{
+    unsigned_transaction: string;
+    estimated_fee_lamports: number;
+    blockhash: string;
+    last_valid_block_height: number;
+  }> {
+    if (!payerPublicKey) {
+      throw new Error('Payer public key is required');
+    }
+    if (!merchantWalletAddress) {
+      throw new Error('Merchant wallet address is required');
+    }
+    if (!Number.isInteger(amountInCents) || amountInCents <= 0) {
+      throw new Error('Amount must be a positive integer number of cents');
+    }
+    if (!checkoutSessionId) {
+      throw new Error('Checkout session ID is required');
+    }
+
+    const payer = new PublicKey(payerPublicKey);
+    const merchant = new PublicKey(merchantWalletAddress);
+    const usdcMint = new PublicKey(this.GetUSDCMintAddress());
+
+    const payerTokenAccount = await getAssociatedTokenAddress(usdcMint, payer);
+    const merchantTokenAccount = await getAssociatedTokenAddress(
+      usdcMint,
+      merchant
+    );
+
+    // Convert cents to USDC atomic units (6 decimals => 1 cent = 10,000 units)
+    const amountInSmallestUnit = amountInCents * 10_000;
+
+    const transaction = new Transaction();
+
+    // Ensure the merchant's USDC token account exists (payer funds rent if not)
+    transaction.add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        payer,
+        merchantTokenAccount,
+        merchant,
+        usdcMint
+      )
+    );
+
+    transaction.add(
+      createTransferCheckedInstruction(
+        payerTokenAccount,
+        usdcMint,
+        merchantTokenAccount,
+        payer,
+        amountInSmallestUnit,
+        6
+      )
+    );
+
+    // Memo binds this transaction to the checkout session
+    transaction.add(
+      new TransactionInstruction({
+        programId: MEMO_PROGRAM_ID,
+        keys: [],
+        data: Buffer.from(checkoutSessionId, 'utf8'),
+      })
+    );
+
+    const { blockhash, lastValidBlockHeight } = await this.WithRetry(() =>
+      this.connection.getLatestBlockhash('confirmed')
+    );
+    transaction.recentBlockhash = blockhash;
+    transaction.feePayer = payer;
+
+    const fee = await this.WithRetry(() =>
+      this.connection.getFeeForMessage(
+        transaction.compileMessage(),
+        'confirmed'
+      )
+    );
+
+    const serializedTransaction = transaction
+      .serialize({ requireAllSignatures: false })
+      .toString('base64');
+
+    return {
+      unsigned_transaction: serializedTransaction,
+      estimated_fee_lamports: fee.value || 0,
+      blockhash,
+      last_valid_block_height: lastValidBlockHeight,
+    };
+  }
+
+  /**
+   * Verify that a broadcast transaction is a valid payment for a checkout
+   * session: it succeeded, transferred at least the expected USDC amount to
+   * the merchant's token account, and carries the session ID memo.
+   *
+   * Polls until the transaction is visible at 'confirmed' commitment or a
+   * timeout is reached (the customer's wallet broadcasts the transaction, so
+   * it may not be queryable immediately).
+   *
+   * @param signature - The transaction signature to verify
+   * @param expected - Expected merchant wallet, amount, and session ID
+   * @returns Verification result with the payer address on success
+   */
+  async VerifyCheckoutPayment(
+    signature: string,
+    expected: {
+      merchantWalletAddress: string;
+      amountInCents: number;
+      checkoutSessionId: string;
+    }
+  ): Promise<CheckoutPaymentVerification> {
+    const merchant = new PublicKey(expected.merchantWalletAddress);
+    const usdcMint = new PublicKey(this.GetUSDCMintAddress());
+    const merchantTokenAccount = await getAssociatedTokenAddress(
+      usdcMint,
+      merchant
+    );
+    const merchantTokenAccountStr = merchantTokenAccount.toBase58();
+
+    // Poll for the transaction to reach 'confirmed' commitment
+    const maxAttempts = 15;
+    let tx: ParsedTransactionWithMeta | null = null;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      tx = await this.GetParsedTransaction(signature);
+      if (tx) break;
+      await Sleep(RPC_DELAY_MS);
+    }
+
+    if (!tx || !tx.meta) {
+      return {
+        verified: false,
+        amount_cents: 0,
+        payer_address: null,
+        failure_reason:
+          'Transaction not found on-chain (may not be confirmed yet)',
+      };
+    }
+
+    if (tx.meta.err) {
+      return {
+        verified: false,
+        amount_cents: 0,
+        payer_address: null,
+        failure_reason: `Transaction failed on-chain: ${JSON.stringify(
+          tx.meta.err
+        )}`,
+      };
+    }
+
+    let transferredAtomic = 0;
+    let payerAddress: string | null = null;
+    let memoMatches = false;
+
+    for (const instruction of tx.transaction.message.instructions) {
+      if (!('parsed' in instruction)) continue;
+
+      if (instruction.program === 'spl-token') {
+        const parsed = instruction.parsed;
+        if (parsed.type !== 'transfer' && parsed.type !== 'transferChecked') {
+          continue;
+        }
+
+        const info = parsed.info;
+        if (info.destination !== merchantTokenAccountStr) continue;
+
+        // transferChecked carries the mint; reject transfers of other tokens
+        if (info.mint && info.mint !== usdcMint.toBase58()) continue;
+
+        const amountRaw =
+          parsed.type === 'transferChecked'
+            ? info.tokenAmount?.amount || '0'
+            : info.amount || '0';
+
+        transferredAtomic += parseInt(amountRaw, 10);
+        payerAddress = info.authority || info.source || payerAddress;
+      }
+
+      if (instruction.program === 'spl-memo') {
+        // Parsed memo instructions expose the memo string directly
+        if (instruction.parsed === expected.checkoutSessionId) {
+          memoMatches = true;
+        }
+      }
+    }
+
+    const transferredCents = Math.floor(transferredAtomic / 10_000);
+
+    if (!memoMatches) {
+      return {
+        verified: false,
+        amount_cents: transferredCents,
+        payer_address: payerAddress,
+        failure_reason:
+          'Transaction does not reference this checkout session (memo missing or mismatched)',
+      };
+    }
+
+    if (transferredAtomic < expected.amountInCents * 10_000) {
+      return {
+        verified: false,
+        amount_cents: transferredCents,
+        payer_address: payerAddress,
+        failure_reason: `Insufficient amount: expected ${expected.amountInCents} cents, received ${transferredCents} cents`,
+      };
+    }
+
+    return {
+      verified: true,
+      amount_cents: transferredCents,
+      payer_address: payerAddress,
+    };
   }
 
   async CreateSubscription(

--- a/apps/api/src/routes/config.routes.ts
+++ b/apps/api/src/routes/config.routes.ts
@@ -151,13 +151,9 @@ router.get(
   ValidateApiKey,
   RequirePlatform(),
   AsyncHandler(async (req: express.Request, res: express.Response) => {
-    const wallets = await externalWalletModule.GetExternalWalletsByAccount(
+    const platformWallet = await externalWalletModule.GetDefaultWallet(
       req.user.account
     );
-
-    // Get the default wallet (or first one)
-    const platformWallet =
-      wallets.find((w) => w.default_for_currency) || wallets[0];
 
     if (!platformWallet) {
       throw new AppError(

--- a/apps/api/src/routes/paymentPages.routes.ts
+++ b/apps/api/src/routes/paymentPages.routes.ts
@@ -27,7 +27,8 @@ const externalWalletModule = new ExternalWalletModule(db, eventService);
 const checkoutPaymentModule = new CheckoutPaymentModule(
   db,
   checkoutSessionModule,
-  externalWalletModule
+  externalWalletModule,
+  productModule
 );
 
 /**

--- a/apps/api/src/routes/paymentPages.routes.ts
+++ b/apps/api/src/routes/paymentPages.routes.ts
@@ -1,16 +1,14 @@
 import * as express from 'express';
 import { AsyncHandler } from '../utils/AsyncHandler';
-import { AppError } from '../utils/AppError';
-import { ERRORS } from '../utils/Errors';
 
 import { db } from '../modules/Database';
 import { EventService } from '../modules/EventService';
 import { CheckoutSessionModule } from '../modules/CheckoutSession';
+import { CheckoutPaymentModule } from '../modules/CheckoutPayment';
 import { PriceModule } from '../modules/Price';
 import { ProductModule } from '../modules/Product';
 import { CustomerModule } from '../modules/Customer';
-
-import { CheckoutSession } from '@zoneless/shared-types';
+import { ExternalWalletModule } from '../modules/ExternalWallet';
 
 const router = express.Router();
 
@@ -25,26 +23,12 @@ const checkoutSessionModule = new CheckoutSessionModule(
   productModule,
   customerModule
 );
-
-/**
- * Strips platform-internal fields before serving a session to an
- * unauthenticated customer.
- */
-function SanitizeCheckoutSession(session: CheckoutSession): CheckoutSession {
-  return {
-    ...session,
-    metadata: null,
-    line_items: session.line_items
-      ? {
-          ...session.line_items,
-          data: session.line_items.data.map((item) => ({
-            ...item,
-            metadata: {},
-          })),
-        }
-      : null,
-  };
-}
+const externalWalletModule = new ExternalWalletModule(db, eventService);
+const checkoutPaymentModule = new CheckoutPaymentModule(
+  db,
+  checkoutSessionModule,
+  externalWalletModule
+);
 
 /**
  * GET /v1/payment_pages/:id
@@ -52,23 +36,59 @@ function SanitizeCheckoutSession(session: CheckoutSession): CheckoutSession {
  * payment_pages endpoint. No authentication is required: the unguessable
  * checkout session ID in the URL acts as the bearer credential, which is how
  * Stripe-hosted checkout links work.
+ *
+ * The response is enriched with the merchant's receiving wallet so the
+ * checkout page can display it and build the payment transaction.
  */
 router.get(
   '/:id',
   AsyncHandler(async (req: express.Request, res: express.Response) => {
-    const session = await checkoutSessionModule.GetCheckoutSession(
+    const session = await checkoutPaymentModule.GetPaymentPageSession(
       req.params.id
     );
+    res.json(session);
+  })
+);
 
-    if (!session) {
-      throw new AppError(
-        ERRORS.CHECKOUT_SESSION_NOT_FOUND.message,
-        ERRORS.CHECKOUT_SESSION_NOT_FOUND.status,
-        ERRORS.CHECKOUT_SESSION_NOT_FOUND.type
-      );
-    }
+/**
+ * POST /v1/payment_pages/:id/prepare
+ * Build an unsigned USDC payment transaction for the checkout session,
+ * transferring the session total from the customer's wallet to the
+ * merchant's wallet. The customer signs and broadcasts it via their wallet.
+ */
+router.post(
+  '/:id/prepare',
+  AsyncHandler(async (req: express.Request, res: express.Response) => {
+    const { payer_wallet: payerWallet, email } = req.body as {
+      payer_wallet?: string;
+      email?: string;
+    };
 
-    res.json(SanitizeCheckoutSession(session));
+    const prepared = await checkoutPaymentModule.PreparePayment(
+      req.params.id,
+      payerWallet,
+      email
+    );
+    res.json(prepared);
+  })
+);
+
+/**
+ * POST /v1/payment_pages/:id/confirm
+ * Verify a broadcast payment transaction on-chain and complete the checkout
+ * session. Emits 'checkout.session.completed' on success. Idempotent: if the
+ * session was already completed with the same signature, it is returned as-is.
+ */
+router.post(
+  '/:id/confirm',
+  AsyncHandler(async (req: express.Request, res: express.Response) => {
+    const { signature } = req.body as { signature?: string };
+
+    const session = await checkoutPaymentModule.ConfirmPayment(
+      req.params.id,
+      signature
+    );
+    res.json(session);
   })
 );
 

--- a/apps/web/src/app/core/services/wallet.service.ts
+++ b/apps/web/src/app/core/services/wallet.service.ts
@@ -57,7 +57,8 @@ export class SolanaWalletService {
   }
 
   async SignAndSendUnsignedTransaction(
-    unsignedTxBase64: string
+    unsignedTxBase64: string,
+    chain: 'solana:devnet' | 'solana:mainnet' = 'solana:devnet'
   ): Promise<Uint8Array> {
     const selectedWallet = this.wallet();
     const connectedAccount = this.account();

--- a/apps/web/src/app/data/services/checkout-session.service.ts
+++ b/apps/web/src/app/data/services/checkout-session.service.ts
@@ -6,6 +6,19 @@ import {
   UpdateCheckoutSessionInput,
 } from '@zoneless/shared-schemas';
 
+/** Unsigned payment transaction returned by the public prepare endpoint. */
+export interface CheckoutPaymentTransaction {
+  object: 'checkout.payment_transaction';
+  checkout_session: string;
+  amount_total: number;
+  currency: string | null;
+  merchant_wallet_address: string;
+  unsigned_transaction: string;
+  estimated_fee_lamports: number;
+  blockhash: string;
+  last_valid_block_height: number;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -91,5 +104,36 @@ export class CheckoutSessionService {
     } finally {
       this.loading.set(false);
     }
+  }
+
+  /**
+   * Build an unsigned USDC payment transaction for a checkout session via
+   * the public payment pages endpoint. The customer signs it in their wallet.
+   */
+  async PreparePayment(
+    checkoutSessionId: string,
+    payerWallet: string,
+    email?: string
+  ): Promise<CheckoutPaymentTransaction> {
+    return this.api.Call<CheckoutPaymentTransaction>(
+      'POST',
+      `payment_pages/${checkoutSessionId}/prepare`,
+      { payer_wallet: payerWallet, ...(email ? { email } : {}) }
+    );
+  }
+
+  /**
+   * Confirm a broadcast payment transaction. The backend verifies it
+   * on-chain and completes the checkout session.
+   */
+  async ConfirmPayment(
+    checkoutSessionId: string,
+    signature: string
+  ): Promise<CheckoutSession> {
+    return this.api.Call<CheckoutSession>(
+      'POST',
+      `payment_pages/${checkoutSessionId}/confirm`,
+      { signature }
+    );
   }
 }

--- a/apps/web/src/app/features/checkout/checkout.component.html
+++ b/apps/web/src/app/features/checkout/checkout.component.html
@@ -2,7 +2,6 @@
 
 @if (checkoutSession(); as session) {
 <div class="checkout-page">
-  <!-- Order summary (left) -->
   <aside class="order-summary">
     <div class="order-summary-content">
       <div class="summary-header">
@@ -29,11 +28,13 @@
       <div class="line-items">
         @for (item of LineItems(); track item.id) {
         <div class="line-item">
+          @if (LineItemImage(item); as imageUrl) {
           <img
             class="line-item-image"
-            [src]="LineItemImage(item)"
+            [src]="imageUrl"
             [alt]="item.description ?? 'Line item'"
           />
+          }
           <div class="line-item-details">
             <div class="line-item-name">{{ item.description }}</div>
             @if ((item.quantity ?? 1) > 1) {
@@ -78,22 +79,8 @@
     </div>
   </aside>
 
-  <!-- Payment form (right) -->
   <main class="payment-panel">
     <div class="payment-content">
-      <div class="express-checkout">
-        <button
-          type="button"
-          class="wallet-button wallet-button-phantom"
-          (click)="ConnectWallet()"
-        >
-          <img src="/assets/icons/phantom-wallet.svg" alt="" />
-          {{ ConnectedWalletLabel() }}
-        </button>
-      </div>
-
-      <div class="divider"><span>OR</span></div>
-
       <div class="form-section">
         <div class="section-label">Contact information</div>
         <label class="contact-box">
@@ -127,29 +114,45 @@
         </div>
       </div>
 
-      @if (paymentComplete()) {
-      <div class="payment-success">
-        <span class="payment-success-title">Payment complete</span>
-        <span class="payment-success-text">
-          Thanks! Your payment of {{ FormatAmount(session.amount_total) }} to
-          {{ MerchantName() }} has been confirmed.
-        </span>
-      </div>
-      } @else {
       <button
         type="button"
         class="action-button action-button-wide pay-button"
-        [disabled]="paying()"
+        [class.pay-button-processing]="IsBusy()"
+        [class.pay-button-success]="IsComplete()"
+        [disabled]="IsBusy() || IsComplete()"
         (click)="Pay()"
       >
+        @if (IsComplete()) {
+        <span class="pay-button-icon pay-button-check">
+          <img src="/assets/icons/check.svg" alt="" />
+        </span>
+        } @else if (IsBusy()) {
+        <span class="pay-button-processing-label">
+          {{ BusyLabel() }}
+          <span class="pay-button-icon pay-button-spinner">
+            <app-loader size="small" color="light"></app-loader>
+          </span>
+        </span>
+        } @else {
         {{ SubmitLabel() }}
+        }
       </button>
-      } @if (paymentError(); as errorMessage) {
+
+      @if (paymentError(); as errorMessage) {
       <div class="payment-error">{{ errorMessage }}</div>
       }
 
       <div class="fine-print">
-        By paying, you agree to Zoneless's <a>Terms</a> and <a>Privacy</a>.
+        By paying, you agree to {{ MerchantName() }}'s @if (MerchantTermsUrl();
+        as termsUrl) {
+        <a [href]="termsUrl" target="_blank" rel="noopener">Terms</a>
+        } @else {
+        <a>Terms</a>
+        } and @if (MerchantPrivacyUrl(); as privacyUrl) {
+        <a [href]="privacyUrl" target="_blank" rel="noopener">Privacy</a>
+        } @else {
+        <a>Privacy</a>
+        }.
       </div>
 
       <div class="payment-footer">

--- a/apps/web/src/app/features/checkout/checkout.component.html
+++ b/apps/web/src/app/features/checkout/checkout.component.html
@@ -82,13 +82,13 @@
   <main class="payment-panel">
     <div class="payment-content">
       <div class="express-checkout">
-        <button type="button" class="wallet-button wallet-button-phantom">
+        <button
+          type="button"
+          class="wallet-button wallet-button-phantom"
+          (click)="ConnectWallet()"
+        >
           <img src="/assets/icons/phantom-wallet.svg" alt="" />
-          Phantom
-        </button>
-        <button type="button" class="wallet-button wallet-button-solana">
-          <img src="/assets/images/logos/solana.svg" alt="" />
-          Solana Pay
+          {{ ConnectedWalletLabel() }}
         </button>
       </div>
 
@@ -117,51 +117,36 @@
           </label>
 
           <div class="method-detail">
-            <div class="method-detail-label">Send USDC on Solana to</div>
-            <div class="wallet-address">{{ walletAddress }}</div>
+            <div class="method-detail-label">Paying with USDC on Solana to</div>
+            <div class="wallet-address">{{ MerchantWalletAddress() }}</div>
             <div class="method-detail-help">
-              Send exactly {{ FormatAmount(session.amount_total) }} in USDC to
-              this address to complete your payment.
+              Connect your wallet and approve the payment of
+              {{ FormatAmount(session.amount_total) }} in USDC.
             </div>
           </div>
-
-          <label class="method-option">
-            <input type="radio" name="payment-method" />
-            <img src="/assets/icons/account_balance_wallet.svg" alt="" />
-            Connected wallet
-            <span class="method-option-note">Powered by Solana</span>
-          </label>
         </div>
       </div>
 
-      <!-- <div class="save-info-box">
-        <label class="save-info-header custom-checkbox">
-          <input type="checkbox" name="save-info" [(ngModel)]="saveInfo" />
-          <span class="checkmark"></span>
-          <span class="save-info-copy">
-            <span class="save-info-title">
-              Save my information for faster checkout
-            </span>
-            <span class="save-info-text">
-              Pay securely at {{ MerchantName() }} and everywhere Zoneless is
-              accepted.
-            </span>
-          </span>
-        </label>
-
-        @if (saveInfo) {
-        <input
-          type="tel"
-          name="phone"
-          [(ngModel)]="phone"
-          placeholder="(201) 555-0123"
-        />
-        }
-      </div> -->
-
-      <button type="button" class="action-button action-button-wide pay-button">
+      @if (paymentComplete()) {
+      <div class="payment-success">
+        <span class="payment-success-title">Payment complete</span>
+        <span class="payment-success-text">
+          Thanks! Your payment of {{ FormatAmount(session.amount_total) }} to
+          {{ MerchantName() }} has been confirmed.
+        </span>
+      </div>
+      } @else {
+      <button
+        type="button"
+        class="action-button action-button-wide pay-button"
+        [disabled]="paying()"
+        (click)="Pay()"
+      >
         {{ SubmitLabel() }}
       </button>
+      } @if (paymentError(); as errorMessage) {
+      <div class="payment-error">{{ errorMessage }}</div>
+      }
 
       <div class="fine-print">
         By paying, you agree to Zoneless's <a>Terms</a> and <a>Privacy</a>.

--- a/apps/web/src/app/features/checkout/checkout.component.scss
+++ b/apps/web/src/app/features/checkout/checkout.component.scss
@@ -225,11 +225,6 @@
   color: #1c1c1c;
 }
 
-.wallet-button-solana {
-  background-color: #000000;
-  color: $background-color;
-}
-
 .divider {
   display: flex;
   align-items: center;
@@ -320,13 +315,6 @@
   }
 }
 
-.method-option-note {
-  margin-left: auto;
-  font-size: $font-size-small;
-  font-weight: $text-weight;
-  opacity: $dimmed-extra;
-}
-
 .method-detail {
   padding: 0 $spacing $spacing;
 }
@@ -353,48 +341,46 @@
   margin-top: $spacing-small;
 }
 
-.save-info-box {
-  border: 1px solid $darkest-background-color;
-  border-radius: $border-radius;
-  padding: $spacing;
-  display: flex;
-  flex-direction: column;
-  gap: $spacing;
-}
-
-.save-info-header {
-  display: flex;
-  align-items: flex-start;
-  gap: $spacing-small;
-  cursor: pointer;
-
-  .checkmark {
-    flex-shrink: 0;
-    margin-top: 2px;
-  }
-}
-
-.save-info-copy {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-extra-small;
-}
-
-.save-info-title {
-  font-size: $font-size;
-  font-weight: $medium-weight;
-}
-
-.save-info-text {
-  font-size: $font-size-small;
-  opacity: $dimmed-extra;
-}
-
 .pay-button {
   margin-top: $spacing-plus;
   justify-content: center;
   font-size: $font-size-med;
   padding: $spacing-snug $spacing;
+
+  &:disabled {
+    opacity: $dimmed;
+    cursor: default;
+    pointer-events: none;
+  }
+}
+
+.payment-error {
+  margin-top: $spacing;
+  padding: $spacing-small $spacing-snug;
+  border-radius: $border-radius-small;
+  background-color: rgba(223, 27, 65, 0.08);
+  color: #df1b41;
+  font-size: $font-size-small;
+}
+
+.payment-success {
+  margin-top: $spacing-plus;
+  padding: $spacing;
+  border: 1px solid $darkest-background-color;
+  border-radius: $border-radius;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-extra-small;
+}
+
+.payment-success-title {
+  font-size: $font-size-med;
+  font-weight: $medium-weight;
+}
+
+.payment-success-text {
+  font-size: $font-size-small;
+  opacity: $dimmed-extra;
 }
 
 .fine-print {

--- a/apps/web/src/app/features/checkout/checkout.component.scss
+++ b/apps/web/src/app/features/checkout/checkout.component.scss
@@ -344,13 +344,73 @@
 .pay-button {
   margin-top: $spacing-plus;
   justify-content: center;
+  align-items: center;
   font-size: $font-size-med;
-  padding: $spacing-snug $spacing;
+  padding: 0 $spacing;
+  height: 48px;
+  line-height: 1;
+  transition: background-color 0.25s ease, transform $transition,
+    box-shadow $transition;
 
   &:disabled {
-    opacity: $dimmed;
     cursor: default;
     pointer-events: none;
+  }
+
+  &:disabled:not(.pay-button-success):not(.pay-button-processing) {
+    opacity: $dimmed;
+  }
+
+  &.pay-button-processing,
+  &.pay-button-success {
+    opacity: 1;
+    transform: none;
+    box-shadow: none;
+  }
+
+  &.pay-button-success {
+    background-color: #54b484;
+    background-image: none;
+  }
+}
+
+.pay-button-processing-label {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-small;
+}
+
+.pay-button-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  animation: payIconSlideIn 0.35s ease;
+}
+
+.pay-button-check {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1.5px solid $background-color;
+
+  img {
+    width: 14px;
+    height: 14px;
+    filter: brightness(0) invert(1);
+  }
+}
+
+@keyframes payIconSlideIn {
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
   }
 }
 
@@ -361,26 +421,6 @@
   background-color: rgba(223, 27, 65, 0.08);
   color: #df1b41;
   font-size: $font-size-small;
-}
-
-.payment-success {
-  margin-top: $spacing-plus;
-  padding: $spacing;
-  border: 1px solid $darkest-background-color;
-  border-radius: $border-radius;
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-extra-small;
-}
-
-.payment-success-title {
-  font-size: $font-size-med;
-  font-weight: $medium-weight;
-}
-
-.payment-success-text {
-  font-size: $font-size-small;
-  opacity: $dimmed-extra;
 }
 
 .fine-print {

--- a/apps/web/src/app/features/checkout/checkout.component.ts
+++ b/apps/web/src/app/features/checkout/checkout.component.ts
@@ -8,8 +8,9 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
+import bs58 from 'bs58';
 
-import { MetaService } from '../../core';
+import { MetaService, SolanaWalletService } from '../../core';
 import { CheckoutSessionService } from '../../data/services/checkout-session.service';
 import { PageLoaderComponent } from '../../shared';
 import {
@@ -17,10 +18,6 @@ import {
   CheckoutSessionLineItem,
   Product,
 } from '@zoneless/shared-types';
-
-/** Placeholder destination wallet until payment methods are wired up. */
-const PLACEHOLDER_WALLET_ADDRESS =
-  'zNL5sVYqe3Pv9xWmA7kQJcT2hGdRb8XuFnE4yLoZi6DC';
 
 @Component({
   selector: 'app-checkout',
@@ -33,15 +30,15 @@ export class CheckoutComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly checkoutSessionService = inject(CheckoutSessionService);
   private readonly metaService = inject(MetaService);
+  private readonly solanaWalletService = inject(SolanaWalletService);
 
   checkoutSession: WritableSignal<CheckoutSession | null> = signal(null);
   loading: WritableSignal<boolean> = signal(true);
+  paying: WritableSignal<boolean> = signal(false);
+  paymentError: WritableSignal<string | null> = signal(null);
+  paymentComplete: WritableSignal<boolean> = signal(false);
 
   email = '';
-  phone = '';
-  saveInfo = true;
-
-  readonly walletAddress = PLACEHOLDER_WALLET_ADDRESS;
 
   async ngOnInit(): Promise<void> {
     const id = this.route.snapshot.paramMap.get('checkoutSessionId');
@@ -80,6 +77,87 @@ export class CheckoutComponent implements OnInit {
     return branding?.icon?.url ?? branding?.logo?.url ?? null;
   }
 
+  MerchantWalletAddress(): string {
+    return this.checkoutSession()?.merchant_wallet?.wallet_address ?? '';
+  }
+
+  ConnectedWalletAddress(): string {
+    return this.solanaWalletService.GetAddress();
+  }
+
+  ConnectedWalletLabel(): string {
+    const address = this.ConnectedWalletAddress();
+    if (!address) return 'Phantom';
+    return `${address.slice(0, 4)}…${address.slice(-4)}`;
+  }
+
+  async ConnectWallet(): Promise<void> {
+    this.paymentError.set(null);
+    try {
+      await this.solanaWalletService.Connect();
+    } catch (error) {
+      this.paymentError.set(this.ErrorMessage(error));
+    }
+  }
+
+  async Pay(): Promise<void> {
+    const session = this.checkoutSession();
+    if (!session || this.paying() || this.paymentComplete()) return;
+
+    this.paying.set(true);
+    this.paymentError.set(null);
+
+    try {
+      if (!this.ConnectedWalletAddress()) {
+        await this.solanaWalletService.Connect();
+      }
+      const payerWallet = this.ConnectedWalletAddress();
+      if (!payerWallet) {
+        throw new Error('Connect a wallet to pay');
+      }
+
+      const prepared = await this.checkoutSessionService.PreparePayment(
+        session.id,
+        payerWallet,
+        this.email || undefined
+      );
+
+      const signatureBytes =
+        await this.solanaWalletService.SignAndSendUnsignedTransaction(
+          prepared.unsigned_transaction,
+          session.livemode ? 'solana:mainnet' : 'solana:devnet'
+        );
+      const signature = bs58.encode(signatureBytes);
+
+      const completedSession = await this.checkoutSessionService.ConfirmPayment(
+        session.id,
+        signature
+      );
+
+      this.checkoutSession.set(completedSession);
+      this.paymentComplete.set(true);
+      this.RedirectToSuccessUrl(completedSession);
+    } catch (error) {
+      this.paymentError.set(this.ErrorMessage(error));
+    } finally {
+      this.paying.set(false);
+    }
+  }
+
+  private RedirectToSuccessUrl(session: CheckoutSession): void {
+    if (!session.success_url) return;
+    const url = session.success_url.replace(
+      '{CHECKOUT_SESSION_ID}',
+      session.id
+    );
+    window.location.assign(url);
+  }
+
+  private ErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) return error.message;
+    return 'Something went wrong processing your payment. Please try again.';
+  }
+
   LineItemImage(item: CheckoutSessionLineItem): string {
     const product = item.price?.product;
     if (product && typeof product === 'object') {
@@ -112,6 +190,7 @@ export class CheckoutComponent implements OnInit {
   }
 
   SubmitLabel(): string {
+    if (this.paying()) return 'Processing…';
     switch (this.checkoutSession()?.submit_type) {
       case 'book':
         return 'Book';

--- a/apps/web/src/app/features/checkout/checkout.component.ts
+++ b/apps/web/src/app/features/checkout/checkout.component.ts
@@ -12,16 +12,18 @@ import bs58 from 'bs58';
 
 import { MetaService, SolanaWalletService } from '../../core';
 import { CheckoutSessionService } from '../../data/services/checkout-session.service';
-import { PageLoaderComponent } from '../../shared';
+import { LoaderComponent, PageLoaderComponent } from '../../shared';
 import {
   CheckoutSession,
   CheckoutSessionLineItem,
   Product,
 } from '@zoneless/shared-types';
 
+type PaymentPhase = 'idle' | 'awaiting_wallet' | 'processing' | 'complete';
+
 @Component({
   selector: 'app-checkout',
-  imports: [FormsModule, PageLoaderComponent],
+  imports: [FormsModule, PageLoaderComponent, LoaderComponent],
   templateUrl: './checkout.component.html',
   styleUrl: './checkout.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -34,9 +36,8 @@ export class CheckoutComponent implements OnInit {
 
   checkoutSession: WritableSignal<CheckoutSession | null> = signal(null);
   loading: WritableSignal<boolean> = signal(true);
-  paying: WritableSignal<boolean> = signal(false);
+  paymentPhase: WritableSignal<PaymentPhase> = signal('idle');
   paymentError: WritableSignal<string | null> = signal(null);
-  paymentComplete: WritableSignal<boolean> = signal(false);
 
   email = '';
 
@@ -44,7 +45,6 @@ export class CheckoutComponent implements OnInit {
     const id = this.route.snapshot.paramMap.get('checkoutSessionId');
     if (!id) return;
     await this.LoadCheckoutSession(id);
-    this.metaService.SetMetaTitle(`${this.MerchantName()} - Checkout`);
   }
 
   private async LoadCheckoutSession(id: string): Promise<void> {
@@ -57,6 +57,7 @@ export class CheckoutComponent implements OnInit {
         checkoutSession.customer_email ??
         checkoutSession.customer_details?.email ??
         '';
+      this.metaService.SetMetaTitle(`${this.MerchantName()} - Checkout`);
     } finally {
       this.loading.set(false);
     }
@@ -67,51 +68,46 @@ export class CheckoutComponent implements OnInit {
   }
 
   MerchantName(): string {
-    return (
-      this.checkoutSession()?.branding_settings?.display_name || 'Zoneless'
-    );
+    return this.checkoutSession()?.merchant?.display_name || 'Merchant';
   }
 
   MerchantIconUrl(): string | null {
-    const branding = this.checkoutSession()?.branding_settings;
-    return branding?.icon?.url ?? branding?.logo?.url ?? null;
+    return this.checkoutSession()?.merchant?.icon_url ?? null;
+  }
+
+  MerchantTermsUrl(): string | null {
+    return this.checkoutSession()?.merchant?.terms_url ?? null;
+  }
+
+  MerchantPrivacyUrl(): string | null {
+    return this.checkoutSession()?.merchant?.privacy_url ?? null;
   }
 
   MerchantWalletAddress(): string {
     return this.checkoutSession()?.merchant_wallet?.wallet_address ?? '';
   }
 
-  ConnectedWalletAddress(): string {
-    return this.solanaWalletService.GetAddress();
+  IsBusy(): boolean {
+    const phase = this.paymentPhase();
+    return phase === 'awaiting_wallet' || phase === 'processing';
   }
 
-  ConnectedWalletLabel(): string {
-    const address = this.ConnectedWalletAddress();
-    if (!address) return 'Phantom';
-    return `${address.slice(0, 4)}…${address.slice(-4)}`;
-  }
-
-  async ConnectWallet(): Promise<void> {
-    this.paymentError.set(null);
-    try {
-      await this.solanaWalletService.Connect();
-    } catch (error) {
-      this.paymentError.set(this.ErrorMessage(error));
-    }
+  IsComplete(): boolean {
+    return this.paymentPhase() === 'complete';
   }
 
   async Pay(): Promise<void> {
     const session = this.checkoutSession();
-    if (!session || this.paying() || this.paymentComplete()) return;
+    if (!session || this.paymentPhase() !== 'idle') return;
 
-    this.paying.set(true);
+    this.paymentPhase.set('awaiting_wallet');
     this.paymentError.set(null);
 
     try {
-      if (!this.ConnectedWalletAddress()) {
+      if (!this.solanaWalletService.GetAddress()) {
         await this.solanaWalletService.Connect();
       }
-      const payerWallet = this.ConnectedWalletAddress();
+      const payerWallet = this.solanaWalletService.GetAddress();
       if (!payerWallet) {
         throw new Error('Connect a wallet to pay');
       }
@@ -129,18 +125,19 @@ export class CheckoutComponent implements OnInit {
         );
       const signature = bs58.encode(signatureBytes);
 
+      this.paymentPhase.set('processing');
+
       const completedSession = await this.checkoutSessionService.ConfirmPayment(
         session.id,
         signature
       );
 
       this.checkoutSession.set(completedSession);
-      this.paymentComplete.set(true);
+      this.paymentPhase.set('complete');
       this.RedirectToSuccessUrl(completedSession);
     } catch (error) {
       this.paymentError.set(this.ErrorMessage(error));
-    } finally {
-      this.paying.set(false);
+      this.paymentPhase.set('idle');
     }
   }
 
@@ -150,7 +147,7 @@ export class CheckoutComponent implements OnInit {
       '{CHECKOUT_SESSION_ID}',
       session.id
     );
-    window.location.assign(url);
+    window.setTimeout(() => window.location.assign(url), 1200);
   }
 
   private ErrorMessage(error: unknown): string {
@@ -158,13 +155,12 @@ export class CheckoutComponent implements OnInit {
     return 'Something went wrong processing your payment. Please try again.';
   }
 
-  LineItemImage(item: CheckoutSessionLineItem): string {
+  LineItemImage(item: CheckoutSessionLineItem): string | null {
     const product = item.price?.product;
     if (product && typeof product === 'object') {
-      const image = (product as Product).images?.[0];
-      if (image) return image;
+      return (product as Product).images?.[0] ?? null;
     }
-    return '/assets/images/logos/usdc.svg';
+    return null;
   }
 
   FormatAmount(cents: number | null | undefined): string {
@@ -190,7 +186,6 @@ export class CheckoutComponent implements OnInit {
   }
 
   SubmitLabel(): string {
-    if (this.paying()) return 'Processing…';
     switch (this.checkoutSession()?.submit_type) {
       case 'book':
         return 'Book';
@@ -201,5 +196,11 @@ export class CheckoutComponent implements OnInit {
       default:
         return 'Pay';
     }
+  }
+
+  BusyLabel(): string {
+    return this.paymentPhase() === 'awaiting_wallet'
+      ? 'Confirm in wallet'
+      : 'Processing';
   }
 }

--- a/libs/shared-types/src/lib/CheckoutSession.ts
+++ b/libs/shared-types/src/lib/CheckoutSession.ts
@@ -451,6 +451,34 @@ export interface CheckoutSession {
    * @zoneless_extension
    */
   platform_account: string;
+
+  /**
+   * On-chain payment details recorded when the session is completed.
+   * @zoneless_extension
+   */
+  payment_details?: {
+    /** The Solana transaction signature of the payment. */
+    transaction_signature: string;
+    /** The customer wallet that paid. */
+    payer_wallet: string | null;
+  } | null;
+
+  /**
+   * The merchant wallet that receives the payment. Only populated on the
+   * public payment_pages response so the hosted checkout can build the
+   * payment transaction.
+   * @zoneless_extension
+   */
+  merchant_wallet?: {
+    /** The merchant's receiving wallet address. */
+    wallet_address: string;
+    /** The network the wallet is on. */
+    network: string;
+    /** The currency the wallet receives. */
+    currency: string;
+    /** The USDC mint address for the active network. */
+    usdc_mint: string;
+  } | null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/libs/shared-types/src/lib/CheckoutSession.ts
+++ b/libs/shared-types/src/lib/CheckoutSession.ts
@@ -479,6 +479,18 @@ export interface CheckoutSession {
     /** The USDC mint address for the active network. */
     usdc_mint: string;
   } | null;
+
+  /**
+   * Merchant display details for the hosted checkout page. Resolved from the
+   * platform account that owns the session (with branding_settings overrides).
+   * @zoneless_extension
+   */
+  merchant?: {
+    display_name: string;
+    terms_url: string | null;
+    privacy_url: string | null;
+    icon_url: string | null;
+  } | null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Adds support for initial one-time payments via USDC, emitting a checkout.session.completed event on success.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
