### PR TITLE
feat: on chain recurring subscriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,12 @@ SOLANA_RPC_URL=
 
 # LIVEMODE controls Solana network: false = devnet (test), true = mainnet (real USDC)
 LIVEMODE=
+
+# Base58 secret key that owns on-chain subscription plans and signs pulls.
+# Required to create recurring prices. Existing plans must keep the same owner.
+# SUBSCRIPTION_OPERATOR_KEY=
+
+# Optional base58 secret key that sponsors Solana checkout network fees / rent.
+# When set, buyers only co-sign; the API cosigns and broadcasts.
+# When unset, buyers pay fees via wallet signAndSend.
+# TRANSACTION_FEE_PAYER_KEY=

--- a/.env.production.example
+++ b/.env.production.example
@@ -44,3 +44,13 @@ SOLANA_RPC_URL=
 
 # LIVEMODE controls Solana network: true = mainnet (real USDC), false = devnet (test)
 LIVEMODE=true
+
+# Base58 secret key that owns on-chain subscription plans and signs pulls.
+# Required to create recurring prices. Must match the owner used when plans
+# were first created.
+# SUBSCRIPTION_OPERATOR_KEY=
+
+# Optional base58 secret key that sponsors Solana checkout network fees / rent.
+# When set, buyers only co-sign; the API cosigns and broadcasts.
+# When unset, buyers pay fees via wallet signAndSend.
+# TRANSACTION_FEE_PAYER_KEY=

--- a/apps/api/src/__tests__/CheckoutPayment.spec.ts
+++ b/apps/api/src/__tests__/CheckoutPayment.spec.ts
@@ -100,7 +100,10 @@ describe('CheckoutPaymentModule', () => {
     Pick<
       Solana,
       | 'BuildCheckoutPaymentTransaction'
+      | 'BuildSubscribeTransaction'
       | 'VerifyCheckoutPayment'
+      | 'VerifySubscribeTransaction'
+      | 'CollectSubscriptionPayment'
       | 'GetUSDCMintAddress'
     >
   >;
@@ -149,7 +152,17 @@ describe('CheckoutPaymentModule', () => {
         blockhash: 'blockhash_1',
         last_valid_block_height: 100,
       }),
+      BuildSubscribeTransaction: jest.fn().mockResolvedValue({
+        unsigned_transaction: 'unsigned_subscribe_base64',
+        estimated_fee_lamports: 5000,
+        blockhash: 'blockhash_1',
+        last_valid_block_height: 100,
+      }),
       VerifyCheckoutPayment: jest.fn(),
+      VerifySubscribeTransaction: jest.fn(),
+      CollectSubscriptionPayment: jest.fn().mockResolvedValue({
+        signature: 'collect_sig',
+      }),
       GetUSDCMintAddress: jest.fn().mockReturnValue('UsdcMint111'),
     };
 
@@ -252,6 +265,52 @@ describe('CheckoutPaymentModule', () => {
           unsigned_transaction: 'unsigned_tx_base64',
         })
       );
+    });
+
+    it('should build a subscribe transaction for subscription mode', async () => {
+      const recurringPrice = BuildPrice({
+        type: 'recurring',
+        recurring: {
+          interval: 'month',
+          interval_count: 1,
+          meter: null,
+          trial_period_days: null,
+          usage_type: 'licensed',
+        },
+        subscription_plan_pda: 'PlanPda111',
+      });
+      const session = BuildOpenSession({
+        mode: 'subscription',
+        payment_intent: null,
+        line_items: {
+          object: 'list',
+          data: [BuildLineItem({ price: recurringPrice })],
+          has_more: false,
+          url: '/v1/checkout/sessions/cs_z_1/line_items',
+        },
+      });
+
+      jest
+        .spyOn(checkoutSessionModule, 'GetCheckoutSessionByUrlSlug')
+        .mockResolvedValue(session);
+      jest
+        .spyOn(checkoutSessionModule, 'GetCheckoutSession')
+        .mockResolvedValue(session);
+      mockDb.Update = jest.fn().mockResolvedValue(undefined);
+
+      const result = await module.PreparePayment(
+        session.url_slug,
+        'PayerWallet111',
+        'buyer@example.com'
+      );
+
+      expect(mockSolana.BuildSubscribeTransaction).toHaveBeenCalledWith(
+        'PayerWallet111',
+        recurringPrice.id,
+        'PlanPda111'
+      );
+      expect(mockSolana.BuildCheckoutPaymentTransaction).not.toHaveBeenCalled();
+      expect(result.unsigned_transaction).toBe('unsigned_subscribe_base64');
     });
   });
 

--- a/apps/api/src/__tests__/CheckoutPayment.spec.ts
+++ b/apps/api/src/__tests__/CheckoutPayment.spec.ts
@@ -37,6 +37,7 @@ jest.mock('../modules/AppConfig', () => ({
     livemode: false,
     appSecret: 'test-secret',
   })),
