### PR TITLE
feat: create payment intent events during checkout

### DIFF
--- a/apps/api/src/__tests__/CheckoutPayment.spec.ts
+++ b/apps/api/src/__tests__/CheckoutPayment.spec.ts
@@ -1,0 +1,378 @@
+import { CheckoutPaymentModule } from '../modules/CheckoutPayment';
+import { CheckoutSessionModule } from '../modules/CheckoutSession';
+import { Database } from '../modules/Database';
+import { EventService } from '../modules/EventService';
+import { ExternalWalletModule } from '../modules/ExternalWallet';
+import { PaymentIntentModule } from '../modules/PaymentIntent';
+import { ProductModule } from '../modules/Product';
+import { Solana } from '../modules/chains/Solana';
+import {
+  CheckoutSession,
+  CheckoutSessionLineItem,
+  ExternalWallet,
+  Price,
+} from '@zoneless/shared-types';
+import {
+  CreateMockDatabase,
+  DeterministicId,
+  GetFixedTimestamp,
+  ResetIdCounter,
+} from './Setup';
+
+jest.mock('../modules/Database');
+jest.mock('../utils/IdGenerator', () => ({
+  GenerateId: jest.fn((prefix: string) => DeterministicId(prefix)),
+}));
+jest.mock('../utils/Timestamp', () => ({
+  Now: jest.fn(() => GetFixedTimestamp()),
+}));
+jest.mock('../modules/AppConfig', () => ({
+  GetAppConfig: jest.fn(() => ({
+    dashboardUrl: 'http://localhost:4200',
+    livemode: false,
+    appSecret: 'test-secret',
+  })),
+}));
+
+function BuildPrice(overrides: Partial<Price> = {}): Price {
+  return {
+    id: 'price_z_1',
+    active: true,
+    currency: 'usdc',
+    metadata: {},
+    nickname: null,
+    product: 'prod_z_1',
+    recurring: null,
+    tax_behavior: 'unspecified',
+    type: 'one_time',
+    unit_amount: 1000,
+    object: 'price',
+    billing_scheme: 'per_unit',
+    currency_options: null,
+    created: 1700000000,
+    custom_unit_amount: null,
+    livemode: false,
+    lookup_key: null,
+    tiers: null,
+    tiers_mode: null,
+    transform_quantity: null,
+    unit_amount_decimal: '1000',
+    platform_account: 'acct_z_platform',
+    ...overrides,
+  };
+}
+
+function BuildLineItem(
+  overrides: Partial<CheckoutSessionLineItem> = {}
+): CheckoutSessionLineItem {
+  return {
+    id: 'li_z_1',
+    object: 'item',
+    amount_discount: 0,
+    amount_subtotal: 1000,
+    amount_tax: 0,
+    amount_total: 1000,
+    currency: 'usdc',
+    description: 'Test Product',
+    discounts: null,
+    metadata: {},
+    price: BuildPrice(),
+    quantity: 1,
+    taxes: null,
+    ...overrides,
+  };
+}
+
+describe('CheckoutPaymentModule', () => {
+  let module: CheckoutPaymentModule;
+  let mockDb: jest.Mocked<Database>;
+  let eventService: jest.Mocked<EventService>;
+  let checkoutSessionModule: CheckoutSessionModule;
+  let paymentIntentModule: PaymentIntentModule;
+  let mockSolana: jest.Mocked<
+    Pick<
+      Solana,
+      | 'BuildCheckoutPaymentTransaction'
+      | 'VerifyCheckoutPayment'
+      | 'GetUSDCMintAddress'
+    >
+  >;
+  let mockExternalWalletModule: jest.Mocked<
+    Pick<ExternalWalletModule, 'GetDefaultWallet'>
+  >;
+
+  const merchantWallet = {
+    id: 'ew_z_1',
+    object: 'wallet' as const,
+    account: 'acct_z_platform',
+    wallet_address: 'MerchantWallet111',
+    network: 'solana',
+    currency: 'usdc',
+    default_for_currency: true,
+    status: 'verified' as const,
+    created: 1700000000,
+    metadata: {},
+    platform_account: 'acct_z_platform',
+  } as unknown as ExternalWallet;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ResetIdCounter();
+    mockDb = CreateMockDatabase();
+    eventService = {
+      Emit: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<EventService>;
+
+    const productModule = new ProductModule(mockDb);
+    paymentIntentModule = new PaymentIntentModule(mockDb, eventService);
+    checkoutSessionModule = new CheckoutSessionModule(
+      mockDb,
+      eventService,
+      undefined,
+      productModule,
+      undefined,
+      paymentIntentModule
+    );
+
+    mockSolana = {
+      BuildCheckoutPaymentTransaction: jest.fn().mockResolvedValue({
+        unsigned_transaction: 'unsigned_tx_base64',
+        estimated_fee_lamports: 5000,
+        blockhash: 'blockhash_1',
+        last_valid_block_height: 100,
+      }),
+      VerifyCheckoutPayment: jest.fn(),
+      GetUSDCMintAddress: jest.fn().mockReturnValue('UsdcMint111'),
+    };
+
+    mockExternalWalletModule = {
+      GetDefaultWallet: jest.fn().mockResolvedValue(merchantWallet),
+    };
+
+    module = new CheckoutPaymentModule(
+      mockDb,
+      checkoutSessionModule,
+      mockExternalWalletModule as unknown as ExternalWalletModule,
+      productModule,
+      paymentIntentModule,
+      mockSolana as unknown as Solana
+    );
+  });
+
+  function BuildOpenSession(
+    overrides: Partial<CheckoutSession> = {}
+  ): CheckoutSession {
+    return {
+      ...checkoutSessionModule.CheckoutSessionObject(
+        'acct_z_platform',
+        { mode: 'payment', success_url: 'https://example.com/success' },
+        [BuildLineItem()]
+      ),
+      payment_intent: 'pi_z_1',
+      ...overrides,
+    };
+  }
+
+  function BuildPaymentIntent(
+    status:
+      | 'requires_payment_method'
+      | 'requires_confirmation'
+      | 'processing' = 'requires_payment_method'
+  ) {
+    return {
+      ...paymentIntentModule.PaymentIntentObject('acct_z_platform', {
+        amount: 1000,
+        currency: 'usdc',
+      }),
+      id: 'pi_z_1',
+      status,
+    };
+  }
+
+  describe('PreparePayment', () => {
+    it('should build an unsigned tx and mark the PaymentIntent requires_confirmation', async () => {
+      const session = BuildOpenSession();
+      const paymentIntent = BuildPaymentIntent();
+      const requiresConfirmation = {
+        ...paymentIntent,
+        status: 'requires_confirmation' as const,
+        payment_method: 'PayerWallet111',
+      };
+
+      jest
+        .spyOn(checkoutSessionModule, 'GetCheckoutSession')
+        .mockResolvedValue(session);
+      mockDb.Get = jest
+        .fn()
+        .mockResolvedValueOnce(paymentIntent)
+        .mockResolvedValueOnce(paymentIntent)
+        .mockResolvedValueOnce(requiresConfirmation);
+
+      const result = await module.PreparePayment(
+        session.id,
+        'PayerWallet111',
+        'buyer@example.com'
+      );
+
+      expect(mockSolana.BuildCheckoutPaymentTransaction).toHaveBeenCalledWith(
+        'PayerWallet111',
+        'MerchantWallet111',
+        1000,
+        session.id
+      );
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'payment_intent.updated',
+        'acct_z_platform',
+        requiresConfirmation,
+        expect.objectContaining({
+          previousAttributes: expect.objectContaining({
+            status: 'requires_payment_method',
+          }),
+        })
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          object: 'checkout.payment_transaction',
+          checkout_session: session.id,
+          amount_total: 1000,
+          unsigned_transaction: 'unsigned_tx_base64',
+        })
+      );
+    });
+  });
+
+  describe('ConfirmPayment', () => {
+    it('should emit processing then succeeded before completing the session', async () => {
+      const session = BuildOpenSession();
+      const requiresConfirmation = BuildPaymentIntent('requires_confirmation');
+      const processing = {
+        ...requiresConfirmation,
+        status: 'processing' as const,
+        next_action: null,
+      };
+      const succeeded = {
+        ...processing,
+        status: 'succeeded' as const,
+        amount_received: 1000,
+        latest_charge: 'sig_abc',
+      };
+      const completedSession = {
+        ...session,
+        status: 'complete' as const,
+        payment_status: 'paid' as const,
+        url: null,
+        payment_details: {
+          transaction_signature: 'sig_abc',
+          payer_wallet: 'PayerWallet111',
+        },
+      };
+
+      jest
+        .spyOn(checkoutSessionModule, 'GetCheckoutSession')
+        .mockResolvedValueOnce(session)
+        .mockResolvedValueOnce(session)
+        .mockResolvedValueOnce(completedSession);
+      jest
+        .spyOn(
+          checkoutSessionModule,
+          'GetCheckoutSessionByTransactionSignature'
+        )
+        .mockResolvedValue(null);
+      jest
+        .spyOn(checkoutSessionModule, 'CompleteCheckoutSession')
+        .mockResolvedValue(completedSession);
+
+      mockDb.Get = jest
+        .fn()
+        // MarkProcessing: idempotency check + ApplyStatusTransition x2
+        .mockResolvedValueOnce(requiresConfirmation)
+        .mockResolvedValueOnce(requiresConfirmation)
+        .mockResolvedValueOnce(processing)
+        // MarkSucceeded: idempotency check + ApplyStatusTransition x2
+        .mockResolvedValueOnce(processing)
+        .mockResolvedValueOnce(processing)
+        .mockResolvedValueOnce(succeeded);
+      mockDb.Find2Custom = jest.fn().mockResolvedValue([
+        {
+          id: 'txn_existing',
+          type: 'payment',
+          source: session.id,
+        },
+      ]);
+
+      mockSolana.VerifyCheckoutPayment.mockResolvedValue({
+        verified: true,
+        payer_address: 'PayerWallet111',
+        amount_cents: 1000,
+        failure_reason: null,
+      });
+
+      const result = await module.ConfirmPayment(session.id, 'sig_abc');
+
+      expect(eventService.Emit.mock.calls.map((call) => call[0])).toEqual([
+        'payment_intent.processing',
+        'payment_intent.succeeded',
+      ]);
+      expect(
+        checkoutSessionModule.CompleteCheckoutSession
+      ).toHaveBeenCalledWith(session.id, {
+        transaction_signature: 'sig_abc',
+        payer_wallet: 'PayerWallet111',
+      });
+      expect(result.status).toBe('complete');
+    });
+
+    it('should emit payment_failed when on-chain verification fails', async () => {
+      const session = BuildOpenSession();
+      const requiresConfirmation = BuildPaymentIntent('requires_confirmation');
+      const processing = {
+        ...requiresConfirmation,
+        status: 'processing' as const,
+        next_action: null,
+      };
+      const failed = {
+        ...processing,
+        status: 'requires_payment_method' as const,
+        last_payment_error: {
+          message: 'Amount mismatch',
+        },
+      };
+
+      jest
+        .spyOn(checkoutSessionModule, 'GetCheckoutSession')
+        .mockResolvedValue(session);
+      jest
+        .spyOn(
+          checkoutSessionModule,
+          'GetCheckoutSessionByTransactionSignature'
+        )
+        .mockResolvedValue(null);
+
+      mockDb.Get = jest
+        .fn()
+        // MarkProcessing
+        .mockResolvedValueOnce(requiresConfirmation)
+        .mockResolvedValueOnce(requiresConfirmation)
+        .mockResolvedValueOnce(processing)
+        // MarkPaymentFailed (ApplyStatusTransition only)
+        .mockResolvedValueOnce(processing)
+        .mockResolvedValueOnce(failed);
+
+      mockSolana.VerifyCheckoutPayment.mockResolvedValue({
+        verified: false,
+        payer_address: null,
+        amount_cents: 0,
+        failure_reason: 'Amount mismatch',
+      });
+
+      await expect(
+        module.ConfirmPayment(session.id, 'sig_bad')
+      ).rejects.toThrow('Amount mismatch');
+
+      expect(eventService.Emit.mock.calls.map((call) => call[0])).toEqual([
+        'payment_intent.processing',
+        'payment_intent.payment_failed',
+      ]);
+    });
+  });
+});

