### PR TITLE
feat: custom checkout domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ DASHBOARD_PORT=
 # Only needed for custom domains — auto-derived from DASHBOARD_PORT if unset.
 DASHBOARD_URL=
 
+# Optional dedicated checkout origin (e.g. https://checkout.zoneless.com).
+# Leave empty to serve checkout from the dashboard URL at /c/:id.
+# When set, session links use https://checkout…/c/:id (same path either way).
+CHECKOUT_URL=
+
 # MongoDB connection string.
 # Leave empty for sensible defaults:
 #   Local dev (npm run dev): mongodb://localhost:27017/zoneless?replicaSet=rs0

--- a/.env.production.example
+++ b/.env.production.example
@@ -4,8 +4,14 @@
 # Start with:
 #   npm run prod
 
-# Your public-facing URL (where the dashboard is accessed)
+# Your public-facing dashboard URL
 DASHBOARD_URL=https://pay.yourdomain.com
+
+# Optional dedicated checkout origin (e.g. https://checkout.yourdomain.com).
+# Leave empty (or equal to DASHBOARD_URL) for single-domain self-hosting —
+# checkout stays at https://pay.yourdomain.com/c/:id.
+# When set, session links use https://checkout…/c/:id (same path either way).
+CHECKOUT_URL=
 
 # MongoDB connection string.
 # Leave empty to use the built-in containerized MongoDB (fine for small deployments).

--- a/apps/api/src/__tests__/CheckoutPayment.spec.ts
+++ b/apps/api/src/__tests__/CheckoutPayment.spec.ts
@@ -30,6 +30,7 @@ jest.mock('../utils/Timestamp', () => ({
 jest.mock('../modules/AppConfig', () => ({
   GetAppConfig: jest.fn(() => ({
     dashboardUrl: 'http://localhost:4200',
+    checkoutUrl: 'http://localhost:4200',
     livemode: false,
     appSecret: 'test-secret',
   })),

--- a/apps/api/src/__tests__/CheckoutSession.spec.ts
+++ b/apps/api/src/__tests__/CheckoutSession.spec.ts
@@ -29,6 +29,7 @@ jest.mock('../utils/Timestamp', () => ({
 jest.mock('../modules/AppConfig', () => ({
   GetAppConfig: jest.fn(() => ({
     dashboardUrl: 'http://localhost:4200',
+    checkoutUrl: 'http://localhost:4200',
     livemode: false,
     appSecret: 'test-secret',
   })),
@@ -139,7 +140,7 @@ describe('CheckoutSessionModule', () => {
       expect(session.livemode).toBe(false);
 
       expect(session.ui_mode).toBe('hosted_page');
-      expect(session.url).toBe(`http://localhost:4200/checkout/${session.id}`);
+      expect(session.url).toBe(`http://localhost:4200/c/${session.id}`);
       expect(session.client_secret).toBeNull();
       expect(session.success_url).toBe('https://example.com/success');
       expect(session.cancel_url).toBeNull();

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -51,10 +51,10 @@ app.set('trust proxy', 1);
 // Request logging (skip health checks)
 app.use(RequestLoggerWithSkip(['/api/health']));
 
-// CORS
+// CORS — allow dashboard and (when configured) dedicated checkout origin
 app.use(
   cors({
-    origin: appConfig.dashboardUrl,
+    origin: [...new Set([appConfig.dashboardUrl, appConfig.checkoutUrl])],
     credentials: true,
   })
 );

--- a/apps/api/src/modules/AppConfig.ts
+++ b/apps/api/src/modules/AppConfig.ts
@@ -54,17 +54,29 @@ function GenerateSecureHex(bytes: number): string {
 }
 
 /**
+ * Strip a trailing slash so URL joins stay consistent.
+ */
+function NormalizeOrigin(url: string): string {
+  return url.replace(/\/$/, '');
+}
+
+/**
  * Build the base config from environment variables.
  * appSecret will be empty until InitializeAppConfig is called (if not in env).
  */
 function BuildConfigFromEnv(): AppConfig {
+  const dashboardUrl = NormalizeOrigin(
+    process.env.DASHBOARD_URL ||
+      `http://localhost:${process.env.DASHBOARD_PORT || '80'}`
+  );
+  const checkoutUrl = NormalizeOrigin(process.env.CHECKOUT_URL || dashboardUrl);
+
   return {
     mongodbUri:
       process.env.MONGODB_URI ||
       'mongodb://localhost:27017/zoneless?replicaSet=rs0',
-    dashboardUrl:
-      process.env.DASHBOARD_URL ||
-      `http://localhost:${process.env.DASHBOARD_PORT || '80'}`,
+    dashboardUrl,
+    checkoutUrl,
     appSecret: process.env.APP_SECRET || '',
     livemode: process.env.LIVEMODE === 'true',
   };

--- a/apps/api/src/modules/CheckoutSession.ts
+++ b/apps/api/src/modules/CheckoutSession.ts
@@ -368,7 +368,7 @@ export class CheckoutSessionModule {
       ui_mode: uiMode,
       url:
         uiMode === 'hosted_page'
-          ? `${GetAppConfig().dashboardUrl}/checkout/${id}`
+          ? `${GetAppConfig().checkoutUrl}/c/${id}`
           : null,
       wallet_options: input.wallet_options
         ? {

--- a/apps/web/src/app/app.routes.ts
+++ b/apps/web/src/app/app.routes.ts
@@ -58,10 +58,10 @@ export const routes: Routes = [
       ),
   },
   {
-    path: 'checkout/:checkoutSessionId',
+    path: 'c/:checkoutSessionId',
     loadComponent: () =>
       import('./features/checkout/checkout.component').then(
-        (mod) => mod.CheckoutComponent
+        (m) => m.CheckoutComponent
       ),
   },
   {
@@ -73,7 +73,7 @@ export const routes: Routes = [
     path: '**',
     loadComponent: () =>
       import('./features/not-found/not-found.component').then(
-        (mod) => mod.NotFoundComponent
+        (m) => m.NotFoundComponent
       ),
   },
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     environment:
       - MONGODB_URI=${MONGODB_URI:-mongodb://mongodb:27017/zoneless?directConnection=true}
       - DASHBOARD_URL=${DASHBOARD_URL:-}
+      - CHECKOUT_URL=${CHECKOUT_URL:-}
       - DASHBOARD_PORT=${DASHBOARD_PORT:-80}
       - APP_SECRET=${APP_SECRET:-}
       - SINGLE_TENANT=${SINGLE_TENANT:-true}

--- a/libs/shared-types/src/lib/Config.ts
+++ b/libs/shared-types/src/lib/Config.ts
@@ -6,8 +6,14 @@
 export interface AppConfig {
   /** MongoDB connection string */
   mongodbUri: string;
-  /** Dashboard URL (e.g., http://localhost:4200 or https://connect.yourdomain.com) */
+  /** Dashboard URL (e.g., http://localhost:4200 or https://dashboard.zoneless.com) */
   dashboardUrl: string;
+  /**
+   * Hosted checkout URL origin (e.g., https://checkout.zoneless.com).
+   * Defaults to dashboardUrl for single-domain / self-hosted deployments.
+   * Session links are always `{checkoutUrl}/c/:id`.
+   */
+  checkoutUrl: string;
   /**
    * Master application secret (from APP_SECRET env or auto-generated).
    * Purpose-specific keys (JWT, encryption) are derived from this via HKDF.


### PR DESCRIPTION
## Description

Lets users specify customer domains for checkout sessions, e.g. checkout.zoneless.com

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