+  IsCheckoutFeeSponsored: jest.fn(() => false),
 }));
 
 function BuildPrice(overrides: Partial<Price> = {}): Price {
@@ -100,10 +101,14 @@ describe('CheckoutPaymentModule', () => {
     Pick<
       Solana,
       | 'BuildCheckoutPaymentTransaction'
+      | 'BuildInitSubscriptionAuthorityTransaction'
       | 'BuildSubscribeTransaction'
       | 'VerifyCheckoutPayment'
       | 'VerifySubscribeTransaction'
       | 'CollectSubscriptionPayment'
+      | 'CosignAndBroadcastCheckoutTransaction'
+      | 'FindExistingSubscriptionDelegation'
+      | 'WaitForSubscriptionAuthority'
       | 'GetUSDCMintAddress'
     >
   >;
@@ -152,6 +157,9 @@ describe('CheckoutPaymentModule', () => {
         blockhash: 'blockhash_1',
         last_valid_block_height: 100,
       }),
+      BuildInitSubscriptionAuthorityTransaction: jest
+        .fn()
+        .mockResolvedValue(null),
       BuildSubscribeTransaction: jest.fn().mockResolvedValue({
         unsigned_transaction: 'unsigned_subscribe_base64',
         estimated_fee_lamports: 5000,
@@ -163,6 +171,11 @@ describe('CheckoutPaymentModule', () => {
       CollectSubscriptionPayment: jest.fn().mockResolvedValue({
         signature: 'collect_sig',
       }),
+      CosignAndBroadcastCheckoutTransaction: jest.fn().mockResolvedValue({
+        signature: 'cosign_sig',
+      }),
+      FindExistingSubscriptionDelegation: jest.fn().mockResolvedValue(null),
+      WaitForSubscriptionAuthority: jest.fn().mockResolvedValue(undefined),
       GetUSDCMintAddress: jest.fn().mockReturnValue('UsdcMint111'),
     };
 
@@ -245,7 +258,8 @@ describe('CheckoutPaymentModule', () => {
         'PayerWallet111',
         'MerchantWallet111',
         1000,
-        session.id
+        session.id,
+        { feeSponsored: false }
       );
       expect(eventService.Emit).toHaveBeenCalledWith(
         'payment_intent.updated',
@@ -304,13 +318,66 @@ describe('CheckoutPaymentModule', () => {
         'buyer@example.com'
       );
 
+      expect(
+        mockSolana.BuildInitSubscriptionAuthorityTransaction
+      ).toHaveBeenCalledWith('PayerWallet111', { feeSponsored: false });
       expect(mockSolana.BuildSubscribeTransaction).toHaveBeenCalledWith(
         'PayerWallet111',
         recurringPrice.id,
-        'PlanPda111'
+        'PlanPda111',
+        { feeSponsored: false }
       );
       expect(mockSolana.BuildCheckoutPaymentTransaction).not.toHaveBeenCalled();
       expect(result.unsigned_transaction).toBe('unsigned_subscribe_base64');
+      expect(result.subscription_step).toBe('subscribe');
+    });
+
+    it('should return init_authority step when subscription authority is missing', async () => {
+      const recurringPrice = BuildPrice({
+        type: 'recurring',
+        recurring: {
+          interval: 'month',
+          interval_count: 1,
+          meter: null,
+          trial_period_days: null,
+          usage_type: 'licensed',
+        },
+        subscription_plan_pda: 'PlanPda111',
+      });
+      const session = BuildOpenSession({
+        mode: 'subscription',
+        payment_intent: null,
+        line_items: {
+          object: 'list',
+          data: [BuildLineItem({ price: recurringPrice })],
+          has_more: false,
+          url: '/v1/checkout/sessions/cs_z_1/line_items',
+        },
+      });
+
+      mockSolana.BuildInitSubscriptionAuthorityTransaction.mockResolvedValue({
+        unsigned_transaction: 'unsigned_init_base64',
+        estimated_fee_lamports: 5000,
+        blockhash: 'blockhash_1',
+        last_valid_block_height: 100,
+      });
+
+      jest
+        .spyOn(checkoutSessionModule, 'GetCheckoutSessionByUrlSlug')
+        .mockResolvedValue(session);
+      jest
+        .spyOn(checkoutSessionModule, 'GetCheckoutSession')
+        .mockResolvedValue(session);
+      mockDb.Update = jest.fn().mockResolvedValue(undefined);
+
+      const result = await module.PreparePayment(
+        session.url_slug,
+        'PayerWallet111'
+      );
+
+      expect(mockSolana.BuildSubscribeTransaction).not.toHaveBeenCalled();
+      expect(result.unsigned_transaction).toBe('unsigned_init_base64');
+      expect(result.subscription_step).toBe('init_authority');
     });
   });
 

--- a/apps/api/src/__tests__/Price.spec.ts
+++ b/apps/api/src/__tests__/Price.spec.ts
@@ -23,7 +23,6 @@ jest.mock('../modules/AppConfig', () => ({
     livemode: false,
     appSecret: 'test-secret',
   })),
-  GetSubscriptionPullerPublicKey: jest.fn(() => 'PullerPublicKey111'),
 }));
 
 describe('PriceModule', () => {

--- a/apps/api/src/__tests__/mocks/Solana.ts
+++ b/apps/api/src/__tests__/mocks/Solana.ts
@@ -43,6 +43,8 @@ export class Solana {
     blockhash: 'blockhash123',
     last_valid_block_height: 100000,
   });
+  BuildInitSubscriptionAuthorityTransaction = jest.fn().mockResolvedValue(null);
+  WaitForSubscriptionAuthority = jest.fn().mockResolvedValue(undefined);
   VerifyCheckoutPayment = jest.fn().mockResolvedValue({
     verified: true,
     amount_cents: 1000,
@@ -56,9 +58,10 @@ export class Solana {
   CollectSubscriptionPayment = jest.fn().mockResolvedValue({
     signature: 'collect_sig',
   });
-  FindExistingSubscriptionDelegation = jest
-    .fn()
-    .mockResolvedValue(null);
+  FindExistingSubscriptionDelegation = jest.fn().mockResolvedValue(null);
+  CosignAndBroadcastCheckoutTransaction = jest.fn().mockResolvedValue({
+    signature: 'checkout_sig',
+  });
   CosignAndBroadcastSubscribeTransaction = jest.fn().mockResolvedValue({
     signature: 'subscribe_sig',
   });

--- a/apps/api/src/__tests__/mocks/Solana.ts
+++ b/apps/api/src/__tests__/mocks/Solana.ts
@@ -29,15 +29,38 @@ export class Solana {
   GetUSDCBalance = jest.fn().mockResolvedValue(100);
   GetSOLBalance = jest.fn().mockResolvedValue(1);
   GetUSDCMintAddress = jest.fn().mockReturnValue('UsdcMint_test');
+  GetPlanOwnerPublicKey = jest.fn().mockReturnValue('PlanOwner111');
   GetIncomingUSDCDeposits = jest.fn().mockResolvedValue([]);
   BuildCheckoutPaymentTransaction = jest.fn().mockResolvedValue({
-    transaction: 'base64tx',
-    usdc_mint: 'UsdcMint_test',
+    unsigned_transaction: 'base64tx',
+    estimated_fee_lamports: 5000,
+    blockhash: 'blockhash123',
+    last_valid_block_height: 100000,
+  });
+  BuildSubscribeTransaction = jest.fn().mockResolvedValue({
+    unsigned_transaction: 'base64subscribe',
+    estimated_fee_lamports: 5000,
+    blockhash: 'blockhash123',
+    last_valid_block_height: 100000,
   });
   VerifyCheckoutPayment = jest.fn().mockResolvedValue({
     verified: true,
     amount_cents: 1000,
     payer_address: 'Payer111',
+  });
+  VerifySubscribeTransaction = jest.fn().mockResolvedValue({
+    verified: true,
+    subscriber_address: 'Payer111',
+    subscription_delegation_pda: 'SubPda_test',
+  });
+  CollectSubscriptionPayment = jest.fn().mockResolvedValue({
+    signature: 'collect_sig',
+  });
+  FindExistingSubscriptionDelegation = jest
+    .fn()
+    .mockResolvedValue(null);
+  CosignAndBroadcastSubscribeTransaction = jest.fn().mockResolvedValue({
+    signature: 'subscribe_sig',
   });
   BuildBatchPayoutTransaction = jest.fn().mockResolvedValue({
     unsigned_transaction: 'base64tx',

--- a/apps/api/src/modules/AppConfig.ts
+++ b/apps/api/src/modules/AppConfig.ts
@@ -118,16 +118,31 @@ export function GetOperatorApiKey(): string {
 }
 
 /**
- * Public key of the wallet authorized to pull recurring subscription payments.
+ * Optional secret key that sponsors Solana checkout network fees / rent.
+ * When unset, the buyer pays fees via signAndSend.
  */
-export function GetSubscriptionPullerPublicKey(): string {
-  const puller = process.env.SUBSCRIPTION_PULLER_PUBLIC_KEY;
-  if (!puller) {
+export function GetCheckoutFeePayerSecretKey(): string | null {
+  const secretKey = process.env.TRANSACTION_FEE_PAYER_KEY;
+  return secretKey && secretKey.length > 0 ? secretKey : null;
+}
+
+/** True when TRANSACTION_FEE_PAYER_KEY is configured. */
+export function IsCheckoutFeeSponsored(): boolean {
+  return !!GetCheckoutFeePayerSecretKey();
+}
+
+/**
+ * Secret key for on-chain subscription plan ownership and payment pulls.
+ * Required for recurring prices.
+ */
+export function RequireSubscriptionOperatorSecretKey(): string {
+  const secretKey = process.env.SUBSCRIPTION_OPERATOR_KEY;
+  if (!secretKey) {
     throw new Error(
-      'SUBSCRIPTION_PULLER_PUBLIC_KEY is required for recurring subscription plans'
+      'SUBSCRIPTION_OPERATOR_KEY is required for recurring subscription plans'
     );
   }
-  return puller;
+  return secretKey;
 }
 
 /**

--- a/apps/api/src/modules/CheckoutPayment.ts
+++ b/apps/api/src/modules/CheckoutPayment.ts
@@ -20,6 +20,7 @@ import type { PaymentIntentModule } from './PaymentIntent';
 import type { ChargeModule } from './Charge';
 import type { PaymentLinkModule } from './PaymentLink';
 import { Solana, SolanaExplorerUrl } from './chains/Solana';
+import { IsCheckoutFeeSponsored } from './AppConfig';
 import { AppError } from '../utils/AppError';
 import { ERRORS } from '../utils/Errors';
 import { Logger } from '../utils/Logger';
@@ -46,11 +47,21 @@ export interface PreparedCheckoutPayment {
   blockhash: string;
   last_valid_block_height: number;
   /**
+   * True when TRANSACTION_FEE_PAYER_KEY is set and the API will cosign/broadcast.
+   */
+  fee_sponsored?: boolean;
+  /**
    * True when the wallet is already subscribed on-chain (e.g. a prior attempt
    * landed but checkout confirm failed). Frontend should confirm without signing.
    */
   already_subscribed?: boolean;
   subscription_delegation_pda?: string;
+  /**
+   * Subscription checkout is two on-chain steps for first-time wallets:
+   * `init_authority` (create SubscriptionAuthority) then `subscribe`.
+   * Omitted for one-time payments.
+   */
+  subscription_step?: 'init_authority' | 'subscribe';
 }
 
 export class CheckoutPaymentModule {
@@ -193,8 +204,8 @@ export class CheckoutPaymentModule {
 
   /**
    * Build an unsigned transaction for the checkout session. One-time sessions
-   * get a USDC transfer; subscription sessions get a Solana `subscribe`
-   * (plus `initSubscriptionAuthority` when needed).
+   * get a USDC transfer; subscription sessions get either an
+   * `initSubscriptionAuthority` tx (first-time wallet) or a `subscribe` tx.
    */
   async PreparePayment(
     urlSlug: string,
@@ -226,14 +237,20 @@ export class CheckoutPaymentModule {
       amountTotal: session.amount_total,
     });
 
+    const feeSponsored = IsCheckoutFeeSponsored();
     const prepared =
       session.mode === 'subscription'
-        ? await this.PrepareSubscribeTransaction(session, payerWallet)
+        ? await this.PrepareSubscribeTransaction(
+            session,
+            payerWallet,
+            feeSponsored
+          )
         : await this.solana.BuildCheckoutPaymentTransaction(
             payerWallet,
             merchantWallet.wallet_address,
             session.amount_total!,
-            session.id
+            session.id,
+            { feeSponsored }
           );
 
     await this.MarkPaymentIntentRequiresConfirmation(session, payerWallet);
@@ -245,12 +262,14 @@ export class CheckoutPaymentModule {
       currency: session.currency,
       merchant_wallet_address: merchantWallet.wallet_address,
       ...prepared,
+      fee_sponsored: feeSponsored,
     };
   }
 
   private async PrepareSubscribeTransaction(
     session: CheckoutSession,
-    payerWallet: string
+    payerWallet: string,
+    feeSponsored: boolean
   ): Promise<
     Omit<
       PreparedCheckoutPayment,
@@ -259,6 +278,7 @@ export class CheckoutPaymentModule {
       | 'amount_total'
       | 'currency'
       | 'merchant_wallet_address'
+      | 'fee_sponsored'
     >
   > {
     const price = this.RequireRecurringCheckoutPrice(session);
@@ -286,11 +306,26 @@ export class CheckoutPaymentModule {
       };
     }
 
-    return this.solana.BuildSubscribeTransaction(
+    const initTx = await this.solana.BuildInitSubscriptionAuthorityTransaction(
       payerWallet,
-      price.id,
-      price.subscription_plan_pda
+      { feeSponsored }
     );
+    if (initTx) {
+      return {
+        ...initTx,
+        subscription_step: 'init_authority',
+      };
+    }
+
+    return {
+      ...(await this.solana.BuildSubscribeTransaction(
+        payerWallet,
+        price.id,
+        price.subscription_plan_pda,
+        { feeSponsored }
+      )),
+      subscription_step: 'subscribe',
+    };
   }
 
   /**
@@ -299,8 +334,11 @@ export class CheckoutPaymentModule {
    * subscription mode it verifies the subscribe PDA, creates the off-chain
    * Subscription, and collects the first period (unless trialing).
    *
-   * Subscription confirms may pass `signed_transaction` instead of
-   * `signature`: the API cosigns with FEE_PAYER and broadcasts.
+   * Fee-sponsored confirms may pass `signed_transaction` instead of
+   * `signature`: the API cosigns with TRANSACTION_FEE_PAYER_KEY and broadcasts.
+   *
+   * For subscription first-time wallets, pass `subscription_step: 'init_authority'`
+   * after the init tx; the session stays open so the client can prepare subscribe.
    */
   async ConfirmPayment(
     urlSlug: string,
@@ -309,17 +347,19 @@ export class CheckoutPaymentModule {
       signed_transaction?: string;
       already_subscribed?: boolean;
       subscription_delegation_pda?: string;
+      subscription_step?: 'init_authority' | 'subscribe';
     }
   ): Promise<CheckoutSession> {
     const session = await this.GetSessionOrThrow(urlSlug);
 
-    // Idempotency: already completed with this signature
-    if (
-      session.status === 'complete' &&
-      signature &&
-      session.payment_details?.transaction_signature === signature
-    ) {
-      if (session.mode === 'payment' && session.amount_total) {
+    // Idempotency: already completed (duplicate / overlapping confirms).
+    if (session.status === 'complete') {
+      if (
+        session.mode === 'payment' &&
+        session.amount_total &&
+        signature &&
+        session.payment_details?.transaction_signature === signature
+      ) {
         await this.RecordPaymentOnLedger(
           session,
           session.amount_total,
@@ -341,13 +381,12 @@ export class CheckoutPaymentModule {
 
     let resolvedSignature = signature;
     if (
-      session.mode === 'subscription' &&
       options?.signed_transaction &&
       typeof options.signed_transaction === 'string'
     ) {
       try {
         const broadcast =
-          await this.solana.CosignAndBroadcastSubscribeTransaction(
+          await this.solana.CosignAndBroadcastCheckoutTransaction(
             options.signed_transaction
           );
         resolvedSignature = broadcast.signature;
@@ -355,7 +394,7 @@ export class CheckoutPaymentModule {
         throw new AppError(
           error instanceof Error
             ? error.message
-            : 'Failed to broadcast subscribe transaction',
+            : 'Failed to broadcast checkout transaction',
           ERRORS.INVALID_REQUEST.status,
           ERRORS.INVALID_REQUEST.type
         );
@@ -368,6 +407,13 @@ export class CheckoutPaymentModule {
         ERRORS.VALIDATION_ERROR.status,
         ERRORS.VALIDATION_ERROR.type
       );
+    }
+
+    if (
+      session.mode === 'subscription' &&
+      options?.subscription_step === 'init_authority'
+    ) {
+      return this.ConfirmSubscriptionAuthorityInit(session, resolvedSignature);
     }
 
     const existingSession =
@@ -387,6 +433,39 @@ export class CheckoutPaymentModule {
     }
 
     return this.ConfirmOneTimePayment(session, resolvedSignature);
+  }
+
+  /**
+   * Land the SubscriptionAuthority init tx without completing checkout.
+   * Client must prepare+confirm subscribe next.
+   */
+  private async ConfirmSubscriptionAuthorityInit(
+    session: CheckoutSession,
+    signature: string
+  ): Promise<CheckoutSession> {
+    const subscriberWallet = await this.ResolvePreparedSubscriberWallet(
+      session
+    );
+
+    Logger.info('Confirming subscription authority init', {
+      checkoutSessionId: session.id,
+      signature,
+      subscriberWallet,
+    });
+
+    try {
+      await this.solana.WaitForSubscriptionAuthority(subscriberWallet);
+    } catch (error) {
+      throw new AppError(
+        error instanceof Error
+          ? error.message
+          : 'Subscription authority init did not confirm on-chain',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    return this.SanitizeCheckoutSession(session);
   }
 
   private async ConfirmOneTimePayment(
@@ -620,8 +699,7 @@ export class CheckoutPaymentModule {
       } catch (error) {
         // Subscribe already landed — surface the collect error instead of
         // pretending checkout collected USDC (collectionSignature === signature).
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = error instanceof Error ? error.message : String(error);
         Logger.error('First-period subscription collect failed', {
           checkoutSessionId: session.id,
           error: message,

--- a/apps/api/src/modules/CheckoutPayment.ts
+++ b/apps/api/src/modules/CheckoutPayment.ts
@@ -1,7 +1,7 @@
 /**
  * @fileOverview Methods for the public hosted checkout payment flow:
  * bootstrapping the payment page, preparing the unsigned USDC payment
- * transaction, and confirming/completing the payment on-chain.
+ * or subscribe transaction, and confirming/completing on-chain.
  *
  * @module CheckoutPayment
  */
@@ -14,6 +14,8 @@ import { ExternalWalletModule } from './ExternalWallet';
 import { BalanceModule } from './Balance';
 import { BalanceTransactionModule } from './BalanceTransaction';
 import { ProductModule } from './Product';
+import type { CustomerModule } from './Customer';
+import type { SubscriptionModule } from './Subscription';
 import type { PaymentIntentModule } from './PaymentIntent';
 import type { ChargeModule } from './Charge';
 import type { PaymentLinkModule } from './PaymentLink';
@@ -31,7 +33,8 @@ import {
   Price,
   Product,
 } from '@zoneless/shared-types';
-/** Unsigned payment transaction bundle returned by PreparePayment. */
+
+/** Unsigned payment / subscribe transaction bundle returned by PreparePayment. */
 export interface PreparedCheckoutPayment {
   object: 'checkout.payment_transaction';
   checkout_session: string;
@@ -42,6 +45,12 @@ export interface PreparedCheckoutPayment {
   estimated_fee_lamports: number;
   blockhash: string;
   last_valid_block_height: number;
+  /**
+   * True when the wallet is already subscribed on-chain (e.g. a prior attempt
+   * landed but checkout confirm failed). Frontend should confirm without signing.
+   */
+  already_subscribed?: boolean;
+  subscription_delegation_pda?: string;
 }
 
 export class CheckoutPaymentModule {
@@ -55,6 +64,8 @@ export class CheckoutPaymentModule {
   private readonly paymentIntentModule: PaymentIntentModule | null;
   private readonly chargeModule: ChargeModule | null;
   private readonly paymentLinkModule: PaymentLinkModule | null;
+  private readonly customerModule: CustomerModule | null;
+  private readonly subscriptionModule: SubscriptionModule | null;
   private readonly solana: Solana;
 
   constructor(
@@ -65,7 +76,9 @@ export class CheckoutPaymentModule {
     paymentIntentModule?: PaymentIntentModule,
     chargeModule?: ChargeModule,
     paymentLinkModule?: PaymentLinkModule,
-    solana?: Solana
+    solana?: Solana,
+    customerModule?: CustomerModule,
+    subscriptionModule?: SubscriptionModule
   ) {
     this.db = db;
     this.accountModule = new AccountModule(db);
@@ -77,6 +90,8 @@ export class CheckoutPaymentModule {
     this.paymentIntentModule = paymentIntentModule || null;
     this.chargeModule = chargeModule || null;
     this.paymentLinkModule = paymentLinkModule || null;
+    this.customerModule = customerModule || null;
+    this.subscriptionModule = subscriptionModule || null;
     this.solana = solana || new Solana();
   }
 
@@ -177,18 +192,9 @@ export class CheckoutPaymentModule {
   }
 
   /**
-   * Build an unsigned USDC payment transaction transferring the session
-   * total from the customer's wallet to the merchant's wallet. The customer
-   * signs and broadcasts it via their wallet.
-   *
-   * Transitions the linked PaymentIntent to `requires_confirmation` once the
-   * customer has provided a wallet (Stripe: payment details attached, ready
-   * to confirm). Emits `payment_intent.updated`.
-   *
-   * @param id - The checkout session ID
-   * @param payerWallet - The customer's wallet address
-   * @param email - Optional customer email to record on the session
-   * @returns The unsigned transaction bundle
+   * Build an unsigned transaction for the checkout session. One-time sessions
+   * get a USDC transfer; subscription sessions get a Solana `subscribe`
+   * (plus `initSubscriptionAuthority` when needed).
    */
   async PreparePayment(
     urlSlug: string,
@@ -214,17 +220,21 @@ export class CheckoutPaymentModule {
       await this.checkoutSessionModule.SetCustomerEmail(session.id, email);
     }
 
-    Logger.info('Preparing checkout payment transaction', {
+    Logger.info('Preparing checkout transaction', {
       checkoutSessionId: session.id,
+      mode: session.mode,
       amountTotal: session.amount_total,
     });
 
-    const prepared = await this.solana.BuildCheckoutPaymentTransaction(
-      payerWallet,
-      merchantWallet.wallet_address,
-      session.amount_total!,
-      session.id
-    );
+    const prepared =
+      session.mode === 'subscription'
+        ? await this.PrepareSubscribeTransaction(session, payerWallet)
+        : await this.solana.BuildCheckoutPaymentTransaction(
+            payerWallet,
+            merchantWallet.wallet_address,
+            session.amount_total!,
+            session.id
+          );
 
     await this.MarkPaymentIntentRequiresConfirmation(session, payerWallet);
 
@@ -238,21 +248,121 @@ export class CheckoutPaymentModule {
     };
   }
 
+  private async PrepareSubscribeTransaction(
+    session: CheckoutSession,
+    payerWallet: string
+  ): Promise<
+    Omit<
+      PreparedCheckoutPayment,
+      | 'object'
+      | 'checkout_session'
+      | 'amount_total'
+      | 'currency'
+      | 'merchant_wallet_address'
+    >
+  > {
+    const price = this.RequireRecurringCheckoutPrice(session);
+    if (!price.subscription_plan_pda) {
+      throw new AppError(
+        'This subscription price has no on-chain plan. Recreate the price and try again.',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const existingPda = await this.solana.FindExistingSubscriptionDelegation(
+      price.subscription_plan_pda,
+      payerWallet
+    );
+    if (existingPda) {
+      // Prior attempt likely landed on-chain while confirm failed (stale blockhash).
+      return {
+        unsigned_transaction: '',
+        estimated_fee_lamports: 0,
+        blockhash: '',
+        last_valid_block_height: 0,
+        already_subscribed: true,
+        subscription_delegation_pda: existingPda,
+      };
+    }
+
+    return this.solana.BuildSubscribeTransaction(
+      payerWallet,
+      price.id,
+      price.subscription_plan_pda
+    );
+  }
+
   /**
-   * Verify a broadcast payment transaction on-chain and complete the
-   * checkout session. Emits Charge + PaymentIntent lifecycle events then
-   * `checkout.session.completed`. Idempotent: if the session was already
-   * completed with the same signature, it is returned as-is.
+   * Verify a broadcast transaction on-chain and complete the checkout
+   * session. For payment mode this verifies a USDC transfer; for
+   * subscription mode it verifies the subscribe PDA, creates the off-chain
+   * Subscription, and collects the first period (unless trialing).
    *
-   * @param urlSlug - The opaque public URL slug for the checkout session
-   * @param signature - The Solana transaction signature of the payment
-   * @returns The completed public checkout session
+   * Subscription confirms may pass `signed_transaction` instead of
+   * `signature`: the API cosigns with FEE_PAYER and broadcasts.
    */
   async ConfirmPayment(
     urlSlug: string,
-    signature: string | undefined
+    signature: string | undefined,
+    options?: {
+      signed_transaction?: string;
+      already_subscribed?: boolean;
+      subscription_delegation_pda?: string;
+    }
   ): Promise<CheckoutSession> {
-    if (!signature || typeof signature !== 'string') {
+    const session = await this.GetSessionOrThrow(urlSlug);
+
+    // Idempotency: already completed with this signature
+    if (
+      session.status === 'complete' &&
+      signature &&
+      session.payment_details?.transaction_signature === signature
+    ) {
+      if (session.mode === 'payment' && session.amount_total) {
+        await this.RecordPaymentOnLedger(
+          session,
+          session.amount_total,
+          session.payment_details.payer_wallet,
+          signature
+        );
+      }
+      return this.SanitizeCheckoutSession(session);
+    }
+
+    this.AssertSessionPayable(session);
+
+    if (session.mode === 'subscription' && options?.already_subscribed) {
+      return this.ConfirmSubscriptionFromExistingOnChain(
+        session,
+        options.subscription_delegation_pda
+      );
+    }
+
+    let resolvedSignature = signature;
+    if (
+      session.mode === 'subscription' &&
+      options?.signed_transaction &&
+      typeof options.signed_transaction === 'string'
+    ) {
+      try {
+        const broadcast =
+          await this.solana.CosignAndBroadcastSubscribeTransaction(
+            options.signed_transaction
+          );
+        resolvedSignature = broadcast.signature;
+      } catch (error) {
+        throw new AppError(
+          error instanceof Error
+            ? error.message
+            : 'Failed to broadcast subscribe transaction',
+          ERRORS.INVALID_REQUEST.status,
+          ERRORS.INVALID_REQUEST.type
+        );
+      }
+    }
+
+    if (!resolvedSignature || typeof resolvedSignature !== 'string') {
       throw new AppError(
         'signature is required',
         ERRORS.VALIDATION_ERROR.status,
@@ -260,30 +370,9 @@ export class CheckoutPaymentModule {
       );
     }
 
-    const session = await this.GetSessionOrThrow(urlSlug);
-
-    // Idempotency: the session was already completed with this signature.
-    // Re-run the ledger recording (a no-op when already recorded) so a
-    // retry can heal a confirm that failed between completion and ledgering.
-    if (
-      session.status === 'complete' &&
-      session.payment_details?.transaction_signature === signature
-    ) {
-      await this.RecordPaymentOnLedger(
-        session,
-        session.amount_total!,
-        session.payment_details.payer_wallet,
-        signature
-      );
-      return this.SanitizeCheckoutSession(session);
-    }
-
-    this.AssertSessionPayable(session);
-
-    // A transaction can only ever complete one checkout session
     const existingSession =
       await this.checkoutSessionModule.GetCheckoutSessionByTransactionSignature(
-        signature
+        resolvedSignature
       );
     if (existingSession) {
       throw new AppError(
@@ -293,6 +382,17 @@ export class CheckoutPaymentModule {
       );
     }
 
+    if (session.mode === 'subscription') {
+      return this.ConfirmSubscription(session, resolvedSignature);
+    }
+
+    return this.ConfirmOneTimePayment(session, resolvedSignature);
+  }
+
+  private async ConfirmOneTimePayment(
+    session: CheckoutSession,
+    signature: string
+  ): Promise<CheckoutSession> {
     const merchantWallet = await this.ResolveMerchantWallet(
       session.platform_account
     );
@@ -379,6 +479,315 @@ export class CheckoutPaymentModule {
     });
 
     return this.SanitizeCheckoutSession(completedSession);
+  }
+
+  private async ConfirmSubscription(
+    session: CheckoutSession,
+    signature: string
+  ): Promise<CheckoutSession> {
+    const price = this.RequireRecurringCheckoutPrice(session);
+    if (!price.subscription_plan_pda) {
+      throw new AppError(
+        'This subscription price has no on-chain plan',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const subscriberWallet = await this.ResolvePreparedSubscriberWallet(
+      session
+    );
+
+    Logger.info('Verifying checkout subscribe transaction', {
+      checkoutSessionId: session.id,
+      signature,
+    });
+
+    const verification = await this.solana.VerifySubscribeTransaction(
+      signature,
+      {
+        planPda: price.subscription_plan_pda,
+        subscriberWallet,
+      }
+    );
+
+    if (!verification.verified || !verification.subscription_delegation_pda) {
+      throw new AppError(
+        verification.failure_reason || 'Subscription verification failed',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    return this.FinalizeSubscriptionCheckout(session, {
+      subscriberWallet,
+      subscriptionDelegationPda: verification.subscription_delegation_pda,
+      signature,
+    });
+  }
+
+  /**
+   * Complete checkout when the on-chain subscribe already exists (e.g. a prior
+   * broadcast succeeded but confirm failed on a stale blockhash).
+   */
+  private async ConfirmSubscriptionFromExistingOnChain(
+    session: CheckoutSession,
+    subscriptionDelegationPda?: string
+  ): Promise<CheckoutSession> {
+    const price = this.RequireRecurringCheckoutPrice(session);
+    if (!price.subscription_plan_pda) {
+      throw new AppError(
+        'This subscription price has no on-chain plan',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const subscriberWallet = await this.ResolvePreparedSubscriberWallet(
+      session
+    );
+    const delegationPda =
+      subscriptionDelegationPda ||
+      (await this.solana.FindExistingSubscriptionDelegation(
+        price.subscription_plan_pda,
+        subscriberWallet
+      ));
+
+    if (!delegationPda) {
+      throw new AppError(
+        'No on-chain subscription found for this wallet and plan',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    Logger.info('Completing checkout from existing on-chain subscription', {
+      checkoutSessionId: session.id,
+      subscriptionDelegationPda: delegationPda,
+    });
+
+    return this.FinalizeSubscriptionCheckout(session, {
+      subscriberWallet,
+      subscriptionDelegationPda: delegationPda,
+      signature: `onchain:${delegationPda}`,
+    });
+  }
+
+  private async FinalizeSubscriptionCheckout(
+    session: CheckoutSession,
+    details: {
+      subscriberWallet: string;
+      subscriptionDelegationPda: string;
+      signature: string;
+    }
+  ): Promise<CheckoutSession> {
+    if (!this.subscriptionModule || !this.customerModule) {
+      throw new AppError(
+        'Subscription checkout is not configured',
+        ERRORS.INTERNAL_ERROR.status,
+        ERRORS.INTERNAL_ERROR.type
+      );
+    }
+
+    const price = this.RequireRecurringCheckoutPrice(session);
+    if (!price.subscription_plan_pda) {
+      throw new AppError(
+        'This subscription price has no on-chain plan',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const merchantWallet = await this.ResolveMerchantWallet(
+      session.platform_account
+    );
+    const { subscriberWallet, subscriptionDelegationPda, signature } = details;
+
+    const trialPeriodDays = price.recurring?.trial_period_days ?? null;
+    const hasTrial = !!trialPeriodDays && trialPeriodDays > 0;
+    let collectionSignature = signature;
+
+    if (!hasTrial) {
+      try {
+        const collection = await this.solana.CollectSubscriptionPayment({
+          subscriberWallet,
+          planPda: price.subscription_plan_pda,
+          subscriptionPda: subscriptionDelegationPda,
+          destinationWallet: merchantWallet.wallet_address,
+          amountCents: price.unit_amount ?? session.amount_total!,
+        });
+        collectionSignature = collection.signature;
+      } catch (error) {
+        // Subscribe already landed — surface the collect error instead of
+        // pretending checkout collected USDC (collectionSignature === signature).
+        const message =
+          error instanceof Error ? error.message : String(error);
+        Logger.error('First-period subscription collect failed', {
+          checkoutSessionId: session.id,
+          error: message,
+        });
+        throw new AppError(
+          `Subscription authorized on-chain, but the first payment could not be collected: ${message}`,
+          ERRORS.INVALID_REQUEST.status,
+          ERRORS.INVALID_REQUEST.type
+        );
+      }
+    }
+
+    const customerId = await this.EnsureCheckoutCustomer(
+      session,
+      subscriberWallet
+    );
+
+    const subscription = await this.subscriptionModule.CreateSubscription(
+      session.platform_account,
+      {
+        customer: customerId,
+        items: [
+          {
+            price: price.id,
+            quantity: session.line_items?.data?.[0]?.quantity ?? 1,
+          },
+        ],
+        ...(hasTrial ? { trial_period_days: trialPeriodDays! } : {}),
+        default_payment_method: subscriberWallet,
+        metadata: {
+          checkout_session: session.id,
+          wallet_address: subscriberWallet,
+        },
+      }
+    );
+
+    await this.subscriptionModule.SetSubscriptionDelegationPda(
+      subscription.id,
+      subscriptionDelegationPda
+    );
+
+    const completedSession =
+      await this.checkoutSessionModule.CompleteCheckoutSession(
+        session.id,
+        {
+          transaction_signature: signature,
+          payer_wallet: subscriberWallet,
+        },
+        { subscription: subscription.id }
+      );
+
+    if (completedSession.payment_link && this.paymentLinkModule) {
+      await this.paymentLinkModule.RecordCompletedSession(
+        completedSession.payment_link
+      );
+    }
+
+    if (
+      !hasTrial &&
+      collectionSignature !== signature &&
+      collectionSignature !== 'already_collected'
+    ) {
+      await this.RecordPaymentOnLedger(
+        completedSession,
+        price.unit_amount ?? session.amount_total!,
+        subscriberWallet,
+        collectionSignature
+      );
+    }
+
+    Logger.info('Checkout session completed via subscription', {
+      checkoutSessionId: completedSession.id,
+      subscriptionId: subscription.id,
+      signature,
+      collectionSignature,
+    });
+
+    return this.SanitizeCheckoutSession(completedSession);
+  }
+
+  private async ResolvePreparedSubscriberWallet(
+    session: CheckoutSession
+  ): Promise<string> {
+    if (session.payment_details?.payer_wallet) {
+      return session.payment_details.payer_wallet;
+    }
+
+    if (session.payment_intent && this.paymentIntentModule) {
+      const paymentIntent = await this.paymentIntentModule.GetPaymentIntent(
+        session.payment_intent
+      );
+      if (paymentIntent?.payment_method) {
+        return paymentIntent.payment_method;
+      }
+    }
+
+    throw new AppError(
+      'Missing subscriber wallet for this Checkout Session. Call prepare again.',
+      ERRORS.INVALID_REQUEST.status,
+      ERRORS.INVALID_REQUEST.type
+    );
+  }
+
+  private async EnsureCheckoutCustomer(
+    session: CheckoutSession,
+    subscriberWallet: string
+  ): Promise<string> {
+    if (session.customer) return session.customer;
+    if (!this.customerModule) {
+      throw new AppError(
+        'Customer module is not configured',
+        ERRORS.INTERNAL_ERROR.status,
+        ERRORS.INTERNAL_ERROR.type
+      );
+    }
+
+    const email =
+      session.customer_email ?? session.customer_details?.email ?? undefined;
+
+    const customer = await this.customerModule.CreateCustomer(
+      session.platform_account,
+      {
+        email,
+        description: `Checkout subscriber ${subscriberWallet}`,
+        metadata: {
+          wallet_address: subscriberWallet,
+          checkout_session: session.id,
+        },
+      }
+    );
+
+    await this.db.Update<CheckoutSession>('CheckoutSessions', session.id, {
+      customer: customer.id,
+    });
+
+    return customer.id;
+  }
+
+  private RequireRecurringCheckoutPrice(session: CheckoutSession): Price {
+    const lineItems = session.line_items?.data ?? [];
+    if (lineItems.length !== 1) {
+      throw new AppError(
+        'Subscription checkout currently supports exactly one line item',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const price = lineItems[0]?.price;
+    if (!price || typeof price === 'string') {
+      throw new AppError(
+        'Subscription checkout requires an expanded recurring price',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    if (price.type !== 'recurring' || !price.recurring) {
+      throw new AppError(
+        'Subscription checkout requires a recurring price',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    return price;
   }
 
   /**
@@ -546,7 +955,10 @@ export class CheckoutPaymentModule {
       );
     }
 
-    if (!session.amount_total || session.amount_total <= 0) {
+    if (
+      session.mode !== 'subscription' &&
+      (!session.amount_total || session.amount_total <= 0)
+    ) {
       throw new AppError(
         'This Checkout Session has no amount due',
         ERRORS.INVALID_REQUEST.status,
@@ -559,6 +971,16 @@ export class CheckoutPaymentModule {
     session: CheckoutSession,
     payerWallet: string
   ): Promise<void> {
+    // Persist payer wallet on the open session so subscription confirm can
+    // resolve the subscriber without relying on a PaymentIntent.
+    await this.db.Update<CheckoutSession>('CheckoutSessions', session.id, {
+      payment_details: {
+        transaction_signature:
+          session.payment_details?.transaction_signature ?? null,
+        payer_wallet: payerWallet,
+      },
+    });
+
     if (!session.payment_intent || !this.paymentIntentModule) return;
 
     // Until crypto PaymentMethods exist, store the payer wallet address as

--- a/apps/api/src/modules/CheckoutSession.ts
+++ b/apps/api/src/modules/CheckoutSession.ts
@@ -619,6 +619,9 @@ export class CheckoutSessionModule {
     paymentDetails: {
       transaction_signature: string;
       payer_wallet: string | null;
+    },
+    options?: {
+      subscription?: string | null;
     }
   ): Promise<CheckoutSessionType> {
     const previousSession = await this.GetCheckoutSession(id);
@@ -644,6 +647,9 @@ export class CheckoutSessionModule {
       payment_status: 'paid',
       url: null,
       payment_details: paymentDetails,
+      ...(options?.subscription !== undefined
+        ? { subscription: options.subscription }
+        : {}),
     });
 
     const session = await this.GetCheckoutSession(id);

--- a/apps/api/src/modules/Payout.ts
+++ b/apps/api/src/modules/Payout.ts
@@ -683,8 +683,6 @@ export class PayoutModule {
     const {
       signed_transaction,
       payouts: payoutIds,
-      blockhash,
-      last_valid_block_height,
     } = input;
 
     // Fetch and validate all payouts
@@ -746,10 +744,7 @@ export class PayoutModule {
 
     // Broadcast the transaction
     const result = await this.solana.BroadcastSignedTransaction(
-      signed_transaction,
-      blockhash && last_valid_block_height
-        ? { blockhash, lastValidBlockHeight: last_valid_block_height }
-        : undefined
+      signed_transaction
     );
 
     // Update all payouts based on result

--- a/apps/api/src/modules/Payout.ts
+++ b/apps/api/src/modules/Payout.ts
@@ -680,10 +680,7 @@ export class PayoutModule {
     platformAccountId: string,
     input: BroadcastPayoutsBatchInput
   ): Promise<PayoutBatchBroadcastResponse> {
-    const {
-      signed_transaction,
-      payouts: payoutIds,
-    } = input;
+    const { signed_transaction, payouts: payoutIds } = input;
 
     // Fetch and validate all payouts
     const payouts: PayoutType[] = [];

--- a/apps/api/src/modules/Price.ts
+++ b/apps/api/src/modules/Price.ts
@@ -23,7 +23,7 @@ import {
 } from '@zoneless/shared-schemas';
 import { ListHelper, ListOptions, ListResult } from '../utils/ListHelper';
 import { Now } from '../utils/Timestamp';
-import { GetAppConfig, GetSubscriptionPullerPublicKey } from './AppConfig';
+import { GetAppConfig } from './AppConfig';
 import { AppError } from '../utils/AppError';
 import { ERRORS } from '../utils/Errors';
 export class PriceModule {
@@ -119,7 +119,7 @@ export class PriceModule {
       const destinationAddress = await this.GetPlatformWalletPublicKey(
         price.platform_account
       );
-      const pullerAddress = GetSubscriptionPullerPublicKey();
+      const pullerAddress = solana.GetPlanOwnerPublicKey();
       const planPda = await solana.CreateSubscriptionPlan(
         price.id,
         periodHours,

--- a/apps/api/src/modules/Subscription.ts
+++ b/apps/api/src/modules/Subscription.ts
@@ -852,6 +852,7 @@ export class SubscriptionModule {
           },
       trial_start: timing.trialStart,
       platform_account: platformAccountId,
+      subscription_delegation_pda: null,
     };
   }
 
@@ -1411,6 +1412,38 @@ export class SubscriptionModule {
     }
     await this.DeleteItems(items.map((item) => item.id));
     await this.db.Delete('Subscriptions', subscriptionId);
+  }
+
+  /**
+   * Persist the on-chain subscription delegation PDA after a successful
+   * hosted checkout subscribe.
+   */
+  async SetSubscriptionDelegationPda(
+    id: string,
+    subscriptionDelegationPda: string
+  ): Promise<SubscriptionType> {
+    const subscription = await this.GetSubscription(id);
+    if (!subscription) {
+      throw new AppError(
+        ERRORS.SUBSCRIPTION_NOT_FOUND.message,
+        ERRORS.SUBSCRIPTION_NOT_FOUND.status,
+        ERRORS.SUBSCRIPTION_NOT_FOUND.type
+      );
+    }
+
+    await this.db.Update<SubscriptionType>('Subscriptions', id, {
+      subscription_delegation_pda: subscriptionDelegationPda,
+    });
+
+    const updated = await this.GetSubscription(id);
+    if (!updated) {
+      throw new AppError(
+        ERRORS.SUBSCRIPTION_NOT_FOUND.message,
+        ERRORS.SUBSCRIPTION_NOT_FOUND.status,
+        ERRORS.SUBSCRIPTION_NOT_FOUND.type
+      );
+    }
+    return updated;
   }
 
   // ───────────────────────────────────────────────────────────────────────────

--- a/apps/api/src/modules/chains/Solana.ts
+++ b/apps/api/src/modules/chains/Solana.ts
@@ -27,12 +27,29 @@ import {
 import { createHash } from 'crypto';
 import {
   address,
+  AccountRole,
   createClient,
   createKeyPairSignerFromBytes,
+  createNoopSigner,
 } from '@solana/kit';
+import type { Instruction } from '@solana/instructions';
 import { solanaRpc } from '@solana/kit-plugin-rpc';
 import { signer } from '@solana/kit-plugin-signer';
-import { findPlanPda, subscriptionsProgram } from '@solana/subscriptions';
+import {
+  findAssociatedTokenPda,
+  TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
+import {
+  findPlanPda,
+  findSubscriptionDelegationPda,
+  findSubscriptionAuthorityPda,
+  fetchMaybePlan,
+  fetchMaybeSubscriptionAuthority,
+  fetchMaybeSubscriptionDelegation,
+  getInitSubscriptionAuthorityOverlayInstructionAsync,
+  getSubscribeOverlayInstructionAsync,
+  subscriptionsProgram,
+} from '@solana/subscriptions';
 
 /**
  * Derive a deterministic on-chain planId (u64) from an off-chain price id string.
@@ -57,6 +74,25 @@ export interface CheckoutPaymentVerification {
   payer_address: string | null;
   /** Reason verification failed, if it did */
   failure_reason?: string;
+}
+
+/** Result of verifying an on-chain subscribe transaction */
+export interface CheckoutSubscribeVerification {
+  verified: boolean;
+  /** Subscriber wallet that signed the subscribe transaction */
+  subscriber_address: string | null;
+  /** Subscription delegation PDA created by the subscribe instruction */
+  subscription_delegation_pda: string | null;
+  /** Reason verification failed, if it did */
+  failure_reason?: string;
+}
+
+/** Shared shape returned by unsigned transaction builders */
+export interface UnsignedSolanaTransaction {
+  unsigned_transaction: string;
+  estimated_fee_lamports: number;
+  blockhash: string;
+  last_valid_block_height: number;
 }
 
 /** Represents a single recipient in a batch USDC transfer */
@@ -319,13 +355,9 @@ export class Solana {
    * The transaction must be fully signed before calling this method.
    *
    * @param signedTransaction - The signed transaction as a base64-encoded string
-   * @param options - Optional blockhash info from the build step to avoid a redundant RPC call
    * @returns Transaction result with signature and status
    */
-  async BroadcastSignedTransaction(
-    signedTransaction: string,
-    options?: { blockhash?: string; lastValidBlockHeight?: number }
-  ): Promise<{
+  async BroadcastSignedTransaction(signedTransaction: string): Promise<{
     signature: string;
     status: 'paid' | 'failed';
     viewer_url: string;
@@ -341,33 +373,16 @@ export class Solana {
         })
       );
 
-      const transaction = Transaction.from(transactionBuffer);
-      const blockhash = options?.blockhash || transaction.recentBlockhash!;
-
-      // Reuse lastValidBlockHeight from build step when available
-      let lastValidBlockHeight = options?.lastValidBlockHeight;
-      if (!lastValidBlockHeight) {
-        const latest = await this.WithRetry(() =>
-          this.connection.getLatestBlockhash('confirmed')
-        );
-        lastValidBlockHeight = latest.lastValidBlockHeight;
-      }
-
-      const confirmation = await this.WithRetry(() =>
-        this.connection.confirmTransaction(
-          { signature, blockhash, lastValidBlockHeight: lastValidBlockHeight! },
-          'confirmed'
-        )
-      );
-
-      if (confirmation.value.err) {
+      // Poll via HTTP — confirmTransaction's websocket path hangs on many RPCs.
+      const confirmed = await this.WaitForSignatureConfirmation(signature);
+      if (!confirmed.ok) {
         return {
           signature,
           status: 'failed',
           viewer_url: this.ExplorerUrl('tx', signature),
-          failure_message: `Transaction failed: ${JSON.stringify(
-            confirmation.value.err
-          )}`,
+          failure_message:
+            confirmed.failure_message ||
+            'Transaction was submitted but failed to confirm',
         };
       }
 
@@ -380,6 +395,21 @@ export class Solana {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
 
+      // sendRawTransaction can throw if the tx already landed (duplicate).
+      const maybeSignature = this.ExtractSignatureFromSendError(error);
+      if (maybeSignature) {
+        const confirmed = await this.WaitForSignatureConfirmation(
+          maybeSignature
+        );
+        if (confirmed.ok) {
+          return {
+            signature: maybeSignature,
+            status: 'paid',
+            viewer_url: this.ExplorerUrl('tx', maybeSignature),
+          };
+        }
+      }
+
       return {
         signature: '',
         status: 'failed',
@@ -387,6 +417,54 @@ export class Solana {
         failure_message: `Broadcast failed: ${errorMessage}`,
       };
     }
+  }
+
+  private async WaitForSignatureConfirmation(
+    signature: string
+  ): Promise<{ ok: boolean; failure_message?: string }> {
+    const maxAttempts = 30;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const statuses = await this.WithRetry(() =>
+        this.connection.getSignatureStatuses([signature], {
+          searchTransactionHistory: true,
+        })
+      );
+      const status = statuses?.value?.[0];
+      if (status?.err) {
+        return {
+          ok: false,
+          failure_message: `Transaction failed: ${JSON.stringify(status.err)}`,
+        };
+      }
+      if (
+        status?.confirmationStatus === 'confirmed' ||
+        status?.confirmationStatus === 'finalized'
+      ) {
+        return { ok: true };
+      }
+      await Sleep(RPC_DELAY_MS);
+    }
+    return {
+      ok: false,
+      failure_message: 'Transaction confirmation timed out',
+    };
+  }
+
+  private ExtractSignatureFromSendError(error: unknown): string | null {
+    if (!error || typeof error !== 'object') return null;
+    const withSignature = error as { signature?: string };
+    if (
+      typeof withSignature.signature === 'string' &&
+      withSignature.signature.length > 0
+    ) {
+      return withSignature.signature;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    // web3.js often embeds: "Transaction ... already been processed: <sig>"
+    const match = message.match(
+      /already (?:been )?processed[:\s]+([1-9A-HJ-NP-Za-km-z]{64,100})/i
+    );
+    return match?.[1] ?? null;
   }
 
   /**
@@ -631,12 +709,7 @@ export class Solana {
     merchantWalletAddress: string,
     amountInCents: number,
     checkoutSessionId: string
-  ): Promise<{
-    unsigned_transaction: string;
-    estimated_fee_lamports: number;
-    blockhash: string;
-    last_valid_block_height: number;
-  }> {
+  ): Promise<UnsignedSolanaTransaction> {
     if (!payerPublicKey) {
       throw new Error('Payer public key is required');
     }
@@ -695,11 +768,498 @@ export class Solana {
       })
     );
 
+    return this.FinalizeUnsignedTransaction(transaction, payer);
+  }
+
+  /**
+   * Build a subscribe transaction for the customer to co-sign.
+   *
+   * Platform `FEE_PAYER` is the fee payer and rent payer (no SOL required from
+   * the subscriber). The returned wire tx is NOT fee-payer-signed yet — the
+   * wallet co-signs as subscriber, then
+   * {@link CosignAndBroadcastSubscribeTransaction} adds the fee-payer
+   * signature and relays on our RPC.
+   */
+  async BuildSubscribeTransaction(
+    subscriberWallet: string,
+    priceId: string,
+    planPda: string
+  ): Promise<UnsignedSolanaTransaction> {
+    if (!subscriberWallet) {
+      throw new Error('Subscriber wallet is required');
+    }
+    if (!priceId) {
+      throw new Error('Price ID is required');
+    }
+    if (!planPda) {
+      throw new Error('Plan PDA is required');
+    }
+
+    const planOwner = this.GetPlanOwnerPublicKey();
+    const planOwnerKeypair = Keypair.fromSecretKey(
+      bs58.decode(this.RequireFeePayerSecretKey())
+    );
+    const planId = PlanIdFromPriceId(priceId);
+    const usdcMintAddress = this.GetUSDCMintAddress();
+    const tokenMint = address(usdcMintAddress);
+    const subscriberAddress = address(subscriberWallet);
+    const subscriberSigner = createNoopSigner(subscriberAddress);
+    const rentPayerSigner = createNoopSigner(address(planOwner));
+
+    const [expectedPlanPda] = await findPlanPda({
+      owner: address(planOwner),
+      planId,
+    });
+    if (expectedPlanPda !== planPda) {
+      throw new Error(
+        `Plan PDA mismatch for price ${priceId}: expected ${expectedPlanPda}, got ${planPda}`
+      );
+    }
+
+    const rpcClient = createClient()
+      .use(signer(subscriberSigner))
+      .use(
+        solanaRpc({
+          rpcUrl: process.env.SOLANA_RPC_URL || clusterApiUrl(this.network),
+        })
+      )
+      .use(subscriptionsProgram());
+
+    const planAccount = await fetchMaybePlan(rpcClient.rpc, address(planPda));
+    if (!planAccount.exists) {
+      throw new Error(
+        'On-chain subscription plan was not found. Recreate the recurring price and try again.'
+      );
+    }
+
+    const [subscriptionPda] = await findSubscriptionDelegationPda({
+      planPda: address(planPda),
+      subscriber: subscriberAddress,
+    });
+    const existingSubscription = await fetchMaybeSubscriptionDelegation(
+      rpcClient.rpc,
+      subscriptionPda
+    );
+    if (existingSubscription.exists) {
+      throw new Error(
+        'This wallet is already subscribed to this plan on-chain.'
+      );
+    }
+
+    const [subscriberAta] = await findAssociatedTokenPda({
+      mint: tokenMint,
+      owner: subscriberAddress,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    const [authorityPda] = await findSubscriptionAuthorityPda({
+      user: subscriberAddress,
+      tokenMint,
+    });
+    const authority = await fetchMaybeSubscriptionAuthority(
+      rpcClient.rpc,
+      authorityPda
+    );
+
+    const kitInstructions: Instruction[] = [];
+    let expectedSubscriptionAuthorityInitId = 0n;
+
+    if (!authority.exists) {
+      kitInstructions.push(
+        await getInitSubscriptionAuthorityOverlayInstructionAsync({
+          owner: subscriberSigner,
+          payer: rentPayerSigner,
+          tokenMint,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          userAta: subscriberAta,
+        })
+      );
+      // New authorities start at initId 0; subscribe in the same tx must match.
+      expectedSubscriptionAuthorityInitId = 0n;
+    } else {
+      expectedSubscriptionAuthorityInitId = authority.data.initId;
+    }
+
+    const planData = planAccount.data.data;
+    kitInstructions.push(
+      await getSubscribeOverlayInstructionAsync({
+        merchant: address(planOwner),
+        planId,
+        tokenMint,
+        payer: rentPayerSigner,
+        subscriber: subscriberSigner,
+        expectedAmount: planData.terms.amount,
+        expectedPeriodHours: planData.terms.periodHours,
+        expectedCreatedAt: planData.terms.createdAt,
+        expectedSubscriptionAuthorityInitId,
+      })
+    );
+
+    const transaction = new Transaction();
+
+    // Ensure the subscriber has a USDC ATA (FEE_PAYER covers rent if created)
+    transaction.add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        planOwnerKeypair.publicKey,
+        new PublicKey(subscriberAta),
+        new PublicKey(subscriberWallet),
+        new PublicKey(usdcMintAddress)
+      )
+    );
+
+    for (const instruction of kitInstructions) {
+      transaction.add(this.ToWeb3Instruction(instruction));
+    }
+
+    const { blockhash, lastValidBlockHeight } = await this.WithRetry(() =>
+      this.connection.getLatestBlockhash('confirmed')
+    );
+    transaction.feePayer = planOwnerKeypair.publicKey;
+    transaction.recentBlockhash = blockhash;
+
+    return {
+      unsigned_transaction: transaction
+        .serialize({ requireAllSignatures: false })
+        .toString('base64'),
+      estimated_fee_lamports: 0,
+      blockhash,
+      last_valid_block_height: lastValidBlockHeight,
+    };
+  }
+
+  /**
+   * After the subscriber co-signs, add the platform fee-payer signature and
+   * broadcast on our RPC.
+   */
+  async CosignAndBroadcastSubscribeTransaction(
+    signedBySubscriberBase64: string
+  ): Promise<{ signature: string }> {
+    const transaction = Transaction.from(
+      Buffer.from(signedBySubscriberBase64, 'base64')
+    );
+    const feePayerKeypair = Keypair.fromSecretKey(
+      bs58.decode(this.RequireFeePayerSecretKey())
+    );
+    transaction.partialSign(feePayerKeypair);
+
+    const broadcast = await this.BroadcastSignedTransaction(
+      transaction.serialize().toString('base64')
+    );
+    if (broadcast.status === 'failed') {
+      throw new Error(
+        broadcast.failure_message || 'Failed to broadcast subscribe transaction'
+      );
+    }
+    return { signature: broadcast.signature };
+  }
+
+  /**
+   * Return the subscription delegation PDA when this wallet is already
+   * subscribed to the plan, otherwise null.
+   */
+  async FindExistingSubscriptionDelegation(
+    planPda: string,
+    subscriberWallet: string
+  ): Promise<string | null> {
+    const [subscriptionPda] = await findSubscriptionDelegationPda({
+      planPda: address(planPda),
+      subscriber: address(subscriberWallet),
+    });
+    const account = await this.WithRetry(() =>
+      this.connection.getAccountInfo(
+        new PublicKey(subscriptionPda),
+        'confirmed'
+      )
+    );
+    return account ? subscriptionPda : null;
+  }
+
+  /**
+   * Verify that a broadcast transaction successfully created a subscription
+   * delegation PDA for the given plan and subscriber.
+   */
+  async VerifySubscribeTransaction(
+    signature: string,
+    expected: {
+      planPda: string;
+      subscriberWallet: string;
+    }
+  ): Promise<CheckoutSubscribeVerification> {
+    const maxAttempts = 15;
+    let tx: ParsedTransactionWithMeta | null = null;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      tx = await this.GetParsedTransaction(signature);
+      if (tx) break;
+      await Sleep(RPC_DELAY_MS);
+    }
+
+    if (!tx || !tx.meta) {
+      return {
+        verified: false,
+        subscriber_address: null,
+        subscription_delegation_pda: null,
+        failure_reason:
+          'Transaction not found on-chain (may not be confirmed yet)',
+      };
+    }
+
+    if (tx.meta.err) {
+      return {
+        verified: false,
+        subscriber_address: null,
+        subscription_delegation_pda: null,
+        failure_reason: `Transaction failed on-chain: ${JSON.stringify(
+          tx.meta.err
+        )}`,
+      };
+    }
+
+    const [subscriptionPda] = await findSubscriptionDelegationPda({
+      planPda: address(expected.planPda),
+      subscriber: address(expected.subscriberWallet),
+    });
+
+    const subscriptionAccount = await this.WithRetry(() =>
+      this.connection.getAccountInfo(new PublicKey(subscriptionPda), 'confirmed')
+    );
+
+    if (!subscriptionAccount) {
+      return {
+        verified: false,
+        subscriber_address: expected.subscriberWallet,
+        subscription_delegation_pda: null,
+        failure_reason:
+          'Subscription account was not created for this subscriber and plan',
+      };
+    }
+
+    const feePayer = tx.transaction.message.accountKeys[0];
+    const feePayerAddress =
+      typeof feePayer === 'string'
+        ? feePayer
+        : feePayer?.pubkey?.toBase58?.() ?? null;
+
+    // Fee payer may be the platform sponsor; subscriber must still appear as a
+    // signer on the transaction (account key with signer flag).
+    const accountKeys = tx.transaction.message.accountKeys;
+    const subscriberSigned = accountKeys.some((key) => {
+      const address =
+        typeof key === 'string' ? key : key?.pubkey?.toBase58?.() ?? '';
+      if (address !== expected.subscriberWallet) return false;
+      if (typeof key === 'string') return true;
+      return key.signer === true || key.signer === undefined;
+    });
+
+    if (!subscriberSigned) {
+      return {
+        verified: false,
+        subscriber_address: feePayerAddress,
+        subscription_delegation_pda: subscriptionPda,
+        failure_reason:
+          'Subscribe transaction was not signed by the expected wallet',
+      };
+    }
+
+    return {
+      verified: true,
+      subscriber_address: expected.subscriberWallet,
+      subscription_delegation_pda: subscriptionPda,
+    };
+  }
+
+  /**
+   * Collect a subscription period payment. Signed by the plan owner
+   * (`FEE_PAYER`). Funds go to the plan's on-chain destination allowlist
+   * (not an arbitrary merchant wallet — mismatched receivers fail on-chain).
+   */
+  async CollectSubscriptionPayment(params: {
+    subscriberWallet: string;
+    planPda: string;
+    subscriptionPda: string;
+    amountCents: number;
+    /** Optional; must match a plan destination if the plan has an allowlist. */
+    destinationWallet?: string;
+  }): Promise<{ signature: string }> {
+    const {
+      subscriberWallet,
+      planPda,
+      subscriptionPda,
+      amountCents,
+      destinationWallet,
+    } = params;
+
+    if (!Number.isInteger(amountCents) || amountCents <= 0) {
+      throw new Error('Amount must be a positive integer number of cents');
+    }
+
+    const feePayerKeypair = Keypair.fromSecretKey(
+      bs58.decode(this.RequireFeePayerSecretKey())
+    );
+    const merchantSigner = await this.GetPlanOwnerSigner();
+    const tokenMint = address(this.GetUSDCMintAddress());
+    const usdcMint = new PublicKey(this.GetUSDCMintAddress());
+
+    const rpcClient = createClient()
+      .use(signer(merchantSigner))
+      .use(
+        solanaRpc({
+          rpcUrl: process.env.SOLANA_RPC_URL || clusterApiUrl(this.network),
+        })
+      )
+      .use(subscriptionsProgram());
+
+    const planAccount = await fetchMaybePlan(rpcClient.rpc, address(planPda));
+    if (!planAccount.exists) {
+      throw new Error(`Subscription plan not found on-chain: ${planPda}`);
+    }
+
+    const SYSTEM_PROGRAM = '11111111111111111111111111111111';
+    const allowlisted = planAccount.data.data.destinations
+      .map((dest) => String(dest))
+      .filter((dest) => dest && dest !== SYSTEM_PROGRAM);
+    // Plans bake the receiving wallet in at create time — collect must use it.
+    const resolvedDestination = allowlisted[0] || destinationWallet;
+
+    if (!resolvedDestination) {
+      throw new Error(
+        'Subscription plan has no destination wallet configured on-chain'
+      );
+    }
+
+    if (
+      destinationWallet &&
+      allowlisted.length > 0 &&
+      !allowlisted.includes(destinationWallet)
+    ) {
+      console.warn(
+        `[Solana] Collect using plan destination ${resolvedDestination} (merchant wallet ${destinationWallet} is not in the plan allowlist)`
+      );
+    }
+
+    const destinationPubkey = new PublicKey(resolvedDestination);
+    const receiverAta = await getAssociatedTokenAddress(
+      usdcMint,
+      destinationPubkey
+    );
+
+    // Receiver ATA must exist — program error 110 if missing.
+    const createAtaTx = new Transaction().add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        feePayerKeypair.publicKey,
+        receiverAta,
+        destinationPubkey,
+        usdcMint
+      )
+    );
+    const { blockhash } = await this.WithRetry(() =>
+      this.connection.getLatestBlockhash('confirmed')
+    );
+    createAtaTx.recentBlockhash = blockhash;
+    createAtaTx.feePayer = feePayerKeypair.publicKey;
+    createAtaTx.sign(feePayerKeypair);
+    const createAtaSignature = await this.WithRetry(() =>
+      this.connection.sendRawTransaction(createAtaTx.serialize(), {
+        skipPreflight: true,
+      })
+    );
+    const createAtaConfirmed = await this.WaitForSignatureConfirmation(
+      createAtaSignature
+    );
+    if (!createAtaConfirmed.ok) {
+      throw new Error(
+        createAtaConfirmed.failure_message ||
+          `Failed to confirm destination ATA creation (${createAtaSignature})`
+      );
+    }
+
+    const amount = BigInt(amountCents * 10_000);
+
+    const existingSub = await fetchMaybeSubscriptionDelegation(
+      rpcClient.rpc,
+      address(subscriptionPda)
+    );
+    if (
+      existingSub.exists &&
+      existingSub.data.amountPulledInPeriod >= amount
+    ) {
+      // Already collected this billing period (e.g. retry after a partial confirm).
+      return { signature: 'already_collected' };
+    }
+
+    try {
+      const result = await rpcClient.subscriptions.instructions
+        .transferSubscription({
+          caller: merchantSigner,
+          delegator: address(subscriberWallet),
+          tokenMint,
+          subscriptionPda: address(subscriptionPda),
+          planPda: address(planPda),
+          amount,
+          receiverAta: address(receiverAta.toBase58()),
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+        })
+        .sendTransaction();
+
+      return { signature: result.context.signature };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/#400|exceeds period limit/i.test(message)) {
+        return { signature: 'already_collected' };
+      }
+      throw new Error(
+        `Subscription collect failed (destination ${resolvedDestination}, ATA ${receiverAta.toBase58()}): ${message}`
+      );
+    }
+  }
+
+  /**
+   * Public key of the wallet that owns on-chain subscription plans
+   * (FEE_PAYER_KEY). This is the `merchant` argument to `subscribe`.
+   */
+  GetPlanOwnerPublicKey(): string {
+    const secretKey = this.RequireFeePayerSecretKey();
+    return Keypair.fromSecretKey(bs58.decode(secretKey)).publicKey.toBase58();
+  }
+
+  private async GetPlanOwnerSigner() {
+    return createKeyPairSignerFromBytes(
+      bs58.decode(this.RequireFeePayerSecretKey())
+    );
+  }
+
+  private RequireFeePayerSecretKey(): string {
+    const secretKey = process.env.FEE_PAYER_KEY;
+    if (!secretKey) {
+      throw new Error('FEE_PAYER_KEY is required');
+    }
+    return secretKey;
+  }
+
+  private ToWeb3Instruction(instruction: Instruction): TransactionInstruction {
+    return new TransactionInstruction({
+      programId: new PublicKey(instruction.programAddress),
+      keys: (instruction.accounts ?? []).map((account) => ({
+        pubkey: new PublicKey(account.address),
+        isSigner:
+          account.role === AccountRole.READONLY_SIGNER ||
+          account.role === AccountRole.WRITABLE_SIGNER,
+        isWritable:
+          account.role === AccountRole.WRITABLE ||
+          account.role === AccountRole.WRITABLE_SIGNER,
+      })),
+      data: Buffer.from(instruction.data ?? new Uint8Array()),
+    });
+  }
+
+  private async FinalizeUnsignedTransaction(
+    transaction: Transaction,
+    feePayer: PublicKey
+  ): Promise<UnsignedSolanaTransaction> {
     const { blockhash, lastValidBlockHeight } = await this.WithRetry(() =>
       this.connection.getLatestBlockhash('confirmed')
     );
     transaction.recentBlockhash = blockhash;
-    transaction.feePayer = payer;
+    transaction.feePayer = feePayer;
 
     const fee = await this.WithRetry(() =>
       this.connection.getFeeForMessage(
@@ -708,12 +1268,10 @@ export class Solana {
       )
     );
 
-    const serializedTransaction = transaction
-      .serialize({ requireAllSignatures: false })
-      .toString('base64');
-
     return {
-      unsigned_transaction: serializedTransaction,
+      unsigned_transaction: transaction
+        .serialize({ requireAllSignatures: false })
+        .toString('base64'),
       estimated_fee_lamports: fee.value || 0,
       blockhash,
       last_valid_block_height: lastValidBlockHeight,
@@ -850,15 +1408,7 @@ export class Solana {
     destinationAddress: string,
     pullerAddress: string
   ): Promise<string> {
-    const secretKey = process.env.FEE_PAYER_KEY;
-
-    if (!secretKey) {
-      throw new Error('FEE_PAYER_KEY is required');
-    }
-
-    const merchantSigner = await createKeyPairSignerFromBytes(
-      bs58.decode(secretKey)
-    );
+    const merchantSigner = await this.GetPlanOwnerSigner();
 
     const merchantClient = createClient()
       .use(signer(merchantSigner))
@@ -871,11 +1421,7 @@ export class Solana {
 
     // USDC has 6 decimals → 10_000 base units = $0.01
     const planId = PlanIdFromPriceId(priceId);
-    const usdcMintAddress =
-      this.network === 'mainnet-beta'
-        ? 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' // Mainnet USDC
-        : '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU'; // Devnet USDC
-    const tokenMint = address(usdcMintAddress);
+    const tokenMint = address(this.GetUSDCMintAddress());
     const amount = BigInt(amountCents * 10_000);
     const periodHoursBigInt = BigInt(periodHours);
     const metadataUri = '';
@@ -899,7 +1445,6 @@ export class Solana {
       owner: merchantSigner.address,
       planId,
     });
-    console.log('PDA CREATED: ', planPda);
     return planPda;
   }
 }

--- a/apps/api/src/modules/chains/Solana.ts
+++ b/apps/api/src/modules/chains/Solana.ts
@@ -50,6 +50,10 @@ import {
   getSubscribeOverlayInstructionAsync,
   subscriptionsProgram,
 } from '@solana/subscriptions';
+import {
+  GetCheckoutFeePayerSecretKey,
+  RequireSubscriptionOperatorSecretKey,
+} from '../AppConfig';
 
 /**
  * Derive a deterministic on-chain planId (u64) from an off-chain price id string.
@@ -117,8 +121,11 @@ export interface IncomingDeposit {
   slot: number;
 }
 
-// Rate limiting configuration - public Solana RPC has strict limits
-const RPC_DELAY_MS = 2000; // 2 second delay between RPC calls to avoid rate limits
+// Rate limiting for bulk deposit scanning (public RPC is strict).
+const RPC_DELAY_MS = 2000;
+// Confirmation polling should be snappy — not the deposit-scan delay.
+const CONFIRM_POLL_MS = 400;
+const CONFIRM_MAX_ATTEMPTS = 75; // ~30s at 400ms
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 2000;
 
@@ -368,7 +375,8 @@ export class Solana {
 
       const signature = await this.WithRetry(() =>
         this.connection.sendRawTransaction(transactionBuffer, {
-          skipPreflight: true,
+          skipPreflight: false,
+          preflightCommitment: 'confirmed',
           maxRetries: 3,
         })
       );
@@ -422,8 +430,7 @@ export class Solana {
   private async WaitForSignatureConfirmation(
     signature: string
   ): Promise<{ ok: boolean; failure_message?: string }> {
-    const maxAttempts = 30;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    for (let attempt = 0; attempt < CONFIRM_MAX_ATTEMPTS; attempt++) {
       const statuses = await this.WithRetry(() =>
         this.connection.getSignatureStatuses([signature], {
           searchTransactionHistory: true,
@@ -442,7 +449,7 @@ export class Solana {
       ) {
         return { ok: true };
       }
-      await Sleep(RPC_DELAY_MS);
+      await Sleep(CONFIRM_POLL_MS);
     }
     return {
       ok: false,
@@ -698,17 +705,15 @@ export class Solana {
    * attaches an SPL Memo with the checkout session ID so the payment can be
    * unambiguously matched to the session during verification.
    *
-   * @param payerPublicKey - The customer's wallet public key (fee payer and source)
-   * @param merchantWalletAddress - The merchant's wallet address (destination)
-   * @param amountInCents - Payment amount in cents (1 cent = 10,000 USDC atomic units)
-   * @param checkoutSessionId - The checkout session ID to embed in the memo
-   * @returns Object containing the unsigned transaction (base64), fee estimate, and blockhash
+   * When `feeSponsored` is true, TRANSACTION_FEE_PAYER_KEY pays network fees
+   * and ATA rent; the customer only co-signs the transfer.
    */
   async BuildCheckoutPaymentTransaction(
     payerPublicKey: string,
     merchantWalletAddress: string,
     amountInCents: number,
-    checkoutSessionId: string
+    checkoutSessionId: string,
+    options?: { feeSponsored?: boolean }
   ): Promise<UnsignedSolanaTransaction> {
     if (!payerPublicKey) {
       throw new Error('Payer public key is required');
@@ -723,9 +728,15 @@ export class Solana {
       throw new Error('Checkout session ID is required');
     }
 
+    const feeSponsored = !!options?.feeSponsored;
     const payer = new PublicKey(payerPublicKey);
     const merchant = new PublicKey(merchantWalletAddress);
     const usdcMint = new PublicKey(this.GetUSDCMintAddress());
+    const rentPayer = feeSponsored
+      ? Keypair.fromSecretKey(
+          bs58.decode(this.RequireCheckoutFeePayerSecretKey())
+        ).publicKey
+      : payer;
 
     const payerTokenAccount = await getAssociatedTokenAddress(usdcMint, payer);
     const merchantTokenAccount = await getAssociatedTokenAddress(
@@ -738,10 +749,10 @@ export class Solana {
 
     const transaction = new Transaction();
 
-    // Ensure the merchant's USDC token account exists (payer funds rent if not)
+    // Ensure the merchant's USDC token account exists
     transaction.add(
       createAssociatedTokenAccountIdempotentInstruction(
-        payer,
+        rentPayer,
         merchantTokenAccount,
         merchant,
         usdcMint
@@ -768,22 +779,97 @@ export class Solana {
       })
     );
 
-    return this.FinalizeUnsignedTransaction(transaction, payer);
+    return this.FinalizeUnsignedTransaction(transaction, rentPayer, {
+      feeSponsored: !!options?.feeSponsored,
+    });
   }
 
   /**
-   * Build a subscribe transaction for the customer to co-sign.
+   * Build an init-only SubscriptionAuthority tx when the subscriber has none
+   * for the USDC mint. Returns null when the authority already exists.
    *
-   * Platform `FEE_PAYER` is the fee payer and rent payer (no SOL required from
-   * the subscriber). The returned wire tx is NOT fee-payer-signed yet — the
-   * wallet co-signs as subscriber, then
-   * {@link CosignAndBroadcastSubscribeTransaction} adds the fee-payer
-   * signature and relays on our RPC.
+   * Must land in its own transaction before subscribe: the program stores
+   * `init_id = Clock::slot` at execution, and bundling with subscribe is
+   * unreliable across program versions / wallet simulation.
+   */
+  async BuildInitSubscriptionAuthorityTransaction(
+    subscriberWallet: string,
+    options?: { feeSponsored?: boolean }
+  ): Promise<UnsignedSolanaTransaction | null> {
+    if (!subscriberWallet) {
+      throw new Error('Subscriber wallet is required');
+    }
+
+    const feeSponsored = !!options?.feeSponsored;
+    const usdcMintAddress = this.GetUSDCMintAddress();
+    const tokenMint = address(usdcMintAddress);
+    const subscriberAddress = address(subscriberWallet);
+    const subscriberSigner = createNoopSigner(subscriberAddress);
+
+    const rentPayerPubkey = feeSponsored
+      ? Keypair.fromSecretKey(
+          bs58.decode(this.RequireCheckoutFeePayerSecretKey())
+        ).publicKey
+      : new PublicKey(subscriberWallet);
+    const rentPayerSigner = createNoopSigner(
+      address(rentPayerPubkey.toBase58())
+    );
+
+    const [authorityPda] = await findSubscriptionAuthorityPda({
+      user: subscriberAddress,
+      tokenMint,
+    });
+    const authority = await fetchMaybeSubscriptionAuthority(
+      this.CreateSubscriptionsRpc(subscriberSigner).rpc,
+      authorityPda
+    );
+    if (authority.exists) {
+      return null;
+    }
+
+    const [subscriberAta] = await findAssociatedTokenPda({
+      mint: tokenMint,
+      owner: subscriberAddress,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    const initIx = await getInitSubscriptionAuthorityOverlayInstructionAsync({
+      owner: subscriberSigner,
+      payer: rentPayerSigner,
+      tokenMint,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      userAta: subscriberAta,
+    });
+
+    const transaction = new Transaction();
+    transaction.add(
+      createAssociatedTokenAccountIdempotentInstruction(
+        rentPayerPubkey,
+        new PublicKey(subscriberAta),
+        new PublicKey(subscriberWallet),
+        new PublicKey(usdcMintAddress)
+      )
+    );
+    transaction.add(this.ToWeb3Instruction(initIx));
+
+    return this.FinalizeUnsignedTransaction(transaction, rentPayerPubkey, {
+      feeSponsored,
+    });
+  }
+
+  /**
+   * Build a subscribe-only transaction. Requires an existing
+   * SubscriptionAuthority; call BuildInitSubscriptionAuthorityTransaction
+   * first for new wallets.
+   *
+   * Plan owner is always SUBSCRIPTION_OPERATOR_KEY. Fee/rent payer is
+   * TRANSACTION_FEE_PAYER_KEY when sponsored, otherwise the subscriber.
    */
   async BuildSubscribeTransaction(
     subscriberWallet: string,
     priceId: string,
-    planPda: string
+    planPda: string,
+    options?: { feeSponsored?: boolean }
   ): Promise<UnsignedSolanaTransaction> {
     if (!subscriberWallet) {
       throw new Error('Subscriber wallet is required');
@@ -795,16 +881,22 @@ export class Solana {
       throw new Error('Plan PDA is required');
     }
 
+    const feeSponsored = !!options?.feeSponsored;
     const planOwner = this.GetPlanOwnerPublicKey();
-    const planOwnerKeypair = Keypair.fromSecretKey(
-      bs58.decode(this.RequireFeePayerSecretKey())
-    );
     const planId = PlanIdFromPriceId(priceId);
     const usdcMintAddress = this.GetUSDCMintAddress();
     const tokenMint = address(usdcMintAddress);
     const subscriberAddress = address(subscriberWallet);
     const subscriberSigner = createNoopSigner(subscriberAddress);
-    const rentPayerSigner = createNoopSigner(address(planOwner));
+
+    const rentPayerPubkey = feeSponsored
+      ? Keypair.fromSecretKey(
+          bs58.decode(this.RequireCheckoutFeePayerSecretKey())
+        ).publicKey
+      : new PublicKey(subscriberWallet);
+    const rentPayerSigner = createNoopSigner(
+      address(rentPayerPubkey.toBase58())
+    );
 
     const [expectedPlanPda] = await findPlanPda({
       owner: address(planOwner),
@@ -816,14 +908,7 @@ export class Solana {
       );
     }
 
-    const rpcClient = createClient()
-      .use(signer(subscriberSigner))
-      .use(
-        solanaRpc({
-          rpcUrl: process.env.SOLANA_RPC_URL || clusterApiUrl(this.network),
-        })
-      )
-      .use(subscriptionsProgram());
+    const rpcClient = this.CreateSubscriptionsRpc(subscriberSigner);
 
     const planAccount = await fetchMaybePlan(rpcClient.rpc, address(planPda));
     if (!planAccount.exists) {
@@ -846,12 +931,6 @@ export class Solana {
       );
     }
 
-    const [subscriberAta] = await findAssociatedTokenPda({
-      mint: tokenMint,
-      owner: subscriberAddress,
-      tokenProgram: TOKEN_PROGRAM_ADDRESS,
-    });
-
     const [authorityPda] = await findSubscriptionAuthorityPda({
       user: subscriberAddress,
       tokenMint,
@@ -860,85 +939,84 @@ export class Solana {
       rpcClient.rpc,
       authorityPda
     );
-
-    const kitInstructions: Instruction[] = [];
-    let expectedSubscriptionAuthorityInitId = 0n;
-
     if (!authority.exists) {
-      kitInstructions.push(
-        await getInitSubscriptionAuthorityOverlayInstructionAsync({
-          owner: subscriberSigner,
-          payer: rentPayerSigner,
-          tokenMint,
-          tokenProgram: TOKEN_PROGRAM_ADDRESS,
-          userAta: subscriberAta,
-        })
+      throw new Error(
+        'Subscription authority is not initialized for this wallet. Init it first.'
       );
-      // New authorities start at initId 0; subscribe in the same tx must match.
-      expectedSubscriptionAuthorityInitId = 0n;
-    } else {
-      expectedSubscriptionAuthorityInitId = authority.data.initId;
     }
 
     const planData = planAccount.data.data;
-    kitInstructions.push(
-      await getSubscribeOverlayInstructionAsync({
-        merchant: address(planOwner),
-        planId,
-        tokenMint,
-        payer: rentPayerSigner,
-        subscriber: subscriberSigner,
-        expectedAmount: planData.terms.amount,
-        expectedPeriodHours: planData.terms.periodHours,
-        expectedCreatedAt: planData.terms.createdAt,
-        expectedSubscriptionAuthorityInitId,
-      })
-    );
+    const subscribeIx = await getSubscribeOverlayInstructionAsync({
+      merchant: address(planOwner),
+      planId,
+      tokenMint,
+      payer: rentPayerSigner,
+      subscriber: subscriberSigner,
+      expectedAmount: planData.terms.amount,
+      expectedPeriodHours: planData.terms.periodHours,
+      expectedCreatedAt: planData.terms.createdAt,
+      expectedSubscriptionAuthorityInitId: authority.data.initId,
+    });
 
     const transaction = new Transaction();
+    transaction.add(this.ToWeb3Instruction(subscribeIx));
 
-    // Ensure the subscriber has a USDC ATA (FEE_PAYER covers rent if created)
-    transaction.add(
-      createAssociatedTokenAccountIdempotentInstruction(
-        planOwnerKeypair.publicKey,
-        new PublicKey(subscriberAta),
-        new PublicKey(subscriberWallet),
-        new PublicKey(usdcMintAddress)
-      )
-    );
-
-    for (const instruction of kitInstructions) {
-      transaction.add(this.ToWeb3Instruction(instruction));
-    }
-
-    const { blockhash, lastValidBlockHeight } = await this.WithRetry(() =>
-      this.connection.getLatestBlockhash('confirmed')
-    );
-    transaction.feePayer = planOwnerKeypair.publicKey;
-    transaction.recentBlockhash = blockhash;
-
-    return {
-      unsigned_transaction: transaction
-        .serialize({ requireAllSignatures: false })
-        .toString('base64'),
-      estimated_fee_lamports: 0,
-      blockhash,
-      last_valid_block_height: lastValidBlockHeight,
-    };
+    return this.FinalizeUnsignedTransaction(transaction, rentPayerPubkey, {
+      feeSponsored,
+    });
   }
 
   /**
-   * After the subscriber co-signs, add the platform fee-payer signature and
-   * broadcast on our RPC.
+   * Poll until the subscriber's SubscriptionAuthority PDA exists (after init).
    */
-  async CosignAndBroadcastSubscribeTransaction(
-    signedBySubscriberBase64: string
+  async WaitForSubscriptionAuthority(
+    subscriberWallet: string,
+    maxAttempts = 20
+  ): Promise<void> {
+    const tokenMint = address(this.GetUSDCMintAddress());
+    const subscriberAddress = address(subscriberWallet);
+    const [authorityPda] = await findSubscriptionAuthorityPda({
+      user: subscriberAddress,
+      tokenMint,
+    });
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const info = await this.WithRetry(() =>
+        this.connection.getAccountInfo(new PublicKey(authorityPda), 'confirmed')
+      );
+      if (info) return;
+      await Sleep(CONFIRM_POLL_MS);
+    }
+    throw new Error(
+      'Subscription authority was not found on-chain after init. Please try again.'
+    );
+  }
+
+  private CreateSubscriptionsRpc(
+    subscriberSigner: ReturnType<typeof createNoopSigner>
+  ) {
+    return createClient()
+      .use(signer(subscriberSigner))
+      .use(
+        solanaRpc({
+          rpcUrl: process.env.SOLANA_RPC_URL || clusterApiUrl(this.network),
+        })
+      )
+      .use(subscriptionsProgram());
+  }
+
+  /**
+   * After the customer co-signs a fee-sponsored checkout tx, add the
+   * TRANSACTION_FEE_PAYER signature and broadcast on our RPC.
+   */
+  async CosignAndBroadcastCheckoutTransaction(
+    signedByCustomerBase64: string
   ): Promise<{ signature: string }> {
     const transaction = Transaction.from(
-      Buffer.from(signedBySubscriberBase64, 'base64')
+      Buffer.from(signedByCustomerBase64, 'base64')
     );
     const feePayerKeypair = Keypair.fromSecretKey(
-      bs58.decode(this.RequireFeePayerSecretKey())
+      bs58.decode(this.RequireCheckoutFeePayerSecretKey())
     );
     transaction.partialSign(feePayerKeypair);
 
@@ -947,10 +1025,17 @@ export class Solana {
     );
     if (broadcast.status === 'failed') {
       throw new Error(
-        broadcast.failure_message || 'Failed to broadcast subscribe transaction'
+        broadcast.failure_message || 'Failed to broadcast checkout transaction'
       );
     }
     return { signature: broadcast.signature };
+  }
+
+  /** @deprecated Use CosignAndBroadcastCheckoutTransaction */
+  async CosignAndBroadcastSubscribeTransaction(
+    signedBySubscriberBase64: string
+  ): Promise<{ signature: string }> {
+    return this.CosignAndBroadcastCheckoutTransaction(signedBySubscriberBase64);
   }
 
   /**
@@ -985,12 +1070,12 @@ export class Solana {
       subscriberWallet: string;
     }
   ): Promise<CheckoutSubscribeVerification> {
-    const maxAttempts = 15;
+    const maxAttempts = 20;
     let tx: ParsedTransactionWithMeta | null = null;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       tx = await this.GetParsedTransaction(signature);
       if (tx) break;
-      await Sleep(RPC_DELAY_MS);
+      await Sleep(CONFIRM_POLL_MS);
     }
 
     if (!tx || !tx.meta) {
@@ -1020,7 +1105,10 @@ export class Solana {
     });
 
     const subscriptionAccount = await this.WithRetry(() =>
-      this.connection.getAccountInfo(new PublicKey(subscriptionPda), 'confirmed')
+      this.connection.getAccountInfo(
+        new PublicKey(subscriptionPda),
+        'confirmed'
+      )
     );
 
     if (!subscriptionAccount) {
@@ -1069,8 +1157,9 @@ export class Solana {
 
   /**
    * Collect a subscription period payment. Signed by the plan owner
-   * (`FEE_PAYER`). Funds go to the plan's on-chain destination allowlist
-   * (not an arbitrary merchant wallet — mismatched receivers fail on-chain).
+   * (`SUBSCRIPTION_OPERATOR_KEY`). Funds go to the plan's on-chain destination
+   * allowlist (not an arbitrary merchant wallet — mismatched receivers fail
+   * on-chain).
    */
   async CollectSubscriptionPayment(params: {
     subscriberWallet: string;
@@ -1092,8 +1181,11 @@ export class Solana {
       throw new Error('Amount must be a positive integer number of cents');
     }
 
+    // Prefer transaction fee payer for ATA rent when configured; else operator.
+    const ataRentPayerSecret =
+      GetCheckoutFeePayerSecretKey() || RequireSubscriptionOperatorSecretKey();
     const feePayerKeypair = Keypair.fromSecretKey(
-      bs58.decode(this.RequireFeePayerSecretKey())
+      bs58.decode(ataRentPayerSecret)
     );
     const merchantSigner = await this.GetPlanOwnerSigner();
     const tokenMint = address(this.GetUSDCMintAddress());
@@ -1142,34 +1234,41 @@ export class Solana {
       destinationPubkey
     );
 
-    // Receiver ATA must exist — program error 110 if missing.
-    const createAtaTx = new Transaction().add(
-      createAssociatedTokenAccountIdempotentInstruction(
-        feePayerKeypair.publicKey,
-        receiverAta,
-        destinationPubkey,
-        usdcMint
-      )
+    // Only create+confirm the destination ATA when missing — otherwise every
+    // collect burns a full confirmation wait on a no-op idempotent create.
+    const existingAta = await this.WithRetry(() =>
+      this.connection.getAccountInfo(receiverAta, 'confirmed')
     );
-    const { blockhash } = await this.WithRetry(() =>
-      this.connection.getLatestBlockhash('confirmed')
-    );
-    createAtaTx.recentBlockhash = blockhash;
-    createAtaTx.feePayer = feePayerKeypair.publicKey;
-    createAtaTx.sign(feePayerKeypair);
-    const createAtaSignature = await this.WithRetry(() =>
-      this.connection.sendRawTransaction(createAtaTx.serialize(), {
-        skipPreflight: true,
-      })
-    );
-    const createAtaConfirmed = await this.WaitForSignatureConfirmation(
-      createAtaSignature
-    );
-    if (!createAtaConfirmed.ok) {
-      throw new Error(
-        createAtaConfirmed.failure_message ||
-          `Failed to confirm destination ATA creation (${createAtaSignature})`
+    if (!existingAta) {
+      const createAtaTx = new Transaction().add(
+        createAssociatedTokenAccountIdempotentInstruction(
+          feePayerKeypair.publicKey,
+          receiverAta,
+          destinationPubkey,
+          usdcMint
+        )
       );
+      const { blockhash } = await this.WithRetry(() =>
+        this.connection.getLatestBlockhash('confirmed')
+      );
+      createAtaTx.recentBlockhash = blockhash;
+      createAtaTx.feePayer = feePayerKeypair.publicKey;
+      createAtaTx.sign(feePayerKeypair);
+      const createAtaSignature = await this.WithRetry(() =>
+        this.connection.sendRawTransaction(createAtaTx.serialize(), {
+          skipPreflight: false,
+          preflightCommitment: 'confirmed',
+        })
+      );
+      const createAtaConfirmed = await this.WaitForSignatureConfirmation(
+        createAtaSignature
+      );
+      if (!createAtaConfirmed.ok) {
+        throw new Error(
+          createAtaConfirmed.failure_message ||
+            `Failed to confirm destination ATA creation (${createAtaSignature})`
+        );
+      }
     }
 
     const amount = BigInt(amountCents * 10_000);
@@ -1178,10 +1277,7 @@ export class Solana {
       rpcClient.rpc,
       address(subscriptionPda)
     );
-    if (
-      existingSub.exists &&
-      existingSub.data.amountPulledInPeriod >= amount
-    ) {
+    if (existingSub.exists && existingSub.data.amountPulledInPeriod >= amount) {
       // Already collected this billing period (e.g. retry after a partial confirm).
       return { signature: 'already_collected' };
     }
@@ -1214,23 +1310,26 @@ export class Solana {
 
   /**
    * Public key of the wallet that owns on-chain subscription plans
-   * (FEE_PAYER_KEY). This is the `merchant` argument to `subscribe`.
+   * (SUBSCRIPTION_OPERATOR_KEY). This is the `merchant` argument to `subscribe`
+   * and the authorized puller.
    */
   GetPlanOwnerPublicKey(): string {
-    const secretKey = this.RequireFeePayerSecretKey();
+    const secretKey = RequireSubscriptionOperatorSecretKey();
     return Keypair.fromSecretKey(bs58.decode(secretKey)).publicKey.toBase58();
   }
 
   private async GetPlanOwnerSigner() {
     return createKeyPairSignerFromBytes(
-      bs58.decode(this.RequireFeePayerSecretKey())
+      bs58.decode(RequireSubscriptionOperatorSecretKey())
     );
   }
 
-  private RequireFeePayerSecretKey(): string {
-    const secretKey = process.env.FEE_PAYER_KEY;
+  private RequireCheckoutFeePayerSecretKey(): string {
+    const secretKey = GetCheckoutFeePayerSecretKey();
     if (!secretKey) {
-      throw new Error('FEE_PAYER_KEY is required');
+      throw new Error(
+        'TRANSACTION_FEE_PAYER_KEY is required for fee sponsorship'
+      );
     }
     return secretKey;
   }
@@ -1253,13 +1352,23 @@ export class Solana {
 
   private async FinalizeUnsignedTransaction(
     transaction: Transaction,
-    feePayer: PublicKey
+    feePayer: PublicKey,
+    options?: { feeSponsored?: boolean }
   ): Promise<UnsignedSolanaTransaction> {
     const { blockhash, lastValidBlockHeight } = await this.WithRetry(() =>
       this.connection.getLatestBlockhash('confirmed')
     );
     transaction.recentBlockhash = blockhash;
     transaction.feePayer = feePayer;
+
+    // Pre-sign with the fee payer so wallet simulation sees a funded payer
+    // and does not warn about the subscriber's empty SOL balance.
+    if (options?.feeSponsored) {
+      const feePayerKeypair = Keypair.fromSecretKey(
+        bs58.decode(this.RequireCheckoutFeePayerSecretKey())
+      );
+      transaction.partialSign(feePayerKeypair);
+    }
 
     const fee = await this.WithRetry(() =>
       this.connection.getFeeForMessage(
@@ -1308,12 +1417,12 @@ export class Solana {
     const merchantTokenAccountStr = merchantTokenAccount.toBase58();
 
     // Poll for the transaction to reach 'confirmed' commitment
-    const maxAttempts = 15;
+    const maxAttempts = 20;
     let tx: ParsedTransactionWithMeta | null = null;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       tx = await this.GetParsedTransaction(signature);
       if (tx) break;
-      await Sleep(RPC_DELAY_MS);
+      await Sleep(CONFIRM_POLL_MS);
     }
 
     if (!tx || !tx.meta) {

--- a/apps/api/src/routes/paymentPages.routes.ts
+++ b/apps/api/src/routes/paymentPages.routes.ts
@@ -112,8 +112,8 @@ router.get(
 /**
  * POST /v1/payment_pages/:urlSlug/prepare
  * Build an unsigned Solana transaction for the checkout session. Payment
- * mode returns a USDC transfer; subscription mode returns subscribe
- * (+ initSubscriptionAuthority when needed). The customer signs via wallet.
+ * mode returns a USDC transfer; subscription mode returns either
+ * initSubscriptionAuthority (first-time wallet) or subscribe.
  */
 router.post(
   '/:urlSlug/prepare',
@@ -146,11 +146,13 @@ router.post(
       signed_transaction: signedTransaction,
       already_subscribed: alreadySubscribed,
       subscription_delegation_pda: subscriptionDelegationPda,
+      subscription_step: subscriptionStep,
     } = req.body as {
       signature?: string;
       signed_transaction?: string;
       already_subscribed?: boolean;
       subscription_delegation_pda?: string;
+      subscription_step?: 'init_authority' | 'subscribe';
     };
 
     const session = await checkoutPaymentModule.ConfirmPayment(
@@ -160,6 +162,7 @@ router.post(
         signed_transaction: signedTransaction,
         already_subscribed: alreadySubscribed,
         subscription_delegation_pda: subscriptionDelegationPda,
+        subscription_step: subscriptionStep,
       }
     );
     res.json(session);

--- a/apps/api/src/routes/paymentPages.routes.ts
+++ b/apps/api/src/routes/paymentPages.routes.ts
@@ -12,6 +12,9 @@ import { ExternalWalletModule } from '../modules/ExternalWallet';
 import { PaymentIntentModule } from '../modules/PaymentIntent';
 import { ChargeModule } from '../modules/Charge';
 import { PaymentLinkModule } from '../modules/PaymentLink';
+import { InvoiceItemModule } from '../modules/InvoiceItem';
+import { InvoiceModule } from '../modules/Invoice';
+import { SubscriptionModule } from '../modules/Subscription';
 
 const router = express.Router();
 
@@ -41,6 +44,25 @@ const paymentLinkModule = new PaymentLinkModule(
   checkoutSessionModule
 );
 const externalWalletModule = new ExternalWalletModule(db, eventService);
+const invoiceItemModule = new InvoiceItemModule(
+  db,
+  eventService,
+  customerModule,
+  priceModule
+);
+const invoiceModule = new InvoiceModule(
+  db,
+  eventService,
+  customerModule,
+  invoiceItemModule
+);
+const subscriptionModule = new SubscriptionModule(
+  db,
+  eventService,
+  customerModule,
+  priceModule,
+  invoiceModule
+);
 const checkoutPaymentModule = new CheckoutPaymentModule(
   db,
   checkoutSessionModule,
@@ -48,7 +70,10 @@ const checkoutPaymentModule = new CheckoutPaymentModule(
   productModule,
   paymentIntentModule,
   chargeModule,
-  paymentLinkModule
+  paymentLinkModule,
+  undefined,
+  customerModule,
+  subscriptionModule
 );
 
 /**
@@ -86,9 +111,9 @@ router.get(
 
 /**
  * POST /v1/payment_pages/:urlSlug/prepare
- * Build an unsigned USDC payment transaction for the checkout session,
- * transferring the session total from the customer's wallet to the
- * merchant's wallet. The customer signs and broadcasts it via their wallet.
+ * Build an unsigned Solana transaction for the checkout session. Payment
+ * mode returns a USDC transfer; subscription mode returns subscribe
+ * (+ initSubscriptionAuthority when needed). The customer signs via wallet.
  */
 router.post(
   '/:urlSlug/prepare',
@@ -109,18 +134,33 @@ router.post(
 
 /**
  * POST /v1/payment_pages/:urlSlug/confirm
- * Verify a broadcast payment transaction on-chain and complete the checkout
- * session. Emits 'checkout.session.completed' on success. Idempotent: if the
- * session was already completed with the same signature, it is returned as-is.
+ * Verify a broadcast transaction on-chain and complete the checkout
+ * session. Subscription mode creates the off-chain Subscription and
+ * collects the first period (unless trialing). Idempotent on signature.
  */
 router.post(
   '/:urlSlug/confirm',
   AsyncHandler(async (req: express.Request, res: express.Response) => {
-    const { signature } = req.body as { signature?: string };
+    const {
+      signature,
+      signed_transaction: signedTransaction,
+      already_subscribed: alreadySubscribed,
+      subscription_delegation_pda: subscriptionDelegationPda,
+    } = req.body as {
+      signature?: string;
+      signed_transaction?: string;
+      already_subscribed?: boolean;
+      subscription_delegation_pda?: string;
+    };
 
     const session = await checkoutPaymentModule.ConfirmPayment(
       req.params.urlSlug,
-      signature
+      signature,
+      {
+        signed_transaction: signedTransaction,
+        already_subscribed: alreadySubscribed,
+        subscription_delegation_pda: subscriptionDelegationPda,
+      }
     );
     res.json(session);
   })

--- a/apps/web/src/app/core/services/wallet.service.ts
+++ b/apps/web/src/app/core/services/wallet.service.ts
@@ -81,9 +81,51 @@ export class SolanaWalletService {
     const result = await feature.signAndSendTransaction({
       account: connectedAccount,
       transaction: transactionBytes,
-      chain: 'solana:devnet', // match backend network
+      chain,
     });
     return result[0].signature;
+  }
+
+  /**
+   * Sign a (possibly partially signed) transaction without broadcasting.
+   * Used for fee-payer-sponsored subscribe txs that the API relays.
+   */
+  async SignUnsignedTransaction(
+    unsignedTxBase64: string,
+    chain: 'solana:devnet' | 'solana:mainnet' = 'solana:devnet'
+  ): Promise<Uint8Array> {
+    const selectedWallet = this.wallet();
+    const connectedAccount = this.account();
+    if (!selectedWallet || !connectedAccount) {
+      throw new Error('Connect wallet first');
+    }
+    const feature = selectedWallet.features['solana:signTransaction'] as
+      | {
+          signTransaction: (input: {
+            account: WalletAccount;
+            transaction: Uint8Array;
+            chain?: string;
+          }) => Promise<readonly { signedTransaction: Uint8Array }[]>;
+        }
+      | undefined;
+    if (!feature) {
+      throw new Error('Wallet does not support solana:signTransaction');
+    }
+    const transactionBytes = this.Base64ToBytes(unsignedTxBase64);
+    const result = await feature.signTransaction({
+      account: connectedAccount,
+      transaction: transactionBytes,
+      chain,
+    });
+    return result[0].signedTransaction;
+  }
+
+  BytesToBase64(bytes: Uint8Array): string {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 1) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
   }
 
   private Base64ToBytes(base64: string): Uint8Array {

--- a/apps/web/src/app/core/services/wallet.service.ts
+++ b/apps/web/src/app/core/services/wallet.service.ts
@@ -88,7 +88,7 @@ export class SolanaWalletService {
 
   /**
    * Sign a (possibly partially signed) transaction without broadcasting.
-   * Used for fee-payer-sponsored subscribe txs that the API relays.
+   * Used when TRANSACTION_FEE_PAYER_KEY sponsors fees and the API relays.
    */
   async SignUnsignedTransaction(
     unsignedTxBase64: string,

--- a/apps/web/src/app/data/services/checkout-session.service.ts
+++ b/apps/web/src/app/data/services/checkout-session.service.ts
@@ -17,6 +17,8 @@ export interface CheckoutPaymentTransaction {
   estimated_fee_lamports: number;
   blockhash: string;
   last_valid_block_height: number;
+  already_subscribed?: boolean;
+  subscription_delegation_pda?: string;
 }
 
 @Injectable({
@@ -137,17 +139,23 @@ export class CheckoutSessionService {
   }
 
   /**
-   * Confirm a broadcast payment transaction. The backend verifies it
-   * on-chain and completes the checkout session.
+   * Confirm a checkout transaction. One-time payments pass `signature`
+   * after the wallet broadcasts. Subscriptions pass `signed_transaction`
+   * for the API to broadcast (fee-payer sponsored).
    */
   async ConfirmPayment(
     urlSlug: string,
-    signature: string
+    payload: {
+      signature?: string;
+      signed_transaction?: string;
+      already_subscribed?: boolean;
+      subscription_delegation_pda?: string;
+    }
   ): Promise<CheckoutSession> {
     return this.api.Call<CheckoutSession>(
       'POST',
       `payment_pages/${urlSlug}/confirm`,
-      { signature }
+      payload
     );
   }
 }

--- a/apps/web/src/app/data/services/checkout-session.service.ts
+++ b/apps/web/src/app/data/services/checkout-session.service.ts
@@ -17,8 +17,10 @@ export interface CheckoutPaymentTransaction {
   estimated_fee_lamports: number;
   blockhash: string;
   last_valid_block_height: number;
+  fee_sponsored?: boolean;
   already_subscribed?: boolean;
   subscription_delegation_pda?: string;
+  subscription_step?: 'init_authority' | 'subscribe';
 }
 
 @Injectable({
@@ -139,9 +141,9 @@ export class CheckoutSessionService {
   }
 
   /**
-   * Confirm a checkout transaction. One-time payments pass `signature`
-   * after the wallet broadcasts. Subscriptions pass `signed_transaction`
-   * for the API to broadcast (fee-payer sponsored).
+   * Confirm a checkout transaction. Fee-sponsored flows pass
+   * `signed_transaction` for the API to cosign and broadcast; buyer-pays
+   * flows pass `signature` after the wallet has already sent the tx.
    */
   async ConfirmPayment(
     urlSlug: string,
@@ -150,6 +152,7 @@ export class CheckoutSessionService {
       signed_transaction?: string;
       already_subscribed?: boolean;
       subscription_delegation_pda?: string;
+      subscription_step?: 'init_authority' | 'subscribe';
     }
   ): Promise<CheckoutSession> {
     return this.api.Call<CheckoutSession>(

--- a/apps/web/src/app/features/checkout/checkout.component.html
+++ b/apps/web/src/app/features/checkout/checkout.component.html
@@ -22,8 +22,13 @@
         }
       </div>
 
-      <div class="summary-merchant">Pay {{ MerchantName() }}</div>
-      <div class="summary-total">{{ FormatAmount(session.amount_total) }}</div>
+      <div class="summary-merchant">{{ SummaryHeading() }}</div>
+      <div class="summary-total">
+        {{ FormatAmount(session.amount_total) }}
+        @if (IsSubscription() && RecurringIntervalLabel(); as cadence) {
+        <span class="summary-cadence">/ {{ cadence }}</span>
+        }
+      </div>
 
       <div class="line-items">
         @for (item of LineItems(); track item.id) {
@@ -39,6 +44,8 @@
             <div class="line-item-name">{{ item.description }}</div>
             @if ((item.quantity ?? 1) > 1) {
             <div class="line-item-quantity">Qty {{ item.quantity }}</div>
+            } @if (LineItemCadence(item); as cadence) {
+            <div class="line-item-quantity">Billed {{ cadence }}</div>
             }
           </div>
           <div class="line-item-amount">
@@ -72,7 +79,7 @@
         }
 
         <div class="summary-row summary-row-total">
-          <span>Total due</span>
+          <span>{{ TotalDueLabel() }}</span>
           <span>{{ FormatAmount(session.amount_total) }}</span>
         </div>
       </div>
@@ -104,11 +111,12 @@
           </label>
 
           <div class="method-detail">
-            <div class="method-detail-label">Paying with USDC on Solana to</div>
+            <div class="method-detail-label">{{ MethodDetailLabel() }}</div>
+            @if (!IsSubscription()) {
             <div class="wallet-address">{{ MerchantWalletAddress() }}</div>
+            }
             <div class="method-detail-help">
-              Connect your wallet and approve the payment of
-              {{ FormatAmount(session.amount_total) }} in USDC.
+              {{ MethodHelpText() }}
             </div>
           </div>
         </div>
@@ -143,8 +151,8 @@
       }
 
       <div class="fine-print">
-        By paying, you agree to {{ MerchantName() }}'s @if (MerchantTermsUrl();
-        as termsUrl) {
+        By {{ FinePrintVerb() }}, you agree to {{ MerchantName() }}'s @if
+        (MerchantTermsUrl(); as termsUrl) {
         <a [href]="termsUrl" target="_blank" rel="noopener">Terms</a>
         } @else {
         <a>Terms</a>

--- a/apps/web/src/app/features/checkout/checkout.component.scss
+++ b/apps/web/src/app/features/checkout/checkout.component.scss
@@ -92,6 +92,14 @@
   margin-bottom: $spacing-extra-large;
 }
 
+.summary-cadence {
+  font-family: inherit;
+  font-weight: $text-weight;
+  font-size: $font-size-med;
+  opacity: $dimmed-extra;
+  margin-left: $spacing-extra-small;
+}
+
 .line-items {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/app/features/checkout/checkout.component.ts
+++ b/apps/web/src/app/features/checkout/checkout.component.ts
@@ -141,9 +141,7 @@ export class CheckoutComponent implements OnInit {
         throw new Error('Connect a wallet to pay');
       }
 
-      const completedSession = this.IsSubscription()
-        ? await this.PaySubscription(session, payerWallet)
-        : await this.PayOneTime(session, payerWallet);
+      const completedSession = await this.PayWithWallet(session, payerWallet);
 
       this.checkoutSession.set(completedSession);
       this.paymentPhase.set('complete');
@@ -154,36 +152,18 @@ export class CheckoutComponent implements OnInit {
     }
   }
 
-  private async PayOneTime(
-    session: CheckoutSession,
-    payerWallet: string
-  ): Promise<CheckoutSession> {
-    const prepared = await this.checkoutSessionService.PreparePayment(
-      session.url_slug,
-      payerWallet,
-      this.email || undefined
-    );
-    const chain = session.livemode ? 'solana:mainnet' : 'solana:devnet';
-    const signatureBytes =
-      await this.solanaWalletService.SignAndSendUnsignedTransaction(
-        prepared.unsigned_transaction,
-        chain
-      );
-    this.paymentPhase.set('processing');
-    return this.checkoutSessionService.ConfirmPayment(session.url_slug, {
-      signature: bs58.encode(signatureBytes),
-    });
-  }
-
-  private async PaySubscription(
+  private async PayWithWallet(
     session: CheckoutSession,
     payerWallet: string
   ): Promise<CheckoutSession> {
     const chain = session.livemode ? 'solana:mainnet' : 'solana:devnet';
-
-    // One automatic retry if the blockhash expired while Phantom was open.
+    // First-time subscribers need init_authority then subscribe (2 wallet
+    // approvals). Allow a couple of blockhash retries on top of that.
+    const maxAttempts = this.IsSubscription() ? 5 : 2;
+    let initAuthorityDone = false;
     let lastError: unknown;
-    for (let attempt = 0; attempt < 2; attempt++) {
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
         this.paymentPhase.set('awaiting_wallet');
         const prepared = await this.checkoutSessionService.PreparePayment(
@@ -200,23 +180,22 @@ export class CheckoutComponent implements OnInit {
           });
         }
 
-        const signedTxBytes =
-          await this.solanaWalletService.SignUnsignedTransaction(
-            prepared.unsigned_transaction,
-            chain
-          );
-        this.paymentPhase.set('processing');
-        return await this.checkoutSessionService.ConfirmPayment(
-          session.url_slug,
-          {
-            signed_transaction:
-              this.solanaWalletService.BytesToBase64(signedTxBytes),
+        if (prepared.subscription_step === 'init_authority') {
+          if (initAuthorityDone) {
+            throw new Error(
+              'Subscription authority init did not land. Please try again.'
+            );
           }
-        );
+          await this.SignAndConfirmPrepared(session, prepared, chain);
+          initAuthorityDone = true;
+          continue;
+        }
+
+        return await this.SignAndConfirmPrepared(session, prepared, chain);
       } catch (error) {
         lastError = error;
         if (
-          attempt === 0 &&
+          this.IsSubscription() &&
           this.IsRetryableSubscribeBroadcastError(error)
         ) {
           continue;
@@ -225,6 +204,45 @@ export class CheckoutComponent implements OnInit {
       }
     }
     throw lastError;
+  }
+
+  private async SignAndConfirmPrepared(
+    session: CheckoutSession,
+    prepared: {
+      unsigned_transaction: string;
+      fee_sponsored?: boolean;
+      subscription_step?: 'init_authority' | 'subscribe';
+    },
+    chain: 'solana:mainnet' | 'solana:devnet'
+  ): Promise<CheckoutSession> {
+    if (prepared.fee_sponsored) {
+      const signedTxBytes =
+        await this.solanaWalletService.SignUnsignedTransaction(
+          prepared.unsigned_transaction,
+          chain
+        );
+      this.paymentPhase.set('processing');
+      return this.checkoutSessionService.ConfirmPayment(session.url_slug, {
+        signed_transaction:
+          this.solanaWalletService.BytesToBase64(signedTxBytes),
+        ...(prepared.subscription_step
+          ? { subscription_step: prepared.subscription_step }
+          : {}),
+      });
+    }
+
+    const signatureBytes =
+      await this.solanaWalletService.SignAndSendUnsignedTransaction(
+        prepared.unsigned_transaction,
+        chain
+      );
+    this.paymentPhase.set('processing');
+    return this.checkoutSessionService.ConfirmPayment(session.url_slug, {
+      signature: bs58.encode(signatureBytes),
+      ...(prepared.subscription_step
+        ? { subscription_step: prepared.subscription_step }
+        : {}),
+    });
   }
 
   private IsRetryableSubscribeBroadcastError(error: unknown): boolean {
@@ -320,8 +338,8 @@ export class CheckoutComponent implements OnInit {
     if (this.IsSubscription()) {
       const cadence = this.RecurringIntervalLabel();
       return cadence
-        ? `Connect your wallet to authorize recurring ${amount} USDC every ${cadence}. Network fees are covered for you.`
-        : `Connect your wallet to authorize this recurring USDC subscription. Network fees are covered for you.`;
+        ? `Connect your wallet to authorize recurring ${amount} USDC every ${cadence}. First-time wallets approve twice.`
+        : `Connect your wallet to authorize this recurring USDC subscription. First-time wallets approve twice.`;
     }
     return `Connect your wallet and approve the payment of ${amount} in USDC.`;
   }

--- a/apps/web/src/app/features/checkout/checkout.component.ts
+++ b/apps/web/src/app/features/checkout/checkout.component.ts
@@ -16,6 +16,7 @@ import { LoaderComponent, PageLoaderComponent } from '../../shared';
 import {
   CheckoutSession,
   CheckoutSessionLineItem,
+  Price,
   Product,
 } from '@zoneless/shared-types';
 
@@ -87,6 +88,34 @@ export class CheckoutComponent implements OnInit {
     return this.checkoutSession()?.merchant_wallet?.wallet_address ?? '';
   }
 
+  IsSubscription(): boolean {
+    return this.checkoutSession()?.mode === 'subscription';
+  }
+
+  RecurringIntervalLabel(): string | null {
+    const price = this.PrimaryPrice();
+    const interval = price?.recurring?.interval;
+    if (!interval) return null;
+    const count = price?.recurring?.interval_count ?? 1;
+    if (count === 1) return interval;
+    return `${count} ${interval}s`;
+  }
+
+  PrimaryPrice(): Price | null {
+    const price = this.LineItems()[0]?.price;
+    if (!price || typeof price === 'string') return null;
+    return price;
+  }
+
+  LineItemCadence(item: CheckoutSessionLineItem): string | null {
+    const price = item.price;
+    if (!price || typeof price === 'string' || !price.recurring) return null;
+    const count = price.recurring.interval_count ?? 1;
+    const interval = price.recurring.interval;
+    if (count === 1) return `every ${interval}`;
+    return `every ${count} ${interval}s`;
+  }
+
   IsBusy(): boolean {
     const phase = this.paymentPhase();
     return phase === 'awaiting_wallet' || phase === 'processing';
@@ -112,25 +141,9 @@ export class CheckoutComponent implements OnInit {
         throw new Error('Connect a wallet to pay');
       }
 
-      const prepared = await this.checkoutSessionService.PreparePayment(
-        session.url_slug,
-        payerWallet,
-        this.email || undefined
-      );
-
-      const signatureBytes =
-        await this.solanaWalletService.SignAndSendUnsignedTransaction(
-          prepared.unsigned_transaction,
-          session.livemode ? 'solana:mainnet' : 'solana:devnet'
-        );
-      const signature = bs58.encode(signatureBytes);
-
-      this.paymentPhase.set('processing');
-
-      const completedSession = await this.checkoutSessionService.ConfirmPayment(
-        session.url_slug,
-        signature
-      );
+      const completedSession = this.IsSubscription()
+        ? await this.PaySubscription(session, payerWallet)
+        : await this.PayOneTime(session, payerWallet);
 
       this.checkoutSession.set(completedSession);
       this.paymentPhase.set('complete');
@@ -139,6 +152,89 @@ export class CheckoutComponent implements OnInit {
       this.paymentError.set(this.ErrorMessage(error));
       this.paymentPhase.set('idle');
     }
+  }
+
+  private async PayOneTime(
+    session: CheckoutSession,
+    payerWallet: string
+  ): Promise<CheckoutSession> {
+    const prepared = await this.checkoutSessionService.PreparePayment(
+      session.url_slug,
+      payerWallet,
+      this.email || undefined
+    );
+    const chain = session.livemode ? 'solana:mainnet' : 'solana:devnet';
+    const signatureBytes =
+      await this.solanaWalletService.SignAndSendUnsignedTransaction(
+        prepared.unsigned_transaction,
+        chain
+      );
+    this.paymentPhase.set('processing');
+    return this.checkoutSessionService.ConfirmPayment(session.url_slug, {
+      signature: bs58.encode(signatureBytes),
+    });
+  }
+
+  private async PaySubscription(
+    session: CheckoutSession,
+    payerWallet: string
+  ): Promise<CheckoutSession> {
+    const chain = session.livemode ? 'solana:mainnet' : 'solana:devnet';
+
+    // One automatic retry if the blockhash expired while Phantom was open.
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        this.paymentPhase.set('awaiting_wallet');
+        const prepared = await this.checkoutSessionService.PreparePayment(
+          session.url_slug,
+          payerWallet,
+          this.email || undefined
+        );
+
+        if (prepared.already_subscribed) {
+          this.paymentPhase.set('processing');
+          return this.checkoutSessionService.ConfirmPayment(session.url_slug, {
+            already_subscribed: true,
+            subscription_delegation_pda: prepared.subscription_delegation_pda,
+          });
+        }
+
+        const signedTxBytes =
+          await this.solanaWalletService.SignUnsignedTransaction(
+            prepared.unsigned_transaction,
+            chain
+          );
+        this.paymentPhase.set('processing');
+        return await this.checkoutSessionService.ConfirmPayment(
+          session.url_slug,
+          {
+            signed_transaction:
+              this.solanaWalletService.BytesToBase64(signedTxBytes),
+          }
+        );
+      } catch (error) {
+        lastError = error;
+        if (
+          attempt === 0 &&
+          this.IsRetryableSubscribeBroadcastError(error)
+        ) {
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw lastError;
+  }
+
+  private IsRetryableSubscribeBroadcastError(error: unknown): boolean {
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof error === 'string'
+        ? error
+        : '';
+    return /blockhash not found|expired|already been processed/i.test(message);
   }
 
   private RedirectToSuccessUrl(session: CheckoutSession): void {
@@ -152,7 +248,9 @@ export class CheckoutComponent implements OnInit {
 
   private ErrorMessage(error: unknown): string {
     if (error instanceof Error && error.message) return error.message;
-    return 'Something went wrong processing your payment. Please try again.';
+    return this.IsSubscription()
+      ? 'Something went wrong starting your subscription. Please try again.'
+      : 'Something went wrong processing your payment. Please try again.';
   }
 
   LineItemImage(item: CheckoutSessionLineItem): string | null {
@@ -186,6 +284,7 @@ export class CheckoutComponent implements OnInit {
   }
 
   SubmitLabel(): string {
+    if (this.IsSubscription()) return 'Subscribe';
     switch (this.checkoutSession()?.submit_type) {
       case 'book':
         return 'Book';
@@ -202,5 +301,36 @@ export class CheckoutComponent implements OnInit {
     return this.paymentPhase() === 'awaiting_wallet'
       ? 'Confirm in wallet'
       : 'Processing';
+  }
+
+  SummaryHeading(): string {
+    return this.IsSubscription()
+      ? `Subscribe to ${this.MerchantName()}`
+      : `Pay ${this.MerchantName()}`;
+  }
+
+  MethodDetailLabel(): string {
+    return this.IsSubscription()
+      ? 'Subscribing with USDC on Solana'
+      : 'Paying with USDC on Solana to';
+  }
+
+  MethodHelpText(): string {
+    const amount = this.FormatAmount(this.checkoutSession()?.amount_total);
+    if (this.IsSubscription()) {
+      const cadence = this.RecurringIntervalLabel();
+      return cadence
+        ? `Connect your wallet to authorize recurring ${amount} USDC every ${cadence}. Network fees are covered for you.`
+        : `Connect your wallet to authorize this recurring USDC subscription. Network fees are covered for you.`;
+    }
+    return `Connect your wallet and approve the payment of ${amount} in USDC.`;
+  }
+
+  FinePrintVerb(): string {
+    return this.IsSubscription() ? 'subscribing' : 'paying';
+  }
+
+  TotalDueLabel(): string {
+    return this.IsSubscription() ? 'Total due today' : 'Total due';
   }
 }

--- a/libs/shared-types/src/lib/CheckoutSession.ts
+++ b/libs/shared-types/src/lib/CheckoutSession.ts
@@ -464,9 +464,9 @@ export interface CheckoutSession {
    * @zoneless_extension
    */
   payment_details?: {
-    /** The Solana transaction signature of the payment. */
-    transaction_signature: string;
-    /** The customer wallet that paid. */
+    /** The Solana transaction signature of the payment. Null after prepare, before confirm. */
+    transaction_signature: string | null;
+    /** The customer wallet that paid / subscribed. */
     payer_wallet: string | null;
   } | null;
 

--- a/libs/shared-types/src/lib/Subscription.ts
+++ b/libs/shared-types/src/lib/Subscription.ts
@@ -223,6 +223,13 @@ export interface Subscription {
    * @zoneless_extension
    */
   platform_account: string;
+
+  /**
+   * Solana subscriptions program delegation PDA for this subscription.
+   * Set when the customer completes hosted checkout subscribe.
+   * @zoneless_extension
+   */
+  subscription_delegation_pda: string | null;
 }
 
 /** A list of subscriptions. */


### PR DESCRIPTION
## Description

Adds recurring subscriptions via Solana's subscription plan program: https://solana.com/docs/payments/subscriptions/subscription-plan

Adds the option to set TRANSACTION_FEE_PAYER_KEY env variable as a hot wallet private key to pay for SOL transaction fee, or leave blank to let buyers absorb the fees.

Added SUBSCRIPTION_OPERATOR_KEY specifically for creating subscription plans and pulling subscriptions.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