--- a/apps/api/src/__tests__/CheckoutSession.spec.ts
+++ b/apps/api/src/__tests__/CheckoutSession.spec.ts
@@ -10,6 +10,7 @@ import { EventService } from '../modules/EventService';
 import { PriceModule } from '../modules/Price';
 import { ProductModule } from '../modules/Product';
 import { CustomerModule } from '../modules/Customer';
+import { PaymentIntentModule } from '../modules/PaymentIntent';
 import { ListHelper } from '../utils/ListHelper';
 import {
   CreateMockDatabase,
@@ -86,6 +87,7 @@ describe('CheckoutSessionModule', () => {
   let module: CheckoutSessionModule;
   let mockDb: jest.Mocked<Database>;
   let eventService: jest.Mocked<EventService>;
+  let paymentIntentModule: PaymentIntentModule;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -98,12 +100,18 @@ describe('CheckoutSessionModule', () => {
     const productModule = new ProductModule(mockDb);
     const priceModule = new PriceModule(mockDb, undefined, productModule);
     const customerModule = new CustomerModule(mockDb);
+    paymentIntentModule = new PaymentIntentModule(
+      mockDb,
+      eventService,
+      customerModule
+    );
     module = new CheckoutSessionModule(
       mockDb,
       eventService,
       priceModule,
       productModule,
-      customerModule
+      customerModule,
+      paymentIntentModule
     );
   });
 
@@ -254,7 +262,7 @@ describe('CheckoutSessionModule', () => {
   });
 
   describe('CreateCheckoutSession', () => {
-    it('should resolve line item prices and persist the session', async () => {
+    it('should resolve line item prices, create a PaymentIntent, and persist the session', async () => {
       mockDb.Get = jest
         .fn()
         .mockImplementation(async (collection: string, id: string) => {
@@ -274,10 +282,22 @@ describe('CheckoutSessionModule', () => {
       });
 
       expect(mockDb.Set).toHaveBeenCalledWith(
+        'PaymentIntents',
+        expect.stringContaining('pi_z'),
+        expect.objectContaining({
+          object: 'payment_intent',
+          amount: 2000,
+          currency: 'usdc',
+          status: 'requires_payment_method',
+          platform_account: 'acct_z_platform',
+        })
+      );
+      expect(mockDb.Set).toHaveBeenCalledWith(
         'CheckoutSessions',
         session.id,
         session
       );
+      expect(session.payment_intent).toEqual(expect.stringContaining('pi_z'));
       expect(session.line_items?.data).toEqual([
         expect.objectContaining({
           object: 'item',
@@ -291,6 +311,70 @@ describe('CheckoutSessionModule', () => {
       ]);
       expect(session.amount_subtotal).toBe(2000);
       expect(session.amount_total).toBe(2000);
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'payment_intent.created',
+        'acct_z_platform',
+        expect.objectContaining({
+          id: session.payment_intent,
+          amount: 2000,
+          status: 'requires_payment_method',
+        })
+      );
+      expect(eventService.Emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass payment_intent_data through to the linked PaymentIntent', async () => {
+      mockDb.Get = jest
+        .fn()
+        .mockImplementation(async (collection: string, id: string) => {
+          if (collection === 'Prices' && id === 'price_z_1') {
+            return BuildPrice();
+          }
+          if (collection === 'Products' && id === 'prod_z_1') {
+            return { id: 'prod_z_1', name: 'Test Product' } as Product;
+          }
+          return null;
+        });
+
+      const session = await module.CreateCheckoutSession('acct_z_platform', {
+        mode: 'payment',
+        success_url: 'https://example.com/success',
+        line_items: [{ price: 'price_z_1', quantity: 1 }],
+        payment_intent_data: {
+          description: 'Order #42',
+          metadata: { order_id: '42' },
+          statement_descriptor: 'ZONELESS',
+        },
+      });
+
+      expect(mockDb.Set).toHaveBeenCalledWith(
+        'PaymentIntents',
+        session.payment_intent,
+        expect.objectContaining({
+          description: 'Order #42',
+          metadata: { order_id: '42' },
+          statement_descriptor: 'ZONELESS',
+        })
+      );
+    });
+
+    it('should not create a PaymentIntent in setup mode', async () => {
+      const session = await module.CreateCheckoutSession('acct_z_platform', {
+        mode: 'setup',
+        success_url: 'https://example.com/success',
+      });
+
+      expect(session.payment_intent).toBeNull();
+      expect(mockDb.Set).toHaveBeenCalledWith(
+        'CheckoutSessions',
+        session.id,
+        session
+      );
+      expect(mockDb.Set).not.toHaveBeenCalledWith(
+        'PaymentIntents',
+        expect.anything(),
+        expect.anything()
+      );
       expect(eventService.Emit).not.toHaveBeenCalled();
     });
 
@@ -539,7 +623,72 @@ describe('CheckoutSessionModule', () => {
   });
 
   describe('ExpireCheckoutSession', () => {
-    it('should expire an open session and emit checkout.session.expired', async () => {
+    it('should expire an open session, cancel its PaymentIntent, and emit events', async () => {
+      const openSession = {
+        ...BuildOpenSession(),
+        payment_intent: 'pi_z_1',
+      };
+      const paymentIntent = paymentIntentModule.PaymentIntentObject(
+        'acct_z_platform',
+        { amount: 1000, currency: 'usdc' }
+      );
+      paymentIntent.id = 'pi_z_1';
+      const canceledPaymentIntent = {
+        ...paymentIntent,
+        status: 'canceled' as const,
+        canceled_at: GetFixedTimestamp(),
+        cancellation_reason: 'abandoned' as const,
+        next_action: null,
+        amount_capturable: 0,
+      };
+      const expiredSession = { ...openSession, status: 'expired', url: null };
+
+      mockDb.Get = jest
+        .fn()
+        .mockResolvedValueOnce(openSession)
+        // CancelPaymentIntent: RequirePaymentIntent before + after update
+        .mockResolvedValueOnce(paymentIntent)
+        .mockResolvedValueOnce(canceledPaymentIntent)
+        // ExpireCheckoutSession: reload after status update
+        .mockResolvedValueOnce(expiredSession);
+
+      const result = await module.ExpireCheckoutSession(openSession.id);
+
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'PaymentIntents',
+        'pi_z_1',
+        expect.objectContaining({
+          status: 'canceled',
+          cancellation_reason: 'abandoned',
+        })
+      );
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'CheckoutSessions',
+        openSession.id,
+        { status: 'expired', url: null }
+      );
+      expect(eventService.Emit.mock.calls.map((call) => call[0])).toEqual([
+        'payment_intent.canceled',
+        'checkout.session.expired',
+      ]);
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'payment_intent.canceled',
+        'acct_z_platform',
+        expect.objectContaining({
+          id: 'pi_z_1',
+          status: 'canceled',
+          cancellation_reason: 'abandoned',
+        })
+      );
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'checkout.session.expired',
+        'acct_z_platform',
+        expiredSession
+      );
+      expect(result).toEqual(expiredSession);
+    });
+
+    it('should expire a session without a PaymentIntent', async () => {
       const openSession = BuildOpenSession();
       const expiredSession = { ...openSession, status: 'expired', url: null };
       mockDb.Get = jest
@@ -559,6 +708,7 @@ describe('CheckoutSessionModule', () => {
         'acct_z_platform',
         expiredSession
       );
+      expect(eventService.Emit).toHaveBeenCalledTimes(1);
       expect(result).toEqual(expiredSession);
     });
 
@@ -580,6 +730,54 @@ describe('CheckoutSessionModule', () => {
       );
       expect(mockDb.Update).not.toHaveBeenCalled();
       expect(eventService.Emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CompleteCheckoutSession', () => {
+    it('should complete an open session and emit checkout.session.completed', async () => {
+      const openSession = {
+        ...BuildOpenSession(),
+        payment_intent: 'pi_z_1',
+      };
+      const completedSession = {
+        ...openSession,
+        status: 'complete' as const,
+        payment_status: 'paid' as const,
+        url: null,
+        payment_details: {
+          transaction_signature: 'sig_abc',
+          payer_wallet: 'payer_wallet_1',
+        },
+      };
+      mockDb.Get = jest
+        .fn()
+        .mockResolvedValueOnce(openSession)
+        .mockResolvedValueOnce(completedSession);
+
+      const result = await module.CompleteCheckoutSession(openSession.id, {
+        transaction_signature: 'sig_abc',
+        payer_wallet: 'payer_wallet_1',
+      });
+
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'CheckoutSessions',
+        openSession.id,
+        {
+          status: 'complete',
+          payment_status: 'paid',
+          url: null,
+          payment_details: {
+            transaction_signature: 'sig_abc',
+            payer_wallet: 'payer_wallet_1',
+          },
+        }
+      );
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'checkout.session.completed',
+        'acct_z_platform',
+        completedSession
+      );
+      expect(result).toEqual(completedSession);
     });
   });
 

--- a/apps/api/src/__tests__/PaymentIntent.spec.ts
+++ b/apps/api/src/__tests__/PaymentIntent.spec.ts
@@ -2,6 +2,7 @@ import { PaymentIntentModule } from '../modules/PaymentIntent';
 import { Database } from '../modules/Database';
 import { CustomerModule } from '../modules/Customer';
 import { AccountModule } from '../modules/Account';
+import { EventService } from '../modules/EventService';
 import { AppError } from '../utils/AppError';
 import { ListHelper } from '../utils/ListHelper';
 import {
@@ -34,6 +35,7 @@ describe('PaymentIntentModule', () => {
   let module: PaymentIntentModule;
   let mockDb: jest.Mocked<Database>;
   let mockCustomerModule: jest.Mocked<Pick<CustomerModule, 'GetCustomer'>>;
+  let eventService: jest.Mocked<EventService>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -42,9 +44,12 @@ describe('PaymentIntentModule', () => {
     mockCustomerModule = {
       GetCustomer: jest.fn(),
     };
+    eventService = {
+      Emit: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<EventService>;
     module = new PaymentIntentModule(
       mockDb,
-      undefined,
+      eventService,
       mockCustomerModule as unknown as CustomerModule
     );
   });
@@ -822,6 +827,250 @@ describe('PaymentIntentModule', () => {
           startingAfter: 'uli_z_unknown',
         })
       ).toThrow('Invalid starting_after ID');
+    });
+  });
+
+  describe('lifecycle transitions', () => {
+    function StoredPaymentIntent(
+      status: PaymentIntent['status'] = 'requires_payment_method'
+    ): PaymentIntent {
+      return {
+        ...module.PaymentIntentObject('acct_z_platform', {
+          amount: 2000,
+          currency: 'usdc',
+        }),
+        status,
+      };
+    }
+
+    it('should mark requires_confirmation and emit payment_intent.updated', async () => {
+      const stored = StoredPaymentIntent();
+      const updated = {
+        ...stored,
+        status: 'requires_confirmation' as const,
+        payment_method: 'PayerWallet111',
+        next_action: null,
+      };
+      mockDb.Get.mockResolvedValueOnce(stored)
+        .mockResolvedValueOnce(stored)
+        .mockResolvedValueOnce(updated);
+
+      const result = await module.MarkRequiresConfirmation(stored.id, {
+        paymentMethod: 'PayerWallet111',
+      });
+
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'PaymentIntents',
+        stored.id,
+        expect.objectContaining({
+          status: 'requires_confirmation',
+          payment_method: 'PayerWallet111',
+        })
+      );
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'payment_intent.updated',
+        'acct_z_platform',
+        updated,
+        expect.objectContaining({
+          previousAttributes: expect.objectContaining({
+            status: 'requires_payment_method',
+          }),
+        })
+      );
+      expect(result.status).toBe('requires_confirmation');
+    });
+
+    it('should be idempotent when already requires_confirmation', async () => {
+      const stored = StoredPaymentIntent('requires_confirmation');
+      mockDb.Get.mockResolvedValue(stored);
+
+      const result = await module.MarkRequiresConfirmation(stored.id);
+
+      expect(mockDb.Update).not.toHaveBeenCalled();
+      expect(eventService.Emit).not.toHaveBeenCalled();
+      expect(result).toEqual(stored);
+    });
+
+    it('should mark requires_action and emit payment_intent.requires_action', async () => {
+      const stored = StoredPaymentIntent('requires_confirmation');
+      const updated = {
+        ...stored,
+        status: 'requires_action' as const,
+        next_action: { type: 'use_stripe_sdk' },
+      };
+      mockDb.Get.mockResolvedValueOnce(stored)
+        .mockResolvedValueOnce(stored)
+        .mockResolvedValueOnce(updated);
+
+      const result = await module.MarkRequiresAction(stored.id, {
+        type: 'use_stripe_sdk',
+      });
+
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'PaymentIntents',
+        stored.id,
+        expect.objectContaining({
+          status: 'requires_action',
+          next_action: { type: 'use_stripe_sdk' },
+        })
+      );
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'payment_intent.requires_action',
+        'acct_z_platform',
+        updated
+      );
+      expect(result.status).toBe('requires_action');
+    });
+
+    it('should refresh next_action without re-emitting when already requires_action', async () => {
+      const stored = StoredPaymentIntent('requires_action');
+      const refreshed = {
+        ...stored,
+        next_action: { type: 'use_stripe_sdk', attempt: 2 },
+      };
+      mockDb.Get.mockResolvedValueOnce(stored).mockResolvedValueOnce(refreshed);
+
+      await module.MarkRequiresAction(stored.id, {
+        type: 'use_stripe_sdk',
+        attempt: 2,
+      });
+
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'PaymentIntents',
+        stored.id,
+        expect.objectContaining({
+          next_action: { type: 'use_stripe_sdk', attempt: 2 },
+        })
+      );
+      expect(eventService.Emit).not.toHaveBeenCalled();
+    });
+
+    it('should mark processing and emit payment_intent.processing', async () => {
+      const stored = StoredPaymentIntent('requires_confirmation');
+      const updated = {
+        ...stored,
+        status: 'processing' as const,
+        next_action: null,
+      };
+      mockDb.Get.mockResolvedValueOnce(stored)
+        .mockResolvedValueOnce(stored)
+        .mockResolvedValueOnce(updated);
+
+      const result = await module.MarkProcessing(stored.id);
+
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'PaymentIntents',
+        stored.id,
+        expect.objectContaining({ status: 'processing', next_action: null })
+      );
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'payment_intent.processing',
+        'acct_z_platform',
+        updated
+      );
+      expect(result.status).toBe('processing');
+    });
+
+    it('should be idempotent when already processing', async () => {
+      const stored = StoredPaymentIntent('processing');
+      mockDb.Get.mockResolvedValue(stored);
+
+      const result = await module.MarkProcessing(stored.id);
+
+      expect(mockDb.Update).not.toHaveBeenCalled();
+      expect(eventService.Emit).not.toHaveBeenCalled();
+      expect(result).toEqual(stored);
+    });
+
+    it('should mark succeeded and emit payment_intent.succeeded', async () => {
+      const stored = StoredPaymentIntent('processing');
+      const updated = {
+        ...stored,
+        status: 'succeeded' as const,
+        amount_received: 2000,
+        latest_charge: 'sig_abc',
+        next_action: null,
+      };
+      mockDb.Get.mockResolvedValueOnce(stored)
+        .mockResolvedValueOnce(stored)
+        .mockResolvedValueOnce(updated);
+
+      const result = await module.MarkSucceeded(stored.id, {
+        amountReceived: 2000,
+        latestCharge: 'sig_abc',
+      });
+
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'PaymentIntents',
+        stored.id,
+        expect.objectContaining({
+          status: 'succeeded',
+          amount_received: 2000,
+          latest_charge: 'sig_abc',
+        })
+      );
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'payment_intent.succeeded',
+        'acct_z_platform',
+        updated
+      );
+      expect(result.status).toBe('succeeded');
+    });
+
+    it('should mark payment failed and emit payment_intent.payment_failed', async () => {
+      const stored = StoredPaymentIntent('processing');
+      const lastPaymentError = {
+        advice_code: null,
+        charge: null,
+        code: 'payment_intent_payment_attempt_failed',
+        decline_code: null,
+        doc_url: null,
+        message: 'Amount mismatch',
+        network_advice_code: null,
+        network_decline_code: null,
+        param: null,
+        payment_method: null,
+        payment_method_type: 'crypto',
+        source: null,
+        type: 'invalid_request_error' as const,
+      };
+      const updated = {
+        ...stored,
+        status: 'requires_payment_method' as const,
+        last_payment_error: lastPaymentError,
+        next_action: null,
+      };
+      mockDb.Get.mockResolvedValueOnce(stored).mockResolvedValueOnce(updated);
+
+      const result = await module.MarkPaymentFailed(
+        stored.id,
+        lastPaymentError
+      );
+
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'PaymentIntents',
+        stored.id,
+        expect.objectContaining({
+          status: 'requires_payment_method',
+          last_payment_error: lastPaymentError,
+        })
+      );
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'payment_intent.payment_failed',
+        'acct_z_platform',
+        updated
+      );
+      expect(result.status).toBe('requires_payment_method');
+    });
+
+    it('should reject succeeded transition from canceled', async () => {
+      const stored = StoredPaymentIntent('canceled');
+      mockDb.Get.mockResolvedValue(stored);
+
+      await expect(module.MarkSucceeded(stored.id)).rejects.toThrow(
+        /cannot transition to 'succeeded' from status 'canceled'/
+      );
+      expect(eventService.Emit).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/modules/CheckoutPayment.ts
+++ b/apps/api/src/modules/CheckoutPayment.ts
@@ -14,6 +14,7 @@ import { ExternalWalletModule } from './ExternalWallet';
 import { BalanceModule } from './Balance';
 import { BalanceTransactionModule } from './BalanceTransaction';
 import { ProductModule } from './Product';
+import type { PaymentIntentModule } from './PaymentIntent';
 import { Solana, SolanaExplorerUrl } from './chains/Solana';
 import { AppError } from '../utils/AppError';
 import { ERRORS } from '../utils/Errors';
@@ -49,6 +50,7 @@ export class CheckoutPaymentModule {
   private readonly productModule: ProductModule;
   private readonly balanceModule: BalanceModule;
   private readonly balanceTransactionModule: BalanceTransactionModule;
+  private readonly paymentIntentModule: PaymentIntentModule | null;
   private readonly solana: Solana;
 
   constructor(
@@ -56,6 +58,7 @@ export class CheckoutPaymentModule {
     checkoutSessionModule: CheckoutSessionModule,
     externalWalletModule: ExternalWalletModule,
     productModule: ProductModule,
+    paymentIntentModule?: PaymentIntentModule,
     solana?: Solana
   ) {
     this.db = db;
@@ -65,6 +68,7 @@ export class CheckoutPaymentModule {
     this.productModule = productModule;
     this.balanceModule = new BalanceModule(db);
     this.balanceTransactionModule = new BalanceTransactionModule(db);
+    this.paymentIntentModule = paymentIntentModule || null;
     this.solana = solana || new Solana();
   }
 
@@ -169,6 +173,10 @@ export class CheckoutPaymentModule {
    * total from the customer's wallet to the merchant's wallet. The customer
    * signs and broadcasts it via their wallet.
    *
+   * Transitions the linked PaymentIntent to `requires_confirmation` once the
+   * customer has provided a wallet (Stripe: payment details attached, ready
+   * to confirm). Emits `payment_intent.updated`.
+   *
    * @param id - The checkout session ID
    * @param payerWallet - The customer's wallet address
    * @param email - Optional customer email to record on the session
@@ -210,6 +218,8 @@ export class CheckoutPaymentModule {
       session.id
     );
 
+    await this.MarkPaymentIntentRequiresConfirmation(session, payerWallet);
+
     return {
       object: 'checkout.payment_transaction',
       checkout_session: session.id,
@@ -222,9 +232,9 @@ export class CheckoutPaymentModule {
 
   /**
    * Verify a broadcast payment transaction on-chain and complete the
-   * checkout session, emitting 'checkout.session.completed'. Idempotent: if
-   * the session was already completed with the same signature, it is
-   * returned as-is.
+   * checkout session, emitting PaymentIntent lifecycle events then
+   * `checkout.session.completed`. Idempotent: if the session was already
+   * completed with the same signature, it is returned as-is.
    *
    * @param id - The checkout session ID
    * @param signature - The Solana transaction signature of the payment
@@ -284,6 +294,8 @@ export class CheckoutPaymentModule {
       signature,
     });
 
+    await this.MarkPaymentIntentProcessing(session);
+
     const verification = await this.solana.VerifyCheckoutPayment(signature, {
       merchantWalletAddress: merchantWallet.wallet_address,
       amountInCents: session.amount_total!,
@@ -291,12 +303,23 @@ export class CheckoutPaymentModule {
     });
 
     if (!verification.verified) {
+      await this.MarkPaymentIntentFailed(
+        session,
+        verification.failure_reason || 'Payment verification failed'
+      );
       throw new AppError(
         verification.failure_reason || 'Payment verification failed',
         ERRORS.INVALID_REQUEST.status,
         ERRORS.INVALID_REQUEST.type
       );
     }
+
+    // Stripe typically delivers payment_intent.succeeded before
+    // checkout.session.completed.
+    await this.MarkPaymentIntentSucceeded(session, {
+      amountReceived: verification.amount_cents,
+      signature,
+    });
 
     const completedSession =
       await this.checkoutSessionModule.CompleteCheckoutSession(session.id, {
@@ -490,5 +513,64 @@ export class CheckoutPaymentModule {
         ERRORS.INVALID_REQUEST.type
       );
     }
+  }
+
+  private async MarkPaymentIntentRequiresConfirmation(
+    session: CheckoutSession,
+    payerWallet: string
+  ): Promise<void> {
+    if (!session.payment_intent || !this.paymentIntentModule) return;
+
+    // Until crypto PaymentMethods exist, store the payer wallet address as
+    // the payment_method stand-in so the PI reflects that details were
+    // collected (Stripe: attach PM → requires_confirmation).
+    await this.paymentIntentModule.MarkRequiresConfirmation(
+      session.payment_intent,
+      { paymentMethod: payerWallet }
+    );
+  }
+
+  private async MarkPaymentIntentProcessing(
+    session: CheckoutSession
+  ): Promise<void> {
+    if (!session.payment_intent || !this.paymentIntentModule) return;
+    await this.paymentIntentModule.MarkProcessing(session.payment_intent);
+  }
+
+  private async MarkPaymentIntentSucceeded(
+    session: CheckoutSession,
+    details: { amountReceived: number; signature: string }
+  ): Promise<void> {
+    if (!session.payment_intent || !this.paymentIntentModule) return;
+
+    await this.paymentIntentModule.MarkSucceeded(session.payment_intent, {
+      amountReceived: details.amountReceived,
+      // Charges are not modeled yet; store the on-chain signature as the
+      // closest Stripe-compatible stand-in for latest_charge.
+      latestCharge: details.signature,
+    });
+  }
+
+  private async MarkPaymentIntentFailed(
+    session: CheckoutSession,
+    message: string
+  ): Promise<void> {
+    if (!session.payment_intent || !this.paymentIntentModule) return;
+
+    await this.paymentIntentModule.MarkPaymentFailed(session.payment_intent, {
+      advice_code: null,
+      charge: null,
+      code: 'payment_intent_payment_attempt_failed',
+      decline_code: null,
+      doc_url: null,
+      message,
+      network_advice_code: null,
+      network_decline_code: null,
+      param: null,
+      payment_method: null,
+      payment_method_type: 'crypto',
+      source: null,
+      type: 'invalid_request_error',
+    });
   }
 }

--- a/apps/api/src/modules/CheckoutSession.ts
+++ b/apps/api/src/modules/CheckoutSession.ts
@@ -18,6 +18,7 @@ import { ValidateUpdate } from './Util';
 import type { PriceModule } from './Price';
 import type { ProductModule } from './Product';
 import type { CustomerModule } from './Customer';
+import type { PaymentIntentModule } from './PaymentIntent';
 import {
   CreateCheckoutSessionSchema,
   CreateCheckoutSessionInput,
@@ -25,6 +26,7 @@ import {
   UpdateCheckoutSessionInput,
   ListCheckoutSessionsFiltersInput,
   CreatePriceInput,
+  CreatePaymentIntentInput,
 } from '@zoneless/shared-schemas';
 import { ListHelper, ListOptions, ListResult } from '../utils/ListHelper';
 import { Now } from '../utils/Timestamp';
@@ -44,6 +46,9 @@ type PriceDataInput = NonNullable<LineItemInput['price_data']>;
 type ShippingOptionInput = NonNullable<
   CreateCheckoutSessionInput['shipping_options']
 >[number];
+type PaymentIntentDataInput = NonNullable<
+  CreateCheckoutSessionInput['payment_intent_data']
+>;
 
 export class CheckoutSessionModule {
   private readonly db: Database;
@@ -52,13 +57,15 @@ export class CheckoutSessionModule {
   private readonly priceModule: PriceModule | null;
   private readonly productModule: ProductModule | null;
   private readonly customerModule: CustomerModule | null;
+  private readonly paymentIntentModule: PaymentIntentModule | null;
 
   constructor(
     db: Database,
     eventService?: EventService,
     priceModule?: PriceModule,
     productModule?: ProductModule,
-    customerModule?: CustomerModule
+    customerModule?: CustomerModule,
+    paymentIntentModule?: PaymentIntentModule
   ) {
     this.db = db;
     this.eventService = eventService || null;
@@ -72,14 +79,17 @@ export class CheckoutSessionModule {
     this.priceModule = priceModule || null;
     this.productModule = productModule || null;
     this.customerModule = customerModule || null;
+    this.paymentIntentModule = paymentIntentModule || null;
   }
 
   /**
    * Create a new checkout session.
    *
-   * Note: no event is emitted on creation. `checkout.session.completed`
-   * and the async payment events are emitted by the payment flow;
-   * `checkout.session.expired` is emitted by ExpireCheckoutSession.
+   * For `payment` mode, creates a linked PaymentIntent (emitting
+   * `payment_intent.created`) and stores its id on the session. No
+   * `checkout.session.*` event is emitted on creation —
+   * `checkout.session.completed` / async payment events come from the
+   * payment flow; `checkout.session.expired` from ExpireCheckoutSession.
    *
    * @param platformAccountId - The platform account ID
    * @param input - The input data for the checkout session
@@ -115,6 +125,14 @@ export class CheckoutSessionModule {
       validatedInput,
       lineItems
     );
+
+    if (session.mode === 'payment' && this.paymentIntentModule) {
+      const paymentIntent = await this.paymentIntentModule.CreatePaymentIntent(
+        platformAccountId,
+        this.BuildPaymentIntentCreateInput(session, validatedInput)
+      );
+      session.payment_intent = paymentIntent.id;
+    }
 
     await this.db.Set('CheckoutSessions', session.id, session);
 
@@ -467,6 +485,18 @@ export class CheckoutSessionModule {
       };
       updatePayload.amount_subtotal = totals.amount_subtotal;
       updatePayload.amount_total = totals.amount_total;
+
+      // Keep the linked PaymentIntent amount in sync (Stripe does the same).
+      if (
+        previousSession.payment_intent &&
+        this.paymentIntentModule &&
+        totals.amount_total !== previousSession.amount_total
+      ) {
+        await this.paymentIntentModule.UpdatePaymentIntent(
+          previousSession.payment_intent,
+          { amount: totals.amount_total }
+        );
+      }
     }
 
     await this.db.Update<CheckoutSessionType>(
@@ -489,8 +519,9 @@ export class CheckoutSessionModule {
 
   /**
    * Expire a checkout session. Only sessions with an `open` status can be
-   * expired. Emits a 'checkout.session.expired' event if EventService is
-   * configured.
+   * expired. Cancels any linked PaymentIntent (emitting
+   * `payment_intent.canceled`) and emits `checkout.session.expired` if
+   * EventService is configured.
    *
    * @param id - The checkout session ID
    * @returns The expired CheckoutSession
@@ -510,6 +541,13 @@ export class CheckoutSessionModule {
         'Only Checkout Sessions with an `open` status can be expired',
         ERRORS.INVALID_REQUEST.status,
         ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    if (previousSession.payment_intent && this.paymentIntentModule) {
+      await this.paymentIntentModule.CancelPaymentIntent(
+        previousSession.payment_intent,
+        { cancellation_reason: 'abandoned' }
       );
     }
 
@@ -963,6 +1001,40 @@ export class CheckoutSessionModule {
       file: input.file ?? null,
       type: input.type,
       url: input.url ?? null,
+    };
+  }
+
+  /**
+   * Maps Checkout Session fields (plus optional `payment_intent_data`) into
+   * the create payload for the linked PaymentIntent.
+   */
+  private BuildPaymentIntentCreateInput(
+    session: CheckoutSessionType,
+    input: CreateCheckoutSessionInput
+  ): CreatePaymentIntentInput {
+    const paymentIntentData: PaymentIntentDataInput =
+      input.payment_intent_data ?? {};
+
+    return {
+      amount: session.amount_total!,
+      currency: session.currency ?? 'usdc',
+      customer: session.customer ?? undefined,
+      customer_account: session.customer_account ?? undefined,
+      payment_method_types: ['crypto'],
+      receipt_email:
+        paymentIntentData.receipt_email ?? session.customer_email ?? undefined,
+      application_fee_amount: paymentIntentData.application_fee_amount,
+      capture_method: paymentIntentData.capture_method,
+      description: paymentIntentData.description,
+      metadata: paymentIntentData.metadata,
+      on_behalf_of: paymentIntentData.on_behalf_of,
+      setup_future_usage: paymentIntentData.setup_future_usage,
+      shipping: paymentIntentData.shipping,
+      statement_descriptor: paymentIntentData.statement_descriptor,
+      statement_descriptor_suffix:
+        paymentIntentData.statement_descriptor_suffix,
+      transfer_data: paymentIntentData.transfer_data,
+      transfer_group: paymentIntentData.transfer_group,
     };
   }
 }

--- a/apps/api/src/modules/PaymentIntent.ts
+++ b/apps/api/src/modules/PaymentIntent.ts
@@ -14,6 +14,7 @@ import { AccountModule } from './Account';
 import type { CustomerModule } from './Customer';
 import { GenerateId } from '../utils/IdGenerator';
 import {
+  EventType,
   PaymentIntent as PaymentIntentType,
   PaymentIntentAmountDetails,
   PaymentIntentAmountDetailsLineItem,
@@ -52,6 +53,40 @@ const CANCELABLE_STATUSES: ReadonlySet<PaymentIntentType['status']> = new Set([
   'requires_action',
   'processing',
 ]);
+
+/** Statuses from which a PaymentIntent may enter `requires_confirmation`. */
+const REQUIRES_CONFIRMATION_FROM: ReadonlySet<PaymentIntentType['status']> =
+  new Set(['requires_payment_method']);
+
+/** Statuses from which a PaymentIntent may enter `requires_action`. */
+const REQUIRES_ACTION_FROM: ReadonlySet<PaymentIntentType['status']> = new Set([
+  'requires_payment_method',
+  'requires_confirmation',
+]);
+
+/** Statuses from which a PaymentIntent may enter `processing`. */
+const PROCESSING_FROM: ReadonlySet<PaymentIntentType['status']> = new Set([
+  'requires_payment_method',
+  'requires_confirmation',
+  'requires_action',
+]);
+
+/** Statuses from which a PaymentIntent may succeed or fail. */
+const TERMINAL_ATTEMPT_FROM: ReadonlySet<PaymentIntentType['status']> = new Set(
+  [
+    'requires_payment_method',
+    'requires_confirmation',
+    'requires_action',
+    'processing',
+  ]
+);
+
+export type PaymentIntentLastPaymentError = NonNullable<
+  PaymentIntentType['last_payment_error']
+>;
+export type PaymentIntentNextAction = NonNullable<
+  PaymentIntentType['next_action']
+>;
 
 type AddressInput = NonNullable<
   NonNullable<CreatePaymentIntentInput['shipping']>['address']
@@ -452,38 +487,222 @@ export class PaymentIntentModule {
   ): Promise<PaymentIntentType> {
     const validatedInput = ValidateUpdate(CancelPaymentIntentSchema, input);
 
-    const previousPaymentIntent = await this.GetPaymentIntent(id);
-    if (!previousPaymentIntent) {
-      throw new AppError(
-        ERRORS.PAYMENT_INTENT_NOT_FOUND.message,
-        ERRORS.PAYMENT_INTENT_NOT_FOUND.status,
-        ERRORS.PAYMENT_INTENT_NOT_FOUND.type
-      );
+    return this.ApplyStatusTransition(id, {
+      eventType: 'payment_intent.canceled',
+      allowedFromStatuses: CANCELABLE_STATUSES,
+      invalidTransitionMessage: (status) =>
+        `PaymentIntent cannot be canceled because it has status: ${status}`,
+      updatePayload: {
+        status: 'canceled',
+        canceled_at: Now(),
+        cancellation_reason: validatedInput.cancellation_reason ?? null,
+        next_action: null,
+        // Stripe refunds remaining capturable amount; until charges exist we zero it.
+        amount_capturable: 0,
+      },
+    });
+  }
+
+  /**
+   * Mark a PaymentIntent as ready to confirm after the customer has provided
+   * payment details (e.g. connected a wallet). Mirrors Stripe's transition
+   * into `requires_confirmation`. Stripe has no dedicated webhook for this
+   * status, so we emit `payment_intent.updated` with `previous_attributes`.
+   * Idempotent when already in `requires_confirmation`.
+   */
+  async MarkRequiresConfirmation(
+    id: string,
+    options: { paymentMethod?: string | null } = {}
+  ): Promise<PaymentIntentType> {
+    const previous = await this.RequirePaymentIntent(id);
+
+    if (previous.status === 'requires_confirmation') {
+      if (options.paymentMethod !== undefined) {
+        await this.db.Update<PaymentIntentType>('PaymentIntents', id, {
+          payment_method: options.paymentMethod,
+          last_payment_error: null,
+        });
+        return (await this.GetPaymentIntent(id))!;
+      }
+      return previous;
     }
 
-    if (!CANCELABLE_STATUSES.has(previousPaymentIntent.status)) {
+    const updatePayload: Partial<PaymentIntentType> = {
+      status: 'requires_confirmation',
+      next_action: null,
+      last_payment_error: null,
+    };
+    if (options.paymentMethod !== undefined) {
+      updatePayload.payment_method = options.paymentMethod;
+    }
+
+    return this.ApplyStatusTransition(id, {
+      eventType: 'payment_intent.updated',
+      allowedFromStatuses: REQUIRES_CONFIRMATION_FROM,
+      updatePayload,
+      previousAttributes: ExtractChangedFields(
+        previous as unknown as Record<string, unknown>,
+        updatePayload as Record<string, unknown>
+      ),
+    });
+  }
+
+  /**
+   * Mark a PaymentIntent as requiring additional customer action (e.g. 3DS)
+   * and emit `payment_intent.requires_action`. Not used by the standard USDC
+   * wallet checkout path — that uses `requires_confirmation` instead.
+   * Idempotent when already in `requires_action`: updates `next_action`
+   * without re-emitting.
+   */
+  async MarkRequiresAction(
+    id: string,
+    nextAction: PaymentIntentNextAction
+  ): Promise<PaymentIntentType> {
+    const previous = await this.RequirePaymentIntent(id);
+
+    if (previous.status === 'requires_action') {
+      await this.db.Update<PaymentIntentType>('PaymentIntents', id, {
+        next_action: nextAction,
+        last_payment_error: null,
+      });
+      return (await this.GetPaymentIntent(id))!;
+    }
+
+    return this.ApplyStatusTransition(id, {
+      eventType: 'payment_intent.requires_action',
+      allowedFromStatuses: REQUIRES_ACTION_FROM,
+      updatePayload: {
+        status: 'requires_action',
+        next_action: nextAction,
+        last_payment_error: null,
+      },
+    });
+  }
+
+  /**
+   * Mark a PaymentIntent as processing (on-chain confirmation in flight)
+   * and emit `payment_intent.processing`. Idempotent when already processing.
+   */
+  async MarkProcessing(id: string): Promise<PaymentIntentType> {
+    const previous = await this.RequirePaymentIntent(id);
+    if (previous.status === 'processing') {
+      return previous;
+    }
+
+    return this.ApplyStatusTransition(id, {
+      eventType: 'payment_intent.processing',
+      allowedFromStatuses: PROCESSING_FROM,
+      updatePayload: {
+        status: 'processing',
+        next_action: null,
+        last_payment_error: null,
+      },
+    });
+  }
+
+  /**
+   * Mark a PaymentIntent as succeeded and emit `payment_intent.succeeded`.
+   * Idempotent when already succeeded.
+   */
+  async MarkSucceeded(
+    id: string,
+    options: { amountReceived?: number; latestCharge?: string | null } = {}
+  ): Promise<PaymentIntentType> {
+    const previous = await this.RequirePaymentIntent(id);
+    if (previous.status === 'succeeded') {
+      return previous;
+    }
+
+    return this.ApplyStatusTransition(id, {
+      eventType: 'payment_intent.succeeded',
+      allowedFromStatuses: TERMINAL_ATTEMPT_FROM,
+      updatePayload: {
+        status: 'succeeded',
+        amount_received: options.amountReceived ?? previous.amount,
+        latest_charge: options.latestCharge ?? previous.latest_charge,
+        next_action: null,
+        last_payment_error: null,
+      },
+    });
+  }
+
+  /**
+   * Record a failed payment attempt: set `last_payment_error`, return the
+   * PaymentIntent to `requires_payment_method` so the customer can retry,
+   * and emit `payment_intent.payment_failed`.
+   */
+  async MarkPaymentFailed(
+    id: string,
+    lastPaymentError: PaymentIntentLastPaymentError
+  ): Promise<PaymentIntentType> {
+    return this.ApplyStatusTransition(id, {
+      eventType: 'payment_intent.payment_failed',
+      allowedFromStatuses: TERMINAL_ATTEMPT_FROM,
+      updatePayload: {
+        status: 'requires_payment_method',
+        last_payment_error: lastPaymentError,
+        next_action: null,
+      },
+    });
+  }
+
+  /**
+   * Persist a status transition and emit the corresponding lifecycle event.
+   * Shared by cancel / requires_confirmation / requires_action / processing /
+   * succeeded / payment_failed.
+   */
+  private async ApplyStatusTransition(
+    id: string,
+    options: {
+      eventType: EventType;
+      allowedFromStatuses: ReadonlySet<PaymentIntentType['status']>;
+      updatePayload: Partial<PaymentIntentType>;
+      previousAttributes?: Record<string, unknown>;
+      invalidTransitionMessage?: (
+        status: PaymentIntentType['status']
+      ) => string;
+    }
+  ): Promise<PaymentIntentType> {
+    const previousPaymentIntent = await this.RequirePaymentIntent(id);
+
+    if (!options.allowedFromStatuses.has(previousPaymentIntent.status)) {
       throw new AppError(
-        `PaymentIntent cannot be canceled because it has status: ${previousPaymentIntent.status}`,
+        options.invalidTransitionMessage?.(previousPaymentIntent.status) ??
+          `PaymentIntent cannot transition to '${options.updatePayload.status}' from status '${previousPaymentIntent.status}'.`,
         ERRORS.INVALID_REQUEST.status,
         ERRORS.INVALID_REQUEST.type
       );
     }
 
-    const updatePayload: Partial<PaymentIntentType> = {
-      status: 'canceled',
-      canceled_at: Now(),
-      cancellation_reason: validatedInput.cancellation_reason ?? null,
-      next_action: null,
-      // Stripe refunds remaining capturable amount; until charges exist we zero it.
-      amount_capturable: 0,
-    };
-
     await this.db.Update<PaymentIntentType>(
       'PaymentIntents',
       id,
-      updatePayload
+      options.updatePayload
     );
 
+    const paymentIntent = await this.RequirePaymentIntent(id);
+
+    if (this.eventService) {
+      if (options.previousAttributes) {
+        await this.eventService.Emit(
+          options.eventType,
+          paymentIntent.platform_account,
+          paymentIntent,
+          { previousAttributes: options.previousAttributes }
+        );
+      } else {
+        await this.eventService.Emit(
+          options.eventType,
+          paymentIntent.platform_account,
+          paymentIntent
+        );
+      }
+    }
+
+    return paymentIntent;
+  }
+
+  private async RequirePaymentIntent(id: string): Promise<PaymentIntentType> {
     const paymentIntent = await this.GetPaymentIntent(id);
     if (!paymentIntent) {
       throw new AppError(
@@ -492,15 +711,6 @@ export class PaymentIntentModule {
         ERRORS.PAYMENT_INTENT_NOT_FOUND.type
       );
     }
-
-    if (this.eventService) {
-      await this.eventService.Emit(
-        'payment_intent.canceled',
-        paymentIntent.platform_account,
-        paymentIntent
-      );
-    }
-
     return paymentIntent;
   }
 

--- a/apps/api/src/routes/checkoutSessions.routes.ts
+++ b/apps/api/src/routes/checkoutSessions.routes.ts
@@ -11,6 +11,7 @@ import { CheckoutSessionModule } from '../modules/CheckoutSession';
 import { PriceModule } from '../modules/Price';
 import { ProductModule } from '../modules/Product';
 import { CustomerModule } from '../modules/Customer';
+import { PaymentIntentModule } from '../modules/PaymentIntent';
 
 import { ValidateRequest } from '../middleware/ValidateRequest';
 import { RequirePlatform } from '../middleware/Authorization';
@@ -29,12 +30,18 @@ const eventService = new EventService(db);
 const productModule = new ProductModule(db, eventService);
 const priceModule = new PriceModule(db, eventService, productModule);
 const customerModule = new CustomerModule(db, eventService);
+const paymentIntentModule = new PaymentIntentModule(
+  db,
+  eventService,
+  customerModule
+);
 const checkoutSessionModule = new CheckoutSessionModule(
   db,
   eventService,
   priceModule,
   productModule,
-  customerModule
+  customerModule,
+  paymentIntentModule
 );
 
 RegisterExpansions('checkout.session', {
@@ -42,6 +49,12 @@ RegisterExpansions('checkout.session', {
     sourcePath: 'customer',
     targetObject: 'customer',
     BatchLoad: (ids, ctx) => customerModule.BatchGet(ids, ctx.platformAccount),
+  },
+  payment_intent: {
+    sourcePath: 'payment_intent',
+    targetObject: 'payment_intent',
+    BatchLoad: (ids, ctx) =>
+      paymentIntentModule.BatchGet(ids, ctx.platformAccount),
   },
 });
 

--- a/apps/api/src/routes/paymentPages.routes.ts
+++ b/apps/api/src/routes/paymentPages.routes.ts
@@ -9,6 +9,7 @@ import { PriceModule } from '../modules/Price';
 import { ProductModule } from '../modules/Product';
 import { CustomerModule } from '../modules/Customer';
 import { ExternalWalletModule } from '../modules/ExternalWallet';
+import { PaymentIntentModule } from '../modules/PaymentIntent';
 
 const router = express.Router();
 
@@ -16,19 +17,26 @@ const eventService = new EventService(db);
 const productModule = new ProductModule(db, eventService);
 const priceModule = new PriceModule(db, eventService, productModule);
 const customerModule = new CustomerModule(db, eventService);
+const paymentIntentModule = new PaymentIntentModule(
+  db,
+  eventService,
+  customerModule
+);
 const checkoutSessionModule = new CheckoutSessionModule(
   db,
   eventService,
   priceModule,
   productModule,
-  customerModule
+  customerModule,
+  paymentIntentModule
 );
 const externalWalletModule = new ExternalWalletModule(db, eventService);
 const checkoutPaymentModule = new CheckoutPaymentModule(
   db,
   checkoutSessionModule,
   externalWalletModule,
-  productModule
+  productModule,
+  paymentIntentModule
 );
 
 /**


### PR DESCRIPTION
## Description

Emit payment intent events during a checkout session flow.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
