### PR TITLE
feat: collecting payments from subscriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,9 @@ LIVEMODE=
 # When set, buyers only co-sign; the API cosigns and broadcasts.
 # When unset, buyers pay fees via wallet signAndSend.
 # TRANSACTION_FEE_PAYER_KEY=
+
+# Subscription billing: in-process poller (single-instance Docker / local only).
+# Prefer POST /v1/billing/run_for_platform (platform API key) or, on managed
+# hosting, POST /v1/billing/run with x-operator-key via cron / Cloud Scheduler.
+# BILLING_MONITOR_ENABLED=false
+# BILLING_POLL_INTERVAL_MS=60000

--- a/.env.production.example
+++ b/.env.production.example
@@ -54,3 +54,9 @@ LIVEMODE=true
 # When set, buyers only co-sign; the API cosigns and broadcasts.
 # When unset, buyers pay fees via wallet signAndSend.
 # TRANSACTION_FEE_PAYER_KEY=
+
+# Subscription billing: leave the in-process poller off for Cloud Run.
+# Trigger POST /v1/billing/run from Cloud Scheduler with x-operator-key,
+# or POST /v1/billing/run_for_platform with a platform API key.
+# BILLING_MONITOR_ENABLED=false
+# BILLING_POLL_INTERVAL_MS=60000

--- a/apps/api/src/__tests__/Invoice.spec.ts
+++ b/apps/api/src/__tests__/Invoice.spec.ts
@@ -386,7 +386,7 @@ describe('InvoiceModule', () => {
 
   describe('FinalizeInvoice', () => {
     it('should move draft to open and emit invoice.finalized', async () => {
-      const existing = DraftInvoice({ number: null });
+      const existing = DraftInvoice({ number: null, amount_due: 0 });
       mockDb.Get = jest
         .fn()
         .mockResolvedValueOnce(existing)
@@ -418,10 +418,70 @@ describe('InvoiceModule', () => {
       expect(result.status).toBe('open');
     });
 
+    it('should create a PaymentIntent and confirmation_secret when amount_due > 0', async () => {
+      const existing = DraftInvoice({
+        number: null,
+        amount_due: 1099,
+        collection_method: 'charge_automatically',
+      });
+      const paymentIntentModule = {
+        CreatePaymentIntent: jest.fn().mockResolvedValue({
+          id: 'pi_z_1',
+          client_secret: 'pi_z_1_secret_abc',
+          amount: 1099,
+        }),
+      };
+
+      module = new InvoiceModule(
+        mockDb,
+        eventService,
+        customerModule,
+        invoiceItemModule,
+        paymentIntentModule as never
+      );
+
+      mockDb.Get = jest
+        .fn()
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce({
+          ...existing,
+          status: 'open',
+          confirmation_secret: {
+            type: 'payment_intent',
+            client_secret: 'pi_z_1_secret_abc',
+          },
+        });
+
+      await module.FinalizeInvoice(existing.id);
+
+      expect(paymentIntentModule.CreatePaymentIntent).toHaveBeenCalledWith(
+        PLATFORM,
+        expect.objectContaining({
+          amount: 1099,
+          currency: 'usdc',
+          customer: CUSTOMER_ID,
+        })
+      );
+      expect(mockDb.Update).toHaveBeenCalledWith(
+        'Invoices',
+        existing.id,
+        expect.objectContaining({
+          status: 'open',
+          confirmation_secret: {
+            type: 'payment_intent',
+            client_secret: 'pi_z_1_secret_abc',
+          },
+          payments: expect.objectContaining({
+            total_count: 1,
+          }),
+        })
+      );
+    });
+
     it('should reject finalizing a non-draft invoice', async () => {
       mockDb.Get = jest
         .fn()
-        .mockResolvedValue(DraftInvoice({ status: 'open' }));
+        .mockResolvedValue(DraftInvoice({ status: 'open', amount_due: 0 }));
 
       await expect(module.FinalizeInvoice('in_z_test001')).rejects.toThrow(
         "Cannot finalize invoice with status 'open'"
@@ -456,13 +516,13 @@ describe('InvoiceModule', () => {
   });
 
   describe('PayInvoice', () => {
-    it('should require paid_out_of_band for v1', async () => {
+    it('should require a PaymentIntent when not paid out of band', async () => {
       mockDb.Get = jest
         .fn()
-        .mockResolvedValue(DraftInvoice({ status: 'open' }));
+        .mockResolvedValue(DraftInvoice({ status: 'open', amount_due: 1099 }));
 
       await expect(module.PayInvoice('in_z_test001', {})).rejects.toThrow(
-        'Automatic invoice payment collection is not implemented yet'
+        'Invoice has no PaymentIntent'
       );
     });
 
@@ -507,6 +567,102 @@ describe('InvoiceModule', () => {
         PLATFORM,
         result
       );
+    });
+
+    it('should settle with settlement_signature and create charge', async () => {
+      const existing = DraftInvoice({
+        status: 'open',
+        amount_due: 1099,
+        amount_remaining: 1099,
+        payments: {
+          object: 'list',
+          data: [
+            {
+              id: 'inpay_z_1',
+              object: 'invoice_payment',
+              amount_paid: null,
+              amount_requested: 1099,
+              created: GetFixedTimestamp(),
+              currency: 'usdc',
+              invoice: 'in_z_test001',
+              is_default: true,
+              livemode: false,
+              payment: {
+                charge: null,
+                payment_intent: 'pi_z_1',
+                payment_record: null,
+                type: 'payment_intent',
+              },
+              status: 'open',
+              status_transitions: { canceled_at: null, paid_at: null },
+              platform_account: PLATFORM,
+            },
+          ],
+          has_more: false,
+          total_count: 1,
+          url: '/v1/invoices/in_z_test001/payments',
+        },
+      });
+
+      const paymentIntentModule = {
+        MarkSucceeded: jest.fn().mockResolvedValue({ id: 'pi_z_1' }),
+        MarkPaymentFailed: jest.fn(),
+      };
+      const chargeModule = {
+        CreateFromPaymentAttempt: jest.fn().mockResolvedValue({
+          id: 'ch_z_1',
+        }),
+        AttachBalanceTransaction: jest.fn().mockResolvedValue({
+          id: 'ch_z_1',
+          balance_transaction: 'txn_z_1',
+        }),
+      };
+
+      module = new InvoiceModule(
+        mockDb,
+        eventService,
+        customerModule,
+        invoiceItemModule,
+        paymentIntentModule as never,
+        chargeModule as never
+      );
+
+      const paidInvoice = {
+        ...existing,
+        status: 'paid' as const,
+        amount_paid: 1099,
+        amount_remaining: 0,
+        attempted: true,
+        next_payment_attempt: null,
+      };
+
+      mockDb.Get = jest
+        .fn()
+        .mockResolvedValueOnce(existing)
+        .mockImplementation(async (collection: string, id: string) => {
+          if (collection === 'Invoices' && id === existing.id) {
+            return paidInvoice;
+          }
+          return null;
+        }) as typeof mockDb.Get;
+
+      const result = await module.PayInvoice(existing.id, {
+        settlement_signature: 'sig_settled',
+      });
+
+      expect(chargeModule.CreateFromPaymentAttempt).toHaveBeenCalled();
+      expect(chargeModule.AttachBalanceTransaction).toHaveBeenCalledWith(
+        'ch_z_1',
+        expect.any(String)
+      );
+      expect(paymentIntentModule.MarkSucceeded).toHaveBeenCalledWith(
+        'pi_z_1',
+        expect.objectContaining({
+          amountReceived: 1099,
+          latestCharge: 'ch_z_1',
+        })
+      );
+      expect(result.status).toBe('paid');
     });
   });
 

--- a/apps/api/src/__tests__/Price.spec.ts
+++ b/apps/api/src/__tests__/Price.spec.ts
@@ -37,6 +37,21 @@ describe('PriceModule', () => {
     module = new PriceModule(mockDb, null, productModule);
   });
 
+  describe('PeriodToHours', () => {
+    it('should convert each recurring interval to hours', () => {
+      expect(module.PeriodToHours('hour')).toBe(1);
+      expect(module.PeriodToHours('day')).toBe(24);
+      expect(module.PeriodToHours('week')).toBe(168);
+      expect(module.PeriodToHours('month')).toBe(720);
+      expect(module.PeriodToHours('year')).toBe(8760);
+    });
+
+    it('should multiply by interval_count', () => {
+      expect(module.PeriodToHours('hour', 3)).toBe(3);
+      expect(module.PeriodToHours('day', 2)).toBe(48);
+    });
+  });
+
   describe('PriceObject', () => {
     it('should create a price with sensible defaults', () => {
       const price = module.PriceObject('acct_z_platform', {

--- a/apps/api/src/__tests__/SubscriptionBilling.spec.ts
+++ b/apps/api/src/__tests__/SubscriptionBilling.spec.ts
@@ -1,0 +1,234 @@
+import { SubscriptionBillingModule } from '../modules/SubscriptionBilling';
+import { SubscriptionModule } from '../modules/Subscription';
+import { InvoiceModule } from '../modules/Invoice';
+import { Database } from '../modules/Database';
+import { CreateMockDatabase, GetFixedTimestamp, ResetIdCounter } from './Setup';
+
+jest.mock('../modules/Database');
+jest.mock('../utils/Timestamp', () => ({
+  Now: jest.fn(() => GetFixedTimestamp()),
+}));
+jest.mock('../modules/AppConfig', () => ({
+  GetAppConfig: jest.fn(() => ({
+    dashboardUrl: 'http://localhost:4200',
+    livemode: false,
+    appSecret: 'test-secret',
+  })),
+}));
+
+const PLATFORM = 'acct_z_platform';
+const SUB_ID = 'sub_z_1';
+const INVOICE_ID = 'in_z_1';
+
+describe('SubscriptionBillingModule', () => {
+  let mockDb: jest.Mocked<Database>;
+  let subscriptionModule: jest.Mocked<SubscriptionModule>;
+  let invoiceModule: jest.Mocked<InvoiceModule>;
+  let module: SubscriptionBillingModule;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ResetIdCounter();
+    mockDb = CreateMockDatabase();
+
+    subscriptionModule = {
+      ClaimForBilling: jest.fn(),
+      ReleaseBillingLock: jest.fn(),
+      CreateCycleInvoice: jest.fn(),
+      AdvanceSubscriptionPeriod: jest.fn(),
+      MarkSubscriptionPastDue: jest.fn(),
+      MarkSubscriptionUnpaid: jest.fn(),
+    } as unknown as jest.Mocked<SubscriptionModule>;
+
+    invoiceModule = {
+      PayInvoice: jest.fn(),
+      MarkInvoiceUncollectible: jest.fn(),
+    } as unknown as jest.Mocked<InvoiceModule>;
+
+    module = new SubscriptionBillingModule(
+      mockDb,
+      subscriptionModule,
+      invoiceModule
+    );
+  });
+
+  it('should create a cycle invoice for a due subscription and advance on pay', async () => {
+    const now = GetFixedTimestamp();
+    mockDb.Query = jest
+      .fn()
+      .mockResolvedValueOnce([]) // retry invoices
+      .mockResolvedValueOnce([
+        {
+          id: 'si_z_1',
+          subscription: SUB_ID,
+          current_period_end: now - 10,
+          platform_account: PLATFORM,
+        },
+      ])
+      .mockResolvedValueOnce([]); // open cycle invoices
+
+    const claimed = {
+      id: SUB_ID,
+      platform_account: PLATFORM,
+      status: 'active',
+      collection_method: 'charge_automatically',
+      subscription_delegation_pda: 'SubPda111',
+      pause_collection: null,
+      items: {
+        object: 'list',
+        data: [
+          {
+            id: 'si_z_1',
+            current_period_start: now - 1000,
+            current_period_end: now - 10,
+          },
+        ],
+      },
+    };
+
+    subscriptionModule.ClaimForBilling.mockResolvedValue(claimed as never);
+    subscriptionModule.CreateCycleInvoice.mockResolvedValue({
+      id: INVOICE_ID,
+      status: 'paid',
+      attempt_count: 1,
+    } as never);
+    subscriptionModule.AdvanceSubscriptionPeriod.mockResolvedValue(
+      claimed as never
+    );
+
+    const result = await module.Run({ batchSize: 10 });
+
+    expect(subscriptionModule.CreateCycleInvoice).toHaveBeenCalledWith(
+      PLATFORM,
+      SUB_ID,
+      { finalize: true, collect: true }
+    );
+    expect(subscriptionModule.AdvanceSubscriptionPeriod).toHaveBeenCalledWith(
+      SUB_ID,
+      INVOICE_ID
+    );
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  it('should retry an open invoice when next_payment_attempt is due', async () => {
+    const now = GetFixedTimestamp();
+    mockDb.Query = jest
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: INVOICE_ID,
+          status: 'open',
+          attempt_count: 1,
+          next_payment_attempt: now - 1,
+          parent: {
+            subscription_details: { subscription: SUB_ID },
+          },
+          metadata: {},
+        },
+      ])
+      .mockResolvedValueOnce([]); // no further due items
+
+    const claimed = {
+      id: SUB_ID,
+      platform_account: PLATFORM,
+      status: 'past_due',
+      collection_method: 'charge_automatically',
+      subscription_delegation_pda: 'SubPda111',
+      items: { object: 'list', data: [] },
+    };
+
+    subscriptionModule.ClaimForBilling.mockResolvedValue(claimed as never);
+    invoiceModule.PayInvoice.mockResolvedValue({
+      id: INVOICE_ID,
+      status: 'paid',
+      attempt_count: 2,
+    } as never);
+    subscriptionModule.AdvanceSubscriptionPeriod.mockResolvedValue(
+      claimed as never
+    );
+
+    const result = await module.Run({ batchSize: 10 });
+
+    expect(invoiceModule.PayInvoice).toHaveBeenCalledWith(INVOICE_ID);
+    expect(subscriptionModule.AdvanceSubscriptionPeriod).toHaveBeenCalled();
+    expect(result.succeeded).toBe(1);
+  });
+
+  it('should mark unpaid after max payment attempts', async () => {
+    const now = GetFixedTimestamp();
+    mockDb.Query = jest
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: INVOICE_ID,
+          status: 'open',
+          attempt_count: 3,
+          next_payment_attempt: now - 1,
+          parent: {
+            subscription_details: { subscription: SUB_ID },
+          },
+          metadata: { last_payment_error: 'insufficient funds' },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const claimed = {
+      id: SUB_ID,
+      platform_account: PLATFORM,
+      status: 'past_due',
+      collection_method: 'charge_automatically',
+      subscription_delegation_pda: 'SubPda111',
+      items: { object: 'list', data: [] },
+    };
+
+    subscriptionModule.ClaimForBilling.mockResolvedValue(claimed as never);
+    invoiceModule.PayInvoice.mockResolvedValue({
+      id: INVOICE_ID,
+      status: 'open',
+      attempt_count: 4,
+      metadata: { last_payment_error: 'insufficient funds' },
+    } as never);
+    invoiceModule.MarkInvoiceUncollectible.mockResolvedValue({
+      id: INVOICE_ID,
+      status: 'uncollectible',
+    } as never);
+    subscriptionModule.MarkSubscriptionUnpaid.mockResolvedValue(
+      claimed as never
+    );
+
+    const result = await module.Run({ batchSize: 10 });
+
+    expect(invoiceModule.MarkInvoiceUncollectible).toHaveBeenCalledWith(
+      INVOICE_ID
+    );
+    expect(subscriptionModule.MarkSubscriptionUnpaid).toHaveBeenCalledWith(
+      SUB_ID,
+      INVOICE_ID
+    );
+    expect(result.failed).toBe(1);
+  });
+
+  it('should skip when claim lock is already held', async () => {
+    const now = GetFixedTimestamp();
+    mockDb.Query = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 'si_z_1',
+          subscription: SUB_ID,
+          current_period_end: now - 10,
+          platform_account: PLATFORM,
+        },
+      ]);
+
+    subscriptionModule.ClaimForBilling.mockResolvedValue(null);
+
+    const result = await module.Run({ batchSize: 10 });
+
+    expect(subscriptionModule.CreateCycleInvoice).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+    expect(result.processed).toBe(0);
+  });
+});

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -25,6 +25,7 @@ import {
 } from './modules/AppConfig';
 import { db } from './modules/Database';
 import { GetTopUpMonitor, TopUpMonitor } from './modules/TopUpMonitor';
+import { GetBillingMonitor, BillingMonitor } from './modules/BillingMonitor';
 import { AccountModule } from './modules/Account';
 import { ExternalWalletModule } from './modules/ExternalWallet';
 
@@ -197,6 +198,15 @@ async function StartServer() {
       }
     }
 
+    // Start Billing Monitor if enabled (single-instance only)
+    if (BillingMonitor.IsEnabled()) {
+      const billingMonitor = GetBillingMonitor(db);
+      billingMonitor.Start();
+      console.log(
+        `🧾 Billing Monitor started (interval ${BillingMonitor.GetPollInterval()}ms)`
+      );
+    }
+
     const server = app.listen(port, () => {
       console.log(`🚀 API running at http://localhost:${port}/v1`);
       console.log(`📊 Health check at http://localhost:${port}/api/health`);
@@ -224,6 +234,11 @@ async function StartServer() {
       if (TopUpMonitor.IsEnabled()) {
         const topUpMonitor = GetTopUpMonitor(db);
         topUpMonitor.Stop();
+      }
+
+      if (BillingMonitor.IsEnabled()) {
+        const billingMonitor = GetBillingMonitor(db);
+        billingMonitor.Stop();
       }
 
       server.close(async () => {

--- a/apps/api/src/modules/BillingMonitor.ts
+++ b/apps/api/src/modules/BillingMonitor.ts
@@ -1,0 +1,118 @@
+/**
+ * @fileOverview Billing Monitor - Polls for due subscription invoices
+ *
+ * Runs at regular intervals to create cycle invoices and collect Solana
+ * subscription payments. DISABLED by default for multi-instance deployments
+ * (e.g. Cloud Run). Prefer POST /v1/billing/run via Cloud Scheduler.
+ *
+ * To enable the in-process monitor (single-instance Docker / local):
+ *   BILLING_MONITOR_ENABLED=true
+ *
+ * @module BillingMonitor
+ */
+
+import { Database } from './Database';
+import {
+  BillingRunResult,
+  CreateSubscriptionBilling,
+  SubscriptionBillingModule,
+} from './SubscriptionBilling';
+import { Logger } from '../utils/Logger';
+
+const BILLING_POLL_INTERVAL_MS = parseInt(
+  process.env.BILLING_POLL_INTERVAL_MS || '60000',
+  10
+);
+const BILLING_MONITOR_ENABLED = process.env.BILLING_MONITOR_ENABLED === 'true';
+
+export class BillingMonitor {
+  private readonly billingModule: SubscriptionBillingModule;
+  private intervalId: NodeJS.Timeout | null = null;
+  private isRunning = false;
+  private isPolling = false;
+
+  constructor(db: Database, billingModule?: SubscriptionBillingModule) {
+    this.billingModule = billingModule ?? CreateSubscriptionBilling(db);
+  }
+
+  static IsEnabled(): boolean {
+    return BILLING_MONITOR_ENABLED;
+  }
+
+  static GetPollInterval(): number {
+    return BILLING_POLL_INTERVAL_MS;
+  }
+
+  Start(): void {
+    if (this.isRunning) {
+      Logger.warn('BillingMonitor is already running');
+      return;
+    }
+
+    if (!BillingMonitor.IsEnabled()) {
+      Logger.info('BillingMonitor is disabled via configuration');
+      return;
+    }
+
+    this.isRunning = true;
+    Logger.info('BillingMonitor started', {
+      pollInterval: BILLING_POLL_INTERVAL_MS,
+    });
+
+    this.Poll().catch((error) => {
+      Logger.error('BillingMonitor initial poll failed', error);
+    });
+
+    this.intervalId = setInterval(() => {
+      this.Poll().catch((error) => {
+        Logger.error('BillingMonitor poll failed', error);
+      });
+    }, BILLING_POLL_INTERVAL_MS);
+  }
+
+  Stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    this.isRunning = false;
+    Logger.info('BillingMonitor stopped');
+  }
+
+  IsRunning(): boolean {
+    return this.isRunning;
+  }
+
+  async ManualPoll(): Promise<BillingRunResult> {
+    return this.Poll();
+  }
+
+  private async Poll(): Promise<BillingRunResult> {
+    if (this.isPolling) {
+      Logger.debug('BillingMonitor poll already in progress, skipping');
+      return {
+        processed: 0,
+        succeeded: 0,
+        failed: 0,
+        skipped: 0,
+        errors: [],
+      };
+    }
+
+    this.isPolling = true;
+    try {
+      return await this.billingModule.Run();
+    } finally {
+      this.isPolling = false;
+    }
+  }
+}
+
+let monitorInstance: BillingMonitor | null = null;
+
+export function GetBillingMonitor(db: Database): BillingMonitor {
+  if (!monitorInstance) {
+    monitorInstance = new BillingMonitor(db);
+  }
+  return monitorInstance;
+}

--- a/apps/api/src/modules/CheckoutPayment.ts
+++ b/apps/api/src/modules/CheckoutPayment.ts
@@ -733,6 +733,9 @@ export class CheckoutPaymentModule {
           checkout_session: session.id,
           wallet_address: subscriberWallet,
         },
+      },
+      {
+        settlementSignature: !hasTrial ? collectionSignature : undefined,
       }
     );
 
@@ -754,19 +757,6 @@ export class CheckoutPaymentModule {
     if (completedSession.payment_link && this.paymentLinkModule) {
       await this.paymentLinkModule.RecordCompletedSession(
         completedSession.payment_link
-      );
-    }
-
-    if (
-      !hasTrial &&
-      collectionSignature !== signature &&
-      collectionSignature !== 'already_collected'
-    ) {
-      await this.RecordPaymentOnLedger(
-        completedSession,
-        price.unit_amount ?? session.amount_total!,
-        subscriberWallet,
-        collectionSignature
       );
     }
 

--- a/apps/api/src/modules/Database.ts
+++ b/apps/api/src/modules/Database.ts
@@ -46,6 +46,26 @@ export class Database {
   }
 
   /**
+   * Atomically find and update a document matching an arbitrary filter.
+   * Returns null when no document matches (e.g. claim already taken).
+   */
+  async FindOneAndUpdateByFilter<T>(
+    collection: string,
+    filter: Record<string, unknown>,
+    data: Record<string, unknown>,
+    session?: ClientSession
+  ): Promise<T | null> {
+    const model = this.GetModel(collection);
+    const options: mongoose.QueryOptions = { new: true };
+    if (session) options.session = session;
+    const result = await model
+      .findOneAndUpdate(filter, data, options)
+      .lean()
+      .exec();
+    return result ? this.StripMongoFields(result as T) : null;
+  }
+
+  /**
    * Add a new document with auto-generated MongoDB _id
    */
   async Add<T>(collection: string, data: Partial<T>): Promise<T> {

--- a/apps/api/src/modules/Invoice.ts
+++ b/apps/api/src/modules/Invoice.ts
@@ -3,6 +3,8 @@
  *
  * Invoices are statements of amounts owed by a customer. They contain invoice
  * items (and later, subscription line items / prorations). Settled in USDC.
+ * Finalizing a charge_automatically invoice creates a PaymentIntent; paying
+ * collects via Solana subscription pull (or paid_out_of_band).
  *
  * @module Invoice
  * @see https://docs.stripe.com/api/invoices
@@ -13,18 +15,29 @@ import { EventService } from './EventService';
 import { ExtractChangedFields } from './Event';
 import type { CustomerModule } from './Customer';
 import type { InvoiceItemModule } from './InvoiceItem';
+import type { PaymentIntentModule } from './PaymentIntent';
+import type { ChargeModule } from './Charge';
+import type { PriceModule } from './Price';
+import { BalanceModule } from './Balance';
+import { BalanceTransactionModule } from './BalanceTransaction';
+import { Solana, SolanaExplorerUrl } from './chains/Solana';
 import { GenerateId } from '../utils/IdGenerator';
 import {
+  BalanceTransaction as BalanceTransactionType,
   Customer as CustomerType,
   Invoice as InvoiceType,
   InvoiceBillingReason,
   InvoiceDeleted,
   InvoiceItem as InvoiceItemType,
   InvoiceLineItem,
+  InvoicePayment,
   InvoiceStatus,
+  Price as PriceType,
   QueryOperators,
+  Subscription as SubscriptionType,
+  SubscriptionItem as SubscriptionItemType,
 } from '@zoneless/shared-types';
-import { StripUndefined, ValidateUpdate } from './Util';
+import { StripUndefined, ValidateUpdate, ExpandableId } from './Util';
 import {
   CreateInvoiceSchema,
   CreateInvoiceInput,
@@ -41,6 +54,8 @@ import { Now } from '../utils/Timestamp';
 import { GetAppConfig } from './AppConfig';
 import { AppError } from '../utils/AppError';
 import { ERRORS } from '../utils/Errors';
+import { Logger } from '../utils/Logger';
+import { ClientSession } from 'mongoose';
 
 /** Fields that may only be changed while the invoice is a draft. */
 const DRAFT_ONLY_UPDATE_FIELDS = new Set([
@@ -55,18 +70,40 @@ const DRAFT_ONLY_UPDATE_FIELDS = new Set([
   'automatically_finalizes_at',
 ]);
 
+/** Max automatic payment attempts before the invoice is exhausted. */
+export const INVOICE_MAX_PAYMENT_ATTEMPTS = 4;
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+/** Delays after attempts 1, 2, and 3 before the next retry. */
+const RETRY_DELAYS_SECONDS = [
+  1 * SECONDS_PER_DAY,
+  3 * SECONDS_PER_DAY,
+  5 * SECONDS_PER_DAY,
+];
+
 export class InvoiceModule {
   private readonly db: Database;
   private readonly eventService: EventService | null;
   private readonly listHelper: ListHelper<InvoiceType>;
   private readonly customerModule: CustomerModule | null;
   private readonly invoiceItemModule: InvoiceItemModule | null;
+  private readonly paymentIntentModule: PaymentIntentModule | null;
+  private readonly chargeModule: ChargeModule | null;
+  private readonly priceModule: PriceModule | null;
+  private readonly balanceModule: BalanceModule;
+  private readonly balanceTransactionModule: BalanceTransactionModule;
+  private readonly solana: Solana;
 
   constructor(
     db: Database,
     eventService?: EventService,
     customerModule?: CustomerModule,
-    invoiceItemModule?: InvoiceItemModule
+    invoiceItemModule?: InvoiceItemModule,
+    paymentIntentModule?: PaymentIntentModule,
+    chargeModule?: ChargeModule,
+    priceModule?: PriceModule,
+    solana?: Solana
   ) {
     this.db = db;
     this.eventService = eventService || null;
@@ -79,6 +116,12 @@ export class InvoiceModule {
     });
     this.customerModule = customerModule || null;
     this.invoiceItemModule = invoiceItemModule || null;
+    this.paymentIntentModule = paymentIntentModule || null;
+    this.chargeModule = chargeModule || null;
+    this.priceModule = priceModule || null;
+    this.balanceModule = new BalanceModule(db);
+    this.balanceTransactionModule = new BalanceTransactionModule(db);
+    this.solana = solana || new Solana();
   }
 
   /**
@@ -383,6 +426,8 @@ export class InvoiceModule {
 
   /**
    * Finalize a draft invoice (draft → open).
+   * For charge_automatically invoices with amount_due > 0, creates a
+   * PaymentIntent and default InvoicePayment, and sets confirmation_secret.
    * Emits `invoice.finalized`.
    */
   async FinalizeInvoice(
@@ -410,6 +455,32 @@ export class InvoiceModule {
       last_finalization_error: null,
     };
 
+    if (
+      previous.collection_method === 'charge_automatically' &&
+      previous.amount_due > 0
+    ) {
+      const paymentIntent = await this.CreateInvoicePaymentIntent(previous);
+      const invoicePayment = this.BuildDefaultInvoicePayment(
+        previous,
+        paymentIntent.id,
+        paymentIntent.amount
+      );
+      updatePayload.confirmation_secret = {
+        type: 'payment_intent',
+        client_secret: paymentIntent.client_secret!,
+      };
+      updatePayload.payments = {
+        object: 'list',
+        data: [invoicePayment],
+        has_more: false,
+        total_count: 1,
+        url: `/v1/invoices/${previous.id}/payments`,
+      };
+      if (previous.collection_method === 'charge_automatically') {
+        updatePayload.next_payment_attempt = now;
+      }
+    }
+
     await this.db.Update<InvoiceType>('Invoices', id, updatePayload);
     const invoice = await this.RequireInvoice(id);
 
@@ -435,6 +506,7 @@ export class InvoiceModule {
     const now = Now();
     await this.db.Update<InvoiceType>('Invoices', id, {
       status: 'uncollectible',
+      next_payment_attempt: null,
       status_transitions: {
         ...previous.status_transitions,
         marked_uncollectible_at: now,
@@ -456,8 +528,10 @@ export class InvoiceModule {
 
   /**
    * Pay an invoice.
-   * v1: only `paid_out_of_band=true` is supported. Emits `invoice.paid` and
-   * `invoice.payment_succeeded`.
+   * Supports `paid_out_of_band`, zero-amount invoices, and automatic Solana
+   * subscription collection (or `settlement_signature` when already collected).
+   * Emits `invoice.paid` / `invoice.payment_succeeded` on success, or
+   * `invoice.payment_failed` on failure.
    */
   async PayInvoice(
     id: string,
@@ -467,45 +541,111 @@ export class InvoiceModule {
     const previous = await this.RequireInvoice(id);
     this.AssertStatus(previous, ['open', 'uncollectible'], 'pay');
 
-    if (!validatedInput.paid_out_of_band) {
+    if (validatedInput.paid_out_of_band) {
+      return this.MarkInvoicePaid(previous, {
+        amountPaidOffStripe: previous.amount_due,
+      });
+    }
+
+    if (previous.amount_due === 0) {
+      return this.MarkInvoicePaid(previous, { amountPaidOffStripe: 0 });
+    }
+
+    const paymentIntentId = this.GetDefaultPaymentIntentId(previous);
+    if (!paymentIntentId) {
       throw new AppError(
-        'Automatic invoice payment collection is not implemented yet. Pass `paid_out_of_band=true` to mark the invoice as paid outside of Zoneless.',
+        'Invoice has no PaymentIntent. Finalize the invoice before paying, or pass `paid_out_of_band=true`.',
         ERRORS.INVALID_REQUEST.status,
         ERRORS.INVALID_REQUEST.type
       );
     }
 
-    const now = Now();
-    await this.db.Update<InvoiceType>('Invoices', id, {
-      status: 'paid',
-      attempted: true,
-      attempt_count: previous.attempt_count + 1,
-      amount_paid: previous.amount_due,
-      amount_paid_off_stripe: previous.amount_due,
-      amount_remaining: 0,
-      amount_overpaid: 0,
-      status_transitions: {
-        ...previous.status_transitions,
-        paid_at: now,
-      },
-    });
-
-    const invoice = await this.RequireInvoice(id);
-
-    if (this.eventService) {
-      await this.eventService.Emit(
-        'invoice.paid',
-        invoice.platform_account,
-        invoice
+    try {
+      const settlement = await this.SettleInvoicePayment(
+        previous,
+        validatedInput.settlement_signature
       );
-      await this.eventService.Emit(
-        'invoice.payment_succeeded',
-        invoice.platform_account,
-        invoice
-      );
+
+      if (this.chargeModule && this.paymentIntentModule) {
+        const charge = await this.chargeModule.CreateFromPaymentAttempt(
+          previous.platform_account,
+          {
+            amount: previous.amount_due,
+            currency: previous.currency,
+            payment_intent: paymentIntentId,
+            payment_method:
+              previous.default_payment_method ??
+              settlement.subscriberWallet ??
+              null,
+            customer: ExpandableId(previous.customer),
+            description: previous.description,
+            metadata: previous.metadata ?? {},
+            crypto: {
+              buyer_address: settlement.subscriberWallet,
+              transaction_hash: settlement.signature,
+            },
+            outcome: 'succeeded',
+          }
+        );
+
+        await this.paymentIntentModule.MarkSucceeded(paymentIntentId, {
+          amountReceived: previous.amount_due,
+          latestCharge: charge.id,
+        });
+
+        await this.SyncInvoicePaymentPaid(
+          previous,
+          paymentIntentId,
+          charge.id,
+          previous.amount_due
+        );
+
+        const balanceTransaction = await this.RecordPaymentOnLedger(
+          previous,
+          settlement.subscriberWallet,
+          settlement.signature
+        );
+        await this.chargeModule.AttachBalanceTransaction(
+          charge.id,
+          balanceTransaction.id
+        );
+      }
+
+      return this.MarkInvoicePaid(previous, {
+        amountPaidOffStripe: 0,
+        paymentIntentId,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      Logger.warn('Invoice payment failed', {
+        invoiceId: previous.id,
+        error: message,
+      });
+
+      if (this.paymentIntentModule) {
+        try {
+          await this.paymentIntentModule.MarkPaymentFailed(paymentIntentId, {
+            advice_code: null,
+            charge: null,
+            code: 'payment_intent_payment_attempt_failed',
+            decline_code: null,
+            doc_url: null,
+            message,
+            network_advice_code: null,
+            network_decline_code: null,
+            param: null,
+            payment_method: null,
+            payment_method_type: 'crypto',
+            source: null,
+            type: 'invalid_request_error',
+          });
+        } catch {
+          // Best-effort PI failure update
+        }
+      }
+
+      return this.RecordInvoicePaymentFailure(previous, message);
     }
-
-    return invoice;
   }
 
   /**
@@ -519,6 +659,7 @@ export class InvoiceModule {
     const now = Now();
     await this.db.Update<InvoiceType>('Invoices', id, {
       status: 'void',
+      next_payment_attempt: null,
       status_transitions: {
         ...previous.status_transitions,
         voided_at: now,
@@ -571,10 +712,8 @@ export class InvoiceModule {
 
   /**
    * Create an invoice for a subscription, attach line items from subscription
-   * prices, optionally finalize, and optionally collect payment.
-   *
-   * Collection currently uses `paid_out_of_band` until PaymentIntent auto-pay /
-   * Solana USDC settlement is wired into finalize/pay.
+   * prices, optionally finalize, and optionally collect payment via Solana
+   * (or record an already-collected `settlementSignature`).
    */
   async CreateSubscriptionInvoice(
     platformAccountId: string,
@@ -595,6 +734,8 @@ export class InvoiceModule {
       }>;
       finalize?: boolean;
       collect?: boolean;
+      /** Skip on-chain collect; record this signature as settlement. */
+      settlementSignature?: string;
     }
   ): Promise<InvoiceType> {
     if (!this.invoiceItemModule) {
@@ -616,8 +757,14 @@ export class InvoiceModule {
       pending_invoice_items_behavior: 'exclude',
     });
 
+    const periodStart =
+      options.lineItems[0]?.period?.start ?? invoice.period_start;
+    const periodEnd = options.lineItems[0]?.period?.end ?? invoice.period_end;
+
     await this.db.Update<InvoiceType>('Invoices', invoice.id, {
       billing_reason: options.billing_reason,
+      period_start: periodStart,
+      period_end: periodEnd,
     });
 
     const createdItems: InvoiceItemType[] = [];
@@ -664,8 +811,9 @@ export class InvoiceModule {
     }
 
     if (options.collect && invoice.status === 'open') {
-      // TODO: Replace with PaymentIntent confirmation + Solana USDC settlement
-      invoice = await this.PayInvoice(invoice.id, { paid_out_of_band: true });
+      invoice = await this.PayInvoice(invoice.id, {
+        settlement_signature: options.settlementSignature,
+      });
     }
 
     return invoice;
@@ -1171,5 +1319,388 @@ export class InvoiceModule {
       );
     }
     return customer;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Settlement helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Credit the merchant platform balance after a successful on-chain invoice
+   * settlement. Idempotent per invoice id (source).
+   */
+  private async RecordPaymentOnLedger(
+    invoice: InvoiceType,
+    payerWallet: string | null,
+    signature: string
+  ): Promise<BalanceTransactionType> {
+    const existing = await this.db.Find2Custom<BalanceTransactionType>(
+      'BalanceTransactions',
+      'source',
+      '==',
+      invoice.id,
+      'type',
+      '==',
+      'payment'
+    );
+    if (existing.length > 0) return existing[0];
+
+    const merchantAccountId = invoice.platform_account;
+    const timestamp = Now();
+    const explorerUrl =
+      signature && signature !== 'already_collected'
+        ? SolanaExplorerUrl('tx', signature)
+        : '';
+
+    const balanceTransaction =
+      this.balanceTransactionModule.BalanceTransactionObject({
+        amount: invoice.amount_due,
+        currency: invoice.currency,
+        account: merchantAccountId,
+        platformAccountId: merchantAccountId,
+        type: 'payment',
+        source: invoice.id,
+        description: `Payment for Invoice ${invoice.id}`,
+        metadata: {
+          blockchain_tx: signature,
+          network: 'solana',
+          sender_address: payerWallet ?? '',
+          explorer_url: explorerUrl,
+        },
+        status: 'available',
+        available_on: timestamp,
+      });
+
+    const balanceData =
+      (await this.balanceModule.GetBalance(merchantAccountId)) ??
+      (await this.balanceModule.CreateBalance(merchantAccountId));
+
+    await this.db.RunTransaction(async (mongoSession: ClientSession) => {
+      await this.db.Set(
+        'BalanceTransactions',
+        balanceTransaction.id,
+        balanceTransaction,
+        mongoSession
+      );
+
+      const updatedBalance = this.balanceModule.UpdateBalance(
+        balanceData,
+        invoice.amount_due,
+        balanceTransaction.currency,
+        'available'
+      );
+      await this.db.Update(
+        'Balances',
+        updatedBalance.id,
+        { available: updatedBalance.available },
+        mongoSession
+      );
+    });
+
+    Logger.info('Recorded invoice payment on ledger', {
+      invoiceId: invoice.id,
+      balanceTransactionId: balanceTransaction.id,
+      amountCents: invoice.amount_due,
+    });
+
+    return balanceTransaction;
+  }
+
+  private async CreateInvoicePaymentIntent(invoice: InvoiceType) {
+    if (!this.paymentIntentModule) {
+      throw new AppError(
+        'PaymentIntentModule not configured for invoice finalization',
+        ERRORS.INTERNAL_ERROR.status,
+        ERRORS.INTERNAL_ERROR.type
+      );
+    }
+
+    const customerId = ExpandableId(invoice.customer)!;
+
+    const subscriptionId = ExpandableId(
+      invoice.parent?.subscription_details?.subscription
+    );
+
+    return this.paymentIntentModule.CreatePaymentIntent(
+      invoice.platform_account,
+      {
+        amount: invoice.amount_due,
+        currency: 'usdc',
+        customer: customerId,
+        description: invoice.description ?? `Invoice ${invoice.id}`,
+        payment_method: invoice.default_payment_method ?? undefined,
+        metadata: {
+          invoice: invoice.id,
+          ...(subscriptionId ? { subscription: subscriptionId } : {}),
+        },
+      }
+    );
+  }
+
+  private BuildDefaultInvoicePayment(
+    invoice: InvoiceType,
+    paymentIntentId: string,
+    amountRequested: number
+  ): InvoicePayment {
+    return {
+      id: GenerateId('inpay_z'),
+      object: 'invoice_payment',
+      amount_paid: null,
+      amount_requested: amountRequested,
+      created: Now(),
+      currency: 'usdc',
+      invoice: invoice.id,
+      is_default: true,
+      livemode: GetAppConfig().livemode,
+      payment: {
+        charge: null,
+        payment_intent: paymentIntentId,
+        payment_record: null,
+        type: 'payment_intent',
+      },
+      status: 'open',
+      status_transitions: {
+        canceled_at: null,
+        paid_at: null,
+      },
+      platform_account: invoice.platform_account,
+    };
+  }
+
+  private GetDefaultPaymentIntentId(invoice: InvoiceType): string | null {
+    const defaultPayment = invoice.payments?.data?.find((p) => p.is_default);
+    return ExpandableId(defaultPayment?.payment?.payment_intent ?? null);
+  }
+
+  private async SyncInvoicePaymentPaid(
+    invoice: InvoiceType,
+    paymentIntentId: string,
+    chargeId: string,
+    amountPaid: number
+  ): Promise<void> {
+    const payments = invoice.payments?.data ?? [];
+    const updated = payments.map((payment) => {
+      const pi = ExpandableId(payment.payment.payment_intent);
+      if (pi !== paymentIntentId) return payment;
+      return {
+        ...payment,
+        amount_paid: amountPaid,
+        status: 'paid' as const,
+        payment: {
+          ...payment.payment,
+          charge: chargeId,
+          payment_intent: paymentIntentId,
+          type: 'payment_intent' as const,
+        },
+        status_transitions: {
+          ...payment.status_transitions,
+          paid_at: Now(),
+        },
+      };
+    });
+
+    await this.db.Update<InvoiceType>('Invoices', invoice.id, {
+      payments: {
+        object: 'list',
+        data: updated,
+        has_more: false,
+        total_count: updated.length,
+        url: `/v1/invoices/${invoice.id}/payments`,
+      },
+    });
+  }
+
+  private async MarkInvoicePaid(
+    previous: InvoiceType,
+    options: {
+      amountPaidOffStripe: number;
+      paymentIntentId?: string;
+    }
+  ): Promise<InvoiceType> {
+    const now = Now();
+    await this.db.Update<InvoiceType>('Invoices', previous.id, {
+      status: 'paid',
+      attempted: true,
+      attempt_count: previous.attempt_count + 1,
+      amount_paid: previous.amount_due,
+      amount_paid_off_stripe: options.amountPaidOffStripe,
+      amount_remaining: 0,
+      amount_overpaid: 0,
+      next_payment_attempt: null,
+      status_transitions: {
+        ...previous.status_transitions,
+        paid_at: now,
+      },
+    });
+
+    const invoice = await this.RequireInvoice(previous.id);
+
+    if (this.eventService) {
+      await this.eventService.Emit(
+        'invoice.paid',
+        invoice.platform_account,
+        invoice
+      );
+      await this.eventService.Emit(
+        'invoice.payment_succeeded',
+        invoice.platform_account,
+        invoice
+      );
+    }
+
+    return invoice;
+  }
+
+  private async RecordInvoicePaymentFailure(
+    previous: InvoiceType,
+    message: string
+  ): Promise<InvoiceType> {
+    const now = Now();
+    const attemptCount = previous.attempt_count + 1;
+    const nextPaymentAttempt = this.ComputeNextPaymentAttempt(
+      attemptCount,
+      now
+    );
+
+    await this.db.Update<InvoiceType>('Invoices', previous.id, {
+      attempted: true,
+      attempt_count: attemptCount,
+      next_payment_attempt: nextPaymentAttempt,
+      metadata: {
+        ...(previous.metadata ?? {}),
+        last_payment_error: message.slice(0, 500),
+      },
+    });
+
+    const invoice = await this.RequireInvoice(previous.id);
+
+    if (this.eventService) {
+      await this.eventService.Emit(
+        'invoice.payment_failed',
+        invoice.platform_account,
+        invoice
+      );
+    }
+
+    return invoice;
+  }
+
+  ComputeNextPaymentAttempt(attemptCount: number, now: number): number | null {
+    if (attemptCount >= INVOICE_MAX_PAYMENT_ATTEMPTS) {
+      return null;
+    }
+    const delay = RETRY_DELAYS_SECONDS[attemptCount - 1];
+    if (delay === undefined) {
+      return null;
+    }
+    return now + delay;
+  }
+
+  private async SettleInvoicePayment(
+    invoice: InvoiceType,
+    settlementSignature?: string
+  ): Promise<{ signature: string; subscriberWallet: string | null }> {
+    if (settlementSignature) {
+      return {
+        signature: settlementSignature,
+        subscriberWallet: invoice.default_payment_method,
+      };
+    }
+
+    const subscriptionId = ExpandableId(
+      invoice.parent?.subscription_details?.subscription
+    );
+    if (!subscriptionId) {
+      throw new AppError(
+        'Automatic collection requires a subscription invoice, paid_out_of_band, or settlement_signature',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const subscription = await this.db.Get<SubscriptionType>(
+      'Subscriptions',
+      subscriptionId
+    );
+    if (!subscription) {
+      throw new AppError(
+        ERRORS.SUBSCRIPTION_NOT_FOUND.message,
+        ERRORS.SUBSCRIPTION_NOT_FOUND.status,
+        ERRORS.SUBSCRIPTION_NOT_FOUND.type
+      );
+    }
+
+    if (!subscription.subscription_delegation_pda) {
+      throw new Error(
+        'Subscription has no on-chain delegation PDA; cannot collect'
+      );
+    }
+
+    const items = await this.db.Find<SubscriptionItemType>(
+      'SubscriptionItems',
+      'subscription',
+      subscriptionId
+    );
+    if (items.length === 0) {
+      throw new Error('Subscription has no items to collect');
+    }
+
+    const priceId = ExpandableId(items[0].price)!;
+    const price = await this.ResolvePrice(
+      subscription.platform_account,
+      priceId
+    );
+    if (!price.subscription_plan_pda) {
+      throw new Error('Subscription price has no on-chain plan PDA');
+    }
+
+    const subscriberWallet =
+      subscription.default_payment_method ||
+      invoice.default_payment_method ||
+      subscription.metadata?.['wallet_address'] ||
+      null;
+    if (!subscriberWallet) {
+      throw new Error('Subscription has no subscriber wallet for collection');
+    }
+
+    const amountCents = invoice.amount_due;
+    const collection = await this.solana.CollectSubscriptionPayment({
+      subscriberWallet,
+      planPda: price.subscription_plan_pda,
+      subscriptionPda: subscription.subscription_delegation_pda,
+      amountCents,
+    });
+
+    return {
+      signature: collection.signature,
+      subscriberWallet,
+    };
+  }
+
+  private async ResolvePrice(
+    platformAccountId: string,
+    priceId: string
+  ): Promise<PriceType> {
+    if (this.priceModule) {
+      const price = await this.priceModule.GetPrice(priceId);
+      if (!price || price.platform_account !== platformAccountId) {
+        throw new AppError(
+          ERRORS.PRICE_NOT_FOUND.message,
+          ERRORS.PRICE_NOT_FOUND.status,
+          ERRORS.PRICE_NOT_FOUND.type
+        );
+      }
+      return price;
+    }
+
+    const price = await this.db.Get<PriceType>('Prices', priceId);
+    if (!price || price.platform_account !== platformAccountId) {
+      throw new AppError(
+        ERRORS.PRICE_NOT_FOUND.message,
+        ERRORS.PRICE_NOT_FOUND.status,
+        ERRORS.PRICE_NOT_FOUND.type
+      );
+    }
+    return price;
   }
 }

--- a/apps/api/src/modules/Price.ts
+++ b/apps/api/src/modules/Price.ts
@@ -8,7 +8,11 @@
 import { Database } from './Database';
 import { EventService } from './EventService';
 import { GenerateId } from '../utils/IdGenerator';
-import { Price as PriceType, QueryOperators } from '@zoneless/shared-types';
+import {
+  Price as PriceType,
+  QueryOperators,
+  RecurringInterval,
+} from '@zoneless/shared-types';
 import { ValidateUpdate } from './Util';
 import { ExtractChangedFields } from './Event';
 import { Solana } from './chains/Solana';
@@ -26,6 +30,7 @@ import { Now } from '../utils/Timestamp';
 import { GetAppConfig } from './AppConfig';
 import { AppError } from '../utils/AppError';
 import { ERRORS } from '../utils/Errors';
+import { RecurringIntervalToHours } from '../utils/RecurringInterval';
 export class PriceModule {
   private readonly db: Database;
   private readonly eventService: EventService | null;
@@ -115,7 +120,10 @@ export class PriceModule {
     ) {
       const solana = new Solana();
       const amount = price.unit_amount as number;
-      const periodHours = this.PeriodToHours(price.recurring.interval);
+      const periodHours = this.PeriodToHours(
+        price.recurring.interval,
+        price.recurring.interval_count
+      );
       const destinationAddress = await this.GetPlatformWalletPublicKey(
         price.platform_account
       );
@@ -168,17 +176,8 @@ export class PriceModule {
     return platformWallet.wallet_address;
   }
 
-  PeriodToHours(period: 'day' | 'week' | 'month' | 'year'): number {
-    switch (period) {
-      case 'day':
-        return 24;
-      case 'week':
-        return 24 * 7;
-      case 'month':
-        return 24 * 30;
-      case 'year':
-        return 24 * 365;
-    }
+  PeriodToHours(period: RecurringInterval, intervalCount = 1): number {
+    return RecurringIntervalToHours(period, intervalCount);
   }
 
   /**

--- a/apps/api/src/modules/Subscription.ts
+++ b/apps/api/src/modules/Subscription.ts
@@ -3,8 +3,7 @@
  *
  * Stripe-compatible subscription CRUD and lifecycle actions. Nested subscription
  * items are persisted in `SubscriptionItems`. Billing runs through invoices:
- * create → line items → finalize → collect (out-of-band until PaymentIntent /
- * Solana USDC settlement is wired). On-chain delegation is stubbed.
+ * create → line items → finalize → collect via PaymentIntent / Solana USDC.
  *
  * @module Subscription
  * @see https://docs.stripe.com/api/subscriptions
@@ -94,7 +93,8 @@ export class SubscriptionModule {
    */
   async CreateSubscription(
     platformAccountId: string,
-    input: CreateSubscriptionInput
+    input: CreateSubscriptionInput,
+    options?: { settlementSignature?: string }
   ): Promise<SubscriptionType> {
     const validatedInput = ValidateUpdate(CreateSubscriptionSchema, input);
 
@@ -151,9 +151,6 @@ export class SubscriptionModule {
 
     await this.db.Set('Subscriptions', subscription.id, subscription);
 
-    // TODO: Solana USDC delegation — approve/delegate for recurring pulls
-    await this.StubEnsureUsdcDelegation(id, customer.id);
-
     let latestInvoiceId: string | null = null;
 
     if (!trial.trial_end) {
@@ -168,6 +165,7 @@ export class SubscriptionModule {
             collect:
               collectionMethod === 'charge_automatically' &&
               paymentBehavior !== 'default_incomplete',
+            settlementSignature: options?.settlementSignature,
           }
         );
         latestInvoiceId = invoice.id;
@@ -487,7 +485,6 @@ export class SubscriptionModule {
     const now = Now();
 
     // TODO: Solana USDC — cancel on-chain delegation / subscription PDA
-    await this.StubCancelOnChainDelegation(id);
 
     let latestInvoiceId =
       typeof previous.latest_invoice === 'string'
@@ -853,6 +850,7 @@ export class SubscriptionModule {
       trial_start: timing.trialStart,
       platform_account: platformAccountId,
       subscription_delegation_pda: null,
+      billing_lock_until: null,
     };
   }
 
@@ -1350,7 +1348,11 @@ export class SubscriptionModule {
       | 'subscription_create'
       | 'subscription_update'
       | 'subscription_cycle',
-    options: { finalize: boolean; collect: boolean }
+    options: {
+      finalize: boolean;
+      collect: boolean;
+      settlementSignature?: string;
+    }
   ): Promise<InvoiceType> {
     if (!this.invoiceModule) {
       throw new AppError(
@@ -1390,6 +1392,178 @@ export class SubscriptionModule {
       lineItems,
       finalize: options.finalize,
       collect: options.collect,
+      settlementSignature: options.settlementSignature,
+    });
+  }
+
+  /**
+   * Create and optionally collect a subscription_cycle invoice for renewals.
+   */
+  async CreateCycleInvoice(
+    platformAccountId: string,
+    subscriptionId: string,
+    options: { finalize?: boolean; collect?: boolean } = {}
+  ): Promise<InvoiceType> {
+    const subscription = await this.RequireSubscription(subscriptionId);
+    const items = subscription.items.data;
+    return this.CreateAndProcessInvoice(
+      platformAccountId,
+      subscription,
+      items,
+      'subscription_cycle',
+      {
+        finalize: options.finalize ?? true,
+        collect: options.collect ?? true,
+      }
+    );
+  }
+
+  /**
+   * Advance each subscription item into the next billing period after a
+   * successful cycle payment. Clears the billing lock and sets status active.
+   */
+  async AdvanceSubscriptionPeriod(
+    subscriptionId: string,
+    latestInvoiceId?: string
+  ): Promise<SubscriptionType> {
+    const subscription = await this.RequireSubscription(subscriptionId);
+
+    for (const item of subscription.items.data) {
+      const price = await this.ResolvePrice(subscription.platform_account, {
+        price: typeof item.price === 'string' ? item.price : item.price.id,
+      } as CreateItemInput);
+      const periodStart = item.current_period_end;
+      const periodEnd = this.AddInterval(
+        periodStart,
+        price.recurring?.interval ?? 'month',
+        price.recurring?.interval_count ?? 1
+      );
+      await this.db.Update<SubscriptionItemType>('SubscriptionItems', item.id, {
+        current_period_start: periodStart,
+        current_period_end: periodEnd,
+      });
+    }
+
+    return this.UpdateSubscriptionBillingState(subscription, {
+      status: 'active',
+      latestInvoiceId,
+    });
+  }
+
+  /**
+   * Mark a subscription past_due after a failed invoice payment attempt.
+   */
+  async MarkSubscriptionPastDue(
+    subscriptionId: string,
+    latestInvoiceId?: string
+  ): Promise<SubscriptionType> {
+    const previous = await this.RequireSubscription(subscriptionId);
+    return this.UpdateSubscriptionBillingState(previous, {
+      status: 'past_due',
+      latestInvoiceId,
+    });
+  }
+
+  /**
+   * After payment retries are exhausted, mark the subscription unpaid.
+   */
+  async MarkSubscriptionUnpaid(
+    subscriptionId: string,
+    latestInvoiceId?: string
+  ): Promise<SubscriptionType> {
+    const previous = await this.RequireSubscription(subscriptionId);
+    return this.UpdateSubscriptionBillingState(previous, {
+      status: 'unpaid',
+      latestInvoiceId,
+    });
+  }
+
+  private async UpdateSubscriptionBillingState(
+    previous: SubscriptionType,
+    options: {
+      status: SubscriptionStatus;
+      latestInvoiceId?: string;
+    }
+  ): Promise<SubscriptionType> {
+    const updatePayload: Partial<SubscriptionType> = {
+      status: options.status,
+      billing_lock_until: null,
+    };
+    if (options.latestInvoiceId) {
+      updatePayload.latest_invoice = options.latestInvoiceId;
+    }
+
+    await this.db.Update<SubscriptionType>(
+      'Subscriptions',
+      previous.id,
+      updatePayload
+    );
+
+    const updated = await this.RequireSubscription(previous.id);
+
+    if (this.eventService) {
+      await this.eventService.Emit(
+        'customer.subscription.updated',
+        updated.platform_account,
+        updated,
+        {
+          previousAttributes: ExtractChangedFields(
+            previous as unknown as Record<string, unknown>,
+            updatePayload as Record<string, unknown>
+          ),
+        }
+      );
+    }
+
+    return updated;
+  }
+
+  /**
+   * Persist the on-chain subscription delegation PDA after a successful
+   * hosted checkout subscribe.
+   */
+  async SetSubscriptionDelegationPda(
+    id: string,
+    subscriptionDelegationPda: string
+  ): Promise<SubscriptionType> {
+    await this.RequireSubscription(id);
+    await this.db.Update<SubscriptionType>('Subscriptions', id, {
+      subscription_delegation_pda: subscriptionDelegationPda,
+    });
+    return this.RequireSubscription(id);
+  }
+
+  /**
+   * Atomically claim a subscription for billing work. Returns null if another
+   * runner already holds the lock.
+   */
+  async ClaimForBilling(
+    subscriptionId: string,
+    lockUntil: number
+  ): Promise<SubscriptionType | null> {
+    const now = Now();
+    const claimed = await this.db.FindOneAndUpdateByFilter<SubscriptionType>(
+      'Subscriptions',
+      {
+        id: subscriptionId,
+        $or: [
+          { billing_lock_until: null },
+          { billing_lock_until: { $exists: false } },
+          { billing_lock_until: { $lte: now } },
+        ],
+      },
+      { $set: { billing_lock_until: lockUntil } }
+    );
+    if (!claimed) {
+      return null;
+    }
+    claimed.items = await this.LoadItemsList(subscriptionId);
+    return claimed;
+  }
+
+  async ReleaseBillingLock(subscriptionId: string): Promise<void> {
+    await this.db.Update<SubscriptionType>('Subscriptions', subscriptionId, {
+      billing_lock_until: null,
     });
   }
 
@@ -1412,62 +1586,6 @@ export class SubscriptionModule {
     }
     await this.DeleteItems(items.map((item) => item.id));
     await this.db.Delete('Subscriptions', subscriptionId);
-  }
-
-  /**
-   * Persist the on-chain subscription delegation PDA after a successful
-   * hosted checkout subscribe.
-   */
-  async SetSubscriptionDelegationPda(
-    id: string,
-    subscriptionDelegationPda: string
-  ): Promise<SubscriptionType> {
-    const subscription = await this.GetSubscription(id);
-    if (!subscription) {
-      throw new AppError(
-        ERRORS.SUBSCRIPTION_NOT_FOUND.message,
-        ERRORS.SUBSCRIPTION_NOT_FOUND.status,
-        ERRORS.SUBSCRIPTION_NOT_FOUND.type
-      );
-    }
-
-    await this.db.Update<SubscriptionType>('Subscriptions', id, {
-      subscription_delegation_pda: subscriptionDelegationPda,
-    });
-
-    const updated = await this.GetSubscription(id);
-    if (!updated) {
-      throw new AppError(
-        ERRORS.SUBSCRIPTION_NOT_FOUND.message,
-        ERRORS.SUBSCRIPTION_NOT_FOUND.status,
-        ERRORS.SUBSCRIPTION_NOT_FOUND.type
-      );
-    }
-    return updated;
-  }
-
-  // ───────────────────────────────────────────────────────────────────────────
-  // Solana stubs
-  // ───────────────────────────────────────────────────────────────────────────
-
-  /**
-   * TODO: Solana USDC delegation — approve/delegate for recurring pulls via the
-   * official Solana subscriptions program.
-   */
-  private async StubEnsureUsdcDelegation(
-    _subscriptionId: string,
-    _customerId: string
-  ): Promise<void> {
-    return;
-  }
-
-  /**
-   * TODO: Solana USDC — cancel on-chain delegation / subscription account.
-   */
-  private async StubCancelOnChainDelegation(
-    _subscriptionId: string
-  ): Promise<void> {
-    return;
   }
 
   // ───────────────────────────────────────────────────────────────────────────

--- a/apps/api/src/modules/Subscription.ts
+++ b/apps/api/src/modules/Subscription.ts
@@ -48,11 +48,14 @@ import {
   UpdateSubscriptionSchema,
 } from '@zoneless/shared-schemas';
 import { z } from 'zod';
+import {
+  AddRecurringInterval,
+  SECONDS_PER_DAY,
+} from '../utils/RecurringInterval';
 
 type CreateItemInput = z.infer<typeof SubscriptionCreateItemSchema>;
 type UpdateItemInput = z.infer<typeof SubscriptionUpdateItemSchema>;
 
-const SECONDS_PER_DAY = 24 * 60 * 60;
 const THREE_DAYS_SECONDS = 3 * SECONDS_PER_DAY;
 
 export class SubscriptionModule {
@@ -1054,7 +1057,7 @@ export class SubscriptionModule {
     periodStart: number
   ): Promise<SubscriptionItemType> {
     const price = await this.ResolvePrice(platformAccountId, itemInput);
-    const periodEnd = this.AddInterval(
+    const periodEnd = AddRecurringInterval(
       periodStart,
       price.recurring?.interval ?? 'month',
       price.recurring?.interval_count ?? 1
@@ -1322,20 +1325,6 @@ export class SubscriptionModule {
     return trialEnd - now <= THREE_DAYS_SECONDS;
   }
 
-  private AddInterval(
-    start: number,
-    interval: 'day' | 'week' | 'month' | 'year',
-    intervalCount: number
-  ): number {
-    const multipliers: Record<typeof interval, number> = {
-      day: SECONDS_PER_DAY,
-      week: 7 * SECONDS_PER_DAY,
-      month: 30 * SECONDS_PER_DAY,
-      year: 365 * SECONDS_PER_DAY,
-    };
-    return start + multipliers[interval] * intervalCount;
-  }
-
   // ───────────────────────────────────────────────────────────────────────────
   // Invoicing
   // ───────────────────────────────────────────────────────────────────────────
@@ -1433,7 +1422,7 @@ export class SubscriptionModule {
         price: typeof item.price === 'string' ? item.price : item.price.id,
       } as CreateItemInput);
       const periodStart = item.current_period_end;
-      const periodEnd = this.AddInterval(
+      const periodEnd = AddRecurringInterval(
         periodStart,
         price.recurring?.interval ?? 'month',
         price.recurring?.interval_count ?? 1

--- a/apps/api/src/modules/SubscriptionBilling.ts
+++ b/apps/api/src/modules/SubscriptionBilling.ts
@@ -1,0 +1,443 @@
+/**
+ * @fileOverview Subscription billing runner
+ *
+ * Finds due subscriptions, claims them atomically, creates cycle invoices (or
+ * retries open invoices), collects via Invoice → PaymentIntent → Solana, then
+ * advances periods or marks past_due / unpaid.
+ *
+ * Safe for multi-instance deployments (Cloud Run) via billing_lock_until claims.
+ *
+ * @module SubscriptionBilling
+ */
+
+import { Database } from './Database';
+import { EventService } from './EventService';
+import { SubscriptionModule } from './Subscription';
+import { InvoiceModule, INVOICE_MAX_PAYMENT_ATTEMPTS } from './Invoice';
+import { CustomerModule } from './Customer';
+import { PriceModule } from './Price';
+import { ProductModule } from './Product';
+import { InvoiceItemModule } from './InvoiceItem';
+import { PaymentIntentModule } from './PaymentIntent';
+import { ChargeModule } from './Charge';
+import {
+  Invoice as InvoiceType,
+  QueryOperators,
+  Subscription as SubscriptionType,
+  SubscriptionItem as SubscriptionItemType,
+} from '@zoneless/shared-types';
+import { Now } from '../utils/Timestamp';
+import { Logger } from '../utils/Logger';
+import { ExpandableId } from './Util';
+
+const DEFAULT_BATCH_SIZE = 25;
+const BILLING_LOCK_SECONDS = 5 * 60;
+
+type QueryParam = {
+  key: string;
+  operator: (typeof QueryOperators)[keyof typeof QueryOperators];
+  value: unknown;
+};
+
+export interface BillingRunResult {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+  errors: Array<{ subscription: string; error: string }>;
+}
+
+/**
+ * Wire Invoice + Subscription once for billing (routes / monitor / tests).
+ */
+export function CreateSubscriptionBilling(
+  db: Database
+): SubscriptionBillingModule {
+  const eventService = new EventService(db);
+  const customerModule = new CustomerModule(db, eventService);
+  const productModule = new ProductModule(db, eventService);
+  const priceModule = new PriceModule(db, eventService, productModule);
+  const paymentIntentModule = new PaymentIntentModule(
+    db,
+    eventService,
+    customerModule
+  );
+  const chargeModule = new ChargeModule(db, eventService, customerModule);
+  const invoiceItemModule = new InvoiceItemModule(
+    db,
+    eventService,
+    customerModule,
+    priceModule
+  );
+  const invoiceModule = new InvoiceModule(
+    db,
+    eventService,
+    customerModule,
+    invoiceItemModule,
+    paymentIntentModule,
+    chargeModule,
+    priceModule
+  );
+  const subscriptionModule = new SubscriptionModule(
+    db,
+    eventService,
+    customerModule,
+    priceModule,
+    invoiceModule
+  );
+  return new SubscriptionBillingModule(db, subscriptionModule, invoiceModule);
+}
+
+export class SubscriptionBillingModule {
+  private readonly db: Database;
+  private readonly subscriptionModule: SubscriptionModule;
+  private readonly invoiceModule: InvoiceModule;
+
+  constructor(
+    db: Database,
+    subscriptionModule: SubscriptionModule,
+    invoiceModule: InvoiceModule
+  ) {
+    this.db = db;
+    this.subscriptionModule = subscriptionModule;
+    this.invoiceModule = invoiceModule;
+  }
+
+  /**
+   * Run one billing pass: process due renewals and invoice retries.
+   */
+  async Run(
+    options: {
+      platformAccountId?: string;
+      batchSize?: number;
+    } = {}
+  ): Promise<BillingRunResult> {
+    const batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+    const now = Now();
+    const result: BillingRunResult = {
+      processed: 0,
+      succeeded: 0,
+      failed: 0,
+      skipped: 0,
+      errors: [],
+    };
+
+    const retryInvoices = await this.FindRetryInvoices(
+      now,
+      options.platformAccountId,
+      batchSize
+    );
+    for (const invoice of retryInvoices) {
+      if (result.processed >= batchSize) break;
+      const subscriptionId = ExpandableId(
+        invoice.parent?.subscription_details?.subscription
+      );
+      if (!subscriptionId) {
+        result.skipped += 1;
+        continue;
+      }
+      await this.WithBillingClaim(subscriptionId, result, async (claimed) => {
+        const paid = await this.invoiceModule.PayInvoice(invoice.id);
+        await this.HandleInvoiceOutcome(claimed, paid, result);
+      });
+    }
+
+    const remaining = batchSize - result.processed;
+    if (remaining <= 0) {
+      return this.Finish(result);
+    }
+
+    const dueSubscriptionIds = await this.FindDueSubscriptionIds(
+      now,
+      options.platformAccountId,
+      remaining * 2
+    );
+
+    for (const subscriptionId of dueSubscriptionIds) {
+      if (result.processed >= batchSize) break;
+      await this.WithBillingClaim(subscriptionId, result, async (claimed) => {
+        await this.CollectOrCreateCycleInvoice(claimed, result);
+      });
+    }
+
+    return this.Finish(result);
+  }
+
+  private Finish(result: BillingRunResult): BillingRunResult {
+    Logger.info('Subscription billing run completed', {
+      processed: result.processed,
+      succeeded: result.succeeded,
+      failed: result.failed,
+      skipped: result.skipped,
+      errorCount: result.errors.length,
+    });
+    return result;
+  }
+
+  /**
+   * Claim → eligibility checks → work. Shared by retries and new cycles.
+   */
+  private async WithBillingClaim(
+    subscriptionId: string,
+    result: BillingRunResult,
+    work: (claimed: SubscriptionType) => Promise<void>
+  ): Promise<void> {
+    const claimed = await this.subscriptionModule.ClaimForBilling(
+      subscriptionId,
+      Now() + BILLING_LOCK_SECONDS
+    );
+    if (!claimed) {
+      result.skipped += 1;
+      return;
+    }
+
+    result.processed += 1;
+
+    try {
+      if (!this.CanAutoCollect(claimed)) {
+        result.skipped += 1;
+        await this.subscriptionModule.ReleaseBillingLock(subscriptionId);
+        return;
+      }
+      await work(claimed);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.failed += 1;
+      result.errors.push({ subscription: subscriptionId, error: message });
+      try {
+        await this.subscriptionModule.MarkSubscriptionPastDue(subscriptionId);
+      } catch {
+        await this.subscriptionModule.ReleaseBillingLock(subscriptionId);
+      }
+    }
+  }
+
+  private CanAutoCollect(subscription: SubscriptionType): boolean {
+    if (
+      !subscription.subscription_delegation_pda ||
+      subscription.collection_method !== 'charge_automatically' ||
+      subscription.pause_collection
+    ) {
+      return false;
+    }
+    if (
+      subscription.status !== 'active' &&
+      subscription.status !== 'past_due' &&
+      subscription.status !== 'trialing'
+    ) {
+      return false;
+    }
+    if (
+      subscription.status === 'trialing' &&
+      subscription.trial_end &&
+      subscription.trial_end > Now()
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  private async CollectOrCreateCycleInvoice(
+    claimed: SubscriptionType,
+    result: BillingRunResult
+  ): Promise<void> {
+    const openCycle = await this.FindOpenCycleInvoice(claimed);
+    if (openCycle) {
+      if (
+        openCycle.next_payment_attempt &&
+        openCycle.next_payment_attempt > Now()
+      ) {
+        result.skipped += 1;
+        await this.subscriptionModule.ReleaseBillingLock(claimed.id);
+        return;
+      }
+      const paid = await this.invoiceModule.PayInvoice(openCycle.id);
+      await this.HandleInvoiceOutcome(claimed, paid, result);
+      return;
+    }
+
+    const minPeriodEnd = Math.min(
+      ...claimed.items.data.map((item) => item.current_period_end)
+    );
+    const dueForTrialEnd =
+      claimed.status === 'trialing' &&
+      !!claimed.trial_end &&
+      claimed.trial_end <= Now();
+    if (minPeriodEnd > Now() && !dueForTrialEnd) {
+      result.skipped += 1;
+      await this.subscriptionModule.ReleaseBillingLock(claimed.id);
+      return;
+    }
+
+    const invoice = await this.subscriptionModule.CreateCycleInvoice(
+      claimed.platform_account,
+      claimed.id,
+      { finalize: true, collect: true }
+    );
+    await this.HandleInvoiceOutcome(claimed, invoice, result);
+  }
+
+  private async FindRetryInvoices(
+    now: number,
+    platformAccountId: string | undefined,
+    limit: number
+  ): Promise<InvoiceType[]> {
+    return this.db.Query<InvoiceType>({
+      collection: 'Invoices',
+      method: 'READ',
+      parameters: this.WithPlatformFilter(
+        [
+          { key: 'status', operator: QueryOperators['=='], value: 'open' },
+          {
+            key: 'collection_method',
+            operator: QueryOperators['=='],
+            value: 'charge_automatically',
+          },
+          {
+            key: 'next_payment_attempt',
+            operator: QueryOperators['<='],
+            value: now,
+          },
+          {
+            key: 'billing_reason',
+            operator: QueryOperators['in'],
+            value: [
+              'subscription_cycle',
+              'subscription_create',
+              'subscription_update',
+            ],
+          },
+        ],
+        platformAccountId
+      ),
+      orderBy: [{ key: 'next_payment_attempt', direction: 'asc' }],
+      limit,
+    });
+  }
+
+  private async FindDueSubscriptionIds(
+    now: number,
+    platformAccountId: string | undefined,
+    limit: number
+  ): Promise<string[]> {
+    const items =
+      (await this.db.Query<SubscriptionItemType>({
+        collection: 'SubscriptionItems',
+        method: 'READ',
+        parameters: this.WithPlatformFilter(
+          [
+            {
+              key: 'current_period_end',
+              operator: QueryOperators['<='],
+              value: now,
+            },
+          ],
+          platformAccountId
+        ),
+        orderBy: [{ key: 'current_period_end', direction: 'asc' }],
+        limit,
+      })) ?? [];
+
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    for (const item of items) {
+      if (seen.has(item.subscription)) continue;
+      seen.add(item.subscription);
+      ids.push(item.subscription);
+    }
+    return ids;
+  }
+
+  private WithPlatformFilter(
+    parameters: QueryParam[],
+    platformAccountId: string | undefined
+  ): QueryParam[] {
+    if (!platformAccountId) return parameters;
+    return [
+      ...parameters,
+      {
+        key: 'platform_account',
+        operator: QueryOperators['=='],
+        value: platformAccountId,
+      },
+    ];
+  }
+
+  private async HandleInvoiceOutcome(
+    subscription: SubscriptionType,
+    invoice: InvoiceType,
+    result: BillingRunResult
+  ): Promise<void> {
+    if (invoice.status === 'paid') {
+      await this.subscriptionModule.AdvanceSubscriptionPeriod(
+        subscription.id,
+        invoice.id
+      );
+      result.succeeded += 1;
+      return;
+    }
+
+    if (
+      invoice.status === 'open' &&
+      invoice.attempt_count >= INVOICE_MAX_PAYMENT_ATTEMPTS
+    ) {
+      await this.invoiceModule.MarkInvoiceUncollectible(invoice.id);
+      await this.subscriptionModule.MarkSubscriptionUnpaid(
+        subscription.id,
+        invoice.id
+      );
+      result.failed += 1;
+      result.errors.push({
+        subscription: subscription.id,
+        error: 'Payment retries exhausted',
+      });
+      return;
+    }
+
+    await this.subscriptionModule.MarkSubscriptionPastDue(
+      subscription.id,
+      invoice.id
+    );
+    result.failed += 1;
+    result.errors.push({
+      subscription: subscription.id,
+      error:
+        invoice.metadata?.['last_payment_error'] ?? 'Invoice payment failed',
+    });
+  }
+
+  private async FindOpenCycleInvoice(
+    subscription: SubscriptionType
+  ): Promise<InvoiceType | null> {
+    const invoices = await this.db.Query<InvoiceType>({
+      collection: 'Invoices',
+      method: 'READ',
+      parameters: [
+        {
+          key: 'parent.subscription_details.subscription',
+          operator: QueryOperators['=='],
+          value: subscription.id,
+        },
+        { key: 'status', operator: QueryOperators['=='], value: 'open' },
+      ],
+      orderBy: [{ key: 'created', direction: 'desc' }],
+      limit: 5,
+    });
+
+    const periodStart = Math.min(
+      ...subscription.items.data.map((item) => item.current_period_start)
+    );
+    const periodEnd = Math.min(
+      ...subscription.items.data.map((item) => item.current_period_end)
+    );
+
+    return (
+      invoices.find(
+        (invoice) =>
+          invoice.billing_reason === 'subscription_cycle' ||
+          invoice.period_end === periodEnd ||
+          invoice.period_start === periodStart
+      ) ?? null
+    );
+  }
+}

--- a/apps/api/src/modules/Util.ts
+++ b/apps/api/src/modules/Util.ts
@@ -72,3 +72,13 @@ export function StripUndefined<T extends Record<string, unknown>>(
   }
   return result;
 }
+
+/**
+ * Resolve a Stripe-style expandable field to its id string.
+ */
+export function ExpandableId(
+  value: string | { id: string } | null | undefined
+): string | null {
+  if (!value) return null;
+  return typeof value === 'string' ? value : value.id;
+}

--- a/apps/api/src/routes/billing.routes.ts
+++ b/apps/api/src/routes/billing.routes.ts
@@ -1,0 +1,84 @@
+/**
+ * @fileOverview Billing run routes
+ *
+ * Triggers subscription cycle collection. Intended for Cloud Scheduler /
+ * host cron. Auth: operator key (all platforms) or platform API key (scoped).
+ */
+
+import * as express from 'express';
+import { AsyncHandler } from '../utils/AsyncHandler';
+import { Logger } from '../utils/Logger';
+import { db } from '../modules/Database';
+import { CreateSubscriptionBilling } from '../modules/SubscriptionBilling';
+import { GetBillingMonitor, BillingMonitor } from '../modules/BillingMonitor';
+import { ValidateOperatorKey } from '../middleware/OperatorMiddleware';
+import { ValidateApiKey } from '../middleware/AuthMiddleware';
+import { RequirePlatform } from '../middleware/Authorization';
+
+const router = express.Router();
+const billingModule = CreateSubscriptionBilling(db);
+
+function ParseBatchSize(body: unknown): number | undefined {
+  return typeof (body as { batch_size?: unknown })?.batch_size === 'number'
+    ? (body as { batch_size: number }).batch_size
+    : undefined;
+}
+
+/**
+ * POST /v1/billing/run — operator key (all platforms / optional filter).
+ */
+router.post(
+  '/run',
+  ValidateOperatorKey,
+  AsyncHandler(async (req: express.Request, res: express.Response) => {
+    Logger.info('Subscription billing run triggered (operator)');
+    const result = await billingModule.Run({
+      platformAccountId:
+        typeof req.body?.platform_account === 'string'
+          ? req.body.platform_account
+          : undefined,
+      batchSize: ParseBatchSize(req.body),
+    });
+    res.json({ object: 'billing.run', ...result });
+  })
+);
+
+/**
+ * POST /v1/billing/run_for_platform — platform API key (scoped).
+ */
+router.post(
+  '/run_for_platform',
+  ValidateApiKey,
+  RequirePlatform(),
+  AsyncHandler(async (req: express.Request, res: express.Response) => {
+    const platformAccountId = req.user.account;
+    Logger.info('Subscription billing run triggered (platform)', {
+      platformAccountId,
+    });
+    const result = await billingModule.Run({
+      platformAccountId,
+      batchSize: ParseBatchSize(req.body),
+    });
+    res.json({ object: 'billing.run', ...result });
+  })
+);
+
+/**
+ * GET /v1/billing/monitor/status
+ */
+router.get(
+  '/monitor/status',
+  ValidateApiKey,
+  RequirePlatform(),
+  AsyncHandler(async (req: express.Request, res: express.Response) => {
+    const monitor = GetBillingMonitor(db);
+    res.json({
+      running: monitor.IsRunning(),
+      enabled: BillingMonitor.IsEnabled(),
+      poll_interval_ms: BillingMonitor.GetPollInterval(),
+      platform_account: req.user.account,
+    });
+  })
+);
+
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -32,6 +32,7 @@ import chargesRouter from './charges.routes';
 import invoiceItemsRouter from './invoiceItems.routes';
 import invoicesRouter from './invoices.routes';
 import reportingRouter from './reporting.routes';
+import billingRouter from './billing.routes';
 
 const router = express.Router();
 
@@ -45,6 +46,9 @@ router.use('/payment_pages', paymentPagesRouter);
 // --- Operator Routes ---
 // Guarded by the operator API key (managed hosting only)
 router.use('/operator', operatorRouter);
+
+// Billing run: operator key (Cloud Scheduler) or platform API key endpoints.
+router.use('/billing', billingRouter);
 
 // --- Authenticated Routes ---
 // All routes below this line require an API Key

--- a/apps/api/src/routes/invoices.routes.ts
+++ b/apps/api/src/routes/invoices.routes.ts
@@ -21,6 +21,8 @@ import { PriceModule } from '../modules/Price';
 import { ProductModule } from '../modules/Product';
 import { InvoiceItemModule } from '../modules/InvoiceItem';
 import { InvoiceModule } from '../modules/Invoice';
+import { PaymentIntentModule } from '../modules/PaymentIntent';
+import { ChargeModule } from '../modules/Charge';
 
 import { ValidateRequest } from '../middleware/ValidateRequest';
 import { RequirePlatform } from '../middleware/Authorization';
@@ -40,6 +42,12 @@ const eventService = new EventService(db);
 const customerModule = new CustomerModule(db, eventService);
 const productModule = new ProductModule(db, eventService);
 const priceModule = new PriceModule(db, eventService, productModule);
+const paymentIntentModule = new PaymentIntentModule(
+  db,
+  eventService,
+  customerModule
+);
+const chargeModule = new ChargeModule(db, eventService, customerModule);
 const invoiceItemModule = new InvoiceItemModule(
   db,
   eventService,
@@ -50,7 +58,10 @@ const invoiceModule = new InvoiceModule(
   db,
   eventService,
   customerModule,
-  invoiceItemModule
+  invoiceItemModule,
+  paymentIntentModule,
+  chargeModule,
+  priceModule
 );
 
 RegisterExpansions('invoice', {

--- a/apps/api/src/routes/paymentPages.routes.ts
+++ b/apps/api/src/routes/paymentPages.routes.ts
@@ -54,7 +54,10 @@ const invoiceModule = new InvoiceModule(
   db,
   eventService,
   customerModule,
-  invoiceItemModule
+  invoiceItemModule,
+  paymentIntentModule,
+  chargeModule,
+  priceModule
 );
 const subscriptionModule = new SubscriptionModule(
   db,

--- a/apps/api/src/routes/prices.routes.ts
+++ b/apps/api/src/routes/prices.routes.ts
@@ -18,6 +18,7 @@ import {
   ParseOptionalQueryBoolean,
 } from '../utils/ListHelper';
 import { ApplyExpand, RegisterExpansions } from '../utils/Expand';
+import type { RecurringInterval } from '@zoneless/shared-types';
 
 const router = express.Router();
 
@@ -172,7 +173,7 @@ router.get(
     }
     const recurring = req.query.recurring as
       | {
-          interval: 'day' | 'week' | 'month' | 'year';
+          interval: RecurringInterval;
           meter: string | undefined;
           usage_type: 'metered' | 'licensed';
         }

--- a/apps/api/src/routes/subscriptions.routes.ts
+++ b/apps/api/src/routes/subscriptions.routes.ts
@@ -22,6 +22,8 @@ import { ProductModule } from '../modules/Product';
 import { InvoiceItemModule } from '../modules/InvoiceItem';
 import { InvoiceModule } from '../modules/Invoice';
 import { SubscriptionModule } from '../modules/Subscription';
+import { PaymentIntentModule } from '../modules/PaymentIntent';
+import { ChargeModule } from '../modules/Charge';
 
 import { ValidateRequest } from '../middleware/ValidateRequest';
 import { RequirePlatform } from '../middleware/Authorization';
@@ -41,6 +43,12 @@ const eventService = new EventService(db);
 const customerModule = new CustomerModule(db, eventService);
 const productModule = new ProductModule(db, eventService);
 const priceModule = new PriceModule(db, eventService, productModule);
+const paymentIntentModule = new PaymentIntentModule(
+  db,
+  eventService,
+  customerModule
+);
+const chargeModule = new ChargeModule(db, eventService, customerModule);
 const invoiceItemModule = new InvoiceItemModule(
   db,
   eventService,
@@ -51,7 +59,10 @@ const invoiceModule = new InvoiceModule(
   db,
   eventService,
   customerModule,
-  invoiceItemModule
+  invoiceItemModule,
+  paymentIntentModule,
+  chargeModule,
+  priceModule
 );
 const subscriptionModule = new SubscriptionModule(
   db,

--- a/apps/api/src/utils/RecurringInterval.ts
+++ b/apps/api/src/utils/RecurringInterval.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileOverview Helpers for recurring billing intervals.
+ *
+ * @module RecurringInterval
+ */
+
+import type { RecurringInterval } from '@zoneless/shared-types';
+
+export const SECONDS_PER_HOUR = 60 * 60;
+export const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
+
+const HOURS_PER_INTERVAL: Record<RecurringInterval, number> = {
+  hour: 1,
+  day: 24,
+  week: 24 * 7,
+  month: 24 * 30,
+  year: 24 * 365,
+};
+
+const SECONDS_PER_INTERVAL: Record<RecurringInterval, number> = {
+  hour: SECONDS_PER_HOUR,
+  day: SECONDS_PER_DAY,
+  week: 7 * SECONDS_PER_DAY,
+  month: 30 * SECONDS_PER_DAY,
+  year: 365 * SECONDS_PER_DAY,
+};
+
+/**
+ * Converts a recurring interval (+ count) to period length in hours.
+ * Used when creating on-chain Solana subscription plans.
+ */
+export function RecurringIntervalToHours(
+  interval: RecurringInterval,
+  intervalCount = 1
+): number {
+  return HOURS_PER_INTERVAL[interval] * intervalCount;
+}
+
+/**
+ * Advances a Unix timestamp by a recurring interval (+ count).
+ */
+export function AddRecurringInterval(
+  start: number,
+  interval: RecurringInterval,
+  intervalCount = 1
+): number {
+  return start + SECONDS_PER_INTERVAL[interval] * intervalCount;
+}

--- a/apps/web/src/app/data/services/webhook-endpoint.service.ts
+++ b/apps/web/src/app/data/services/webhook-endpoint.service.ts
@@ -73,6 +73,7 @@ const EVENT_TYPE_LABELS: Record<(typeof EVENT_TYPES)[number], string> = {
   'invoice.marked_uncollectible': 'Invoice marked uncollectible',
   'invoice.paid': 'Invoice paid',
   'invoice.payment_succeeded': 'Invoice payment succeeded',
+  'invoice.payment_failed': 'Invoice payment failed',
   'invoice.updated': 'Invoice updated',
   'invoice.voided': 'Invoice voided',
   'invoiceitem.created': 'Invoice item created',

--- a/apps/web/src/app/features/account/products/components/price-form/price-form.component.html
+++ b/apps/web/src/app/features/account/products/components/price-form/price-form.component.html
@@ -76,6 +76,7 @@
       [disabled]="mode === 'edit'"
       [class.dimmed-disabled]="mode === 'edit'"
     >
+      <option value="hour">Hourly</option>
       <option value="day">Daily</option>
       <option value="week">Weekly</option>
       <option value="month">Monthly</option>

--- a/apps/web/src/app/features/account/products/components/price-form/price-form.component.ts
+++ b/apps/web/src/app/features/account/products/components/price-form/price-form.component.ts
@@ -12,7 +12,7 @@ import {
   inject,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Price } from '@zoneless/shared-types';
+import { Price, RecurringInterval } from '@zoneless/shared-types';
 import { ConfigService } from '../../../../../data';
 import { CreatePriceInput, UpdatePriceInput } from '@zoneless/shared-schemas';
 
@@ -45,8 +45,7 @@ export class PriceFormComponent implements OnInit, OnChanges {
   unitAmount: WritableSignal<number> = signal(0);
   unitAmountError: WritableSignal<string> = signal('');
 
-  interval: WritableSignal<'day' | 'week' | 'month' | 'year'> = signal('month');
-  intervalError: WritableSignal<string> = signal('');
+  interval: WritableSignal<RecurringInterval> = signal('month');
 
   nickname: WritableSignal<string> = signal('');
   NICKNAME_MAX_LENGTH = 22;
@@ -111,7 +110,7 @@ export class PriceFormComponent implements OnInit, OnChanges {
     }
   }
 
-  OnIntervalChange(value: 'day' | 'week' | 'month' | 'year'): void {
+  OnIntervalChange(value: RecurringInterval): void {
     this.interval.set(value);
     this.EmitFormChange();
   }

--- a/apps/web/src/app/features/account/products/components/product-form/product-form.component.html
+++ b/apps/web/src/app/features/account/products/components/product-form/product-form.component.html
@@ -220,6 +220,7 @@
   <div class="field-title">Billing Period</div>
   <div class="field-value">
     <select [ngModel]="interval()" (ngModelChange)="OnIntervalChange($event)">
+      <option value="hour">Hourly</option>
       <option value="day">Daily</option>
       <option value="week">Weekly</option>
       <option value="month">Monthly</option>

--- a/apps/web/src/app/features/account/products/components/product-form/product-form.component.ts
+++ b/apps/web/src/app/features/account/products/components/product-form/product-form.component.ts
@@ -13,7 +13,12 @@ import {
   ViewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { Product, Price, MarketingFeature } from '@zoneless/shared-types';
+import {
+  Product,
+  Price,
+  MarketingFeature,
+  RecurringInterval,
+} from '@zoneless/shared-types';
 import { ConfigService } from '../../../../../data';
 import {
   CreateProductInput,
@@ -27,6 +32,7 @@ import { PriceActionsHostComponent } from '../price-actions-host/price-actions-h
 import { PriceActionsService } from '../../services/price-actions.service';
 import { MetadataEditorComponent } from '../../../components';
 import { Subscription } from 'rxjs';
+import { FormatPriceDisplay } from '../../util/price-display';
 export type ProductFormMode = 'create' | 'edit';
 
 @Component({
@@ -83,8 +89,7 @@ export class ProductFormComponent implements OnInit, OnChanges {
   selectedPricing: WritableSignal<'one-time' | 'recurring'> =
     signal('recurring');
 
-  interval: WritableSignal<'day' | 'week' | 'month' | 'year'> = signal('month');
-  intervalError: WritableSignal<string> = signal('');
+  interval: WritableSignal<RecurringInterval> = signal('month');
 
   detailsExpanded: WritableSignal<boolean> = signal(false);
 
@@ -191,7 +196,7 @@ export class ProductFormComponent implements OnInit, OnChanges {
     }
   }
 
-  OnIntervalChange(value: 'day' | 'week' | 'month' | 'year'): void {
+  OnIntervalChange(value: RecurringInterval): void {
     this.interval.set(value);
     this.EmitFormChange();
   }
@@ -305,27 +310,7 @@ export class ProductFormComponent implements OnInit, OnChanges {
         type: 'text',
         bolded: true,
         formatter: (item: unknown) => {
-          const price = item as Price;
-          if (price === null) {
-            return 'No prices';
-          }
-          const unitAmount = price.unit_amount ?? 0;
-          if (price.recurring) {
-            const recurringData = price.recurring;
-            if (recurringData?.interval === 'day') {
-              return `$${(unitAmount / 100).toFixed(2)} / day`;
-            }
-            if (recurringData?.interval === 'week') {
-              return `$${(unitAmount / 100).toFixed(2)} / week`;
-            }
-            if (recurringData?.interval === 'month') {
-              return `$${(unitAmount / 100).toFixed(2)} / month`;
-            }
-            if (recurringData?.interval === 'year') {
-              return `$${(unitAmount / 100).toFixed(2)} / year`;
-            }
-          }
-          return `$${(unitAmount / 100).toFixed(2)}`;
+          return FormatPriceDisplay(item as Price);
         },
       },
       {

--- a/apps/web/src/app/features/account/products/util/price-display.ts
+++ b/apps/web/src/app/features/account/products/util/price-display.ts
@@ -1,0 +1,51 @@
+import type { Price, RecurringInterval } from '@zoneless/shared-types';
+
+/**
+ * Formats a unit amount (cents) with an optional recurring interval suffix.
+ * e.g. `$10.00 / hour`, `$10.00 / month`, or `$10.00` for one-time.
+ */
+export function FormatPriceWithInterval(
+  unitAmount: number,
+  interval?: RecurringInterval | null
+): string {
+  const formatted = `$${(unitAmount / 100).toFixed(2)}`;
+  return interval ? `${formatted} / ${interval}` : formatted;
+}
+
+/**
+ * Human-readable label for a recurring interval (e.g. Hourly, Monthly).
+ */
+export function FormatIntervalLabel(interval: RecurringInterval): string {
+  switch (interval) {
+    case 'hour':
+      return 'Hourly';
+    case 'day':
+      return 'Daily';
+    case 'week':
+      return 'Weekly';
+    case 'month':
+      return 'Monthly';
+    case 'year':
+      return 'Yearly';
+  }
+}
+
+/**
+ * Short per-period label for list/detail displays (e.g. Per hour, Per month).
+ */
+export function FormatIntervalPerLabel(interval: RecurringInterval): string {
+  return `Per ${interval}`;
+}
+
+/**
+ * Formats a Price object's unit amount with its recurring interval if present.
+ */
+export function FormatPriceDisplay(price: Price | null | undefined): string {
+  if (!price) {
+    return 'No prices';
+  }
+  return FormatPriceWithInterval(
+    price.unit_amount ?? 0,
+    price.recurring?.interval ?? null
+  );
+}

--- a/apps/web/src/app/features/account/products/views/price-detail/price-detail.component.html
+++ b/apps/web/src/app/features/account/products/views/price-detail/price-detail.component.html
@@ -91,17 +91,8 @@
       <span>${{ (price.unit_amount ?? 0) / 100 | number : '1.2-2' }}</span>
       @if (price.recurring) {
       <span>/</span>
-      } @switch (price.recurring?.interval) { @case ('day') {
-      <span>day</span>
-      } @case ('week') {
-      <span>week</span>
-      } @case ('month') {
-      <span>month</span>
-      } @case ('year') {
-      <span>year</span>
-      } @default {
-      <span>—</span>
-      } }
+      <span>{{ price.recurring.interval }}</span>
+      }
     </div>
   </div>
   <div class="vertical-line"></div>
@@ -194,17 +185,9 @@
     </tr>
     <tr>
       <td class="dimmed-extra">Interval</td>
-      @if(price.recurring){ @switch (price.recurring.interval) { @case ('day') {
-      <td>Daily</td>
-      } @case ('week') {
-      <td>Weekly</td>
-      } @case ('month') {
-      <td>Monthly</td>
-      } @case ('year') {
-      <td>Yearly</td>
-      } @default {
-      <td>—</td>
-      } } } @else {
+      @if (price.recurring) {
+      <td>{{ FormatIntervalLabel(price.recurring.interval) }}</td>
+      } @else {
       <td>One-time</td>
       }
     </tr>

--- a/apps/web/src/app/features/account/products/views/price-detail/price-detail.component.ts
+++ b/apps/web/src/app/features/account/products/views/price-detail/price-detail.component.ts
@@ -19,6 +19,7 @@ import {
   CopyTextComponent,
 } from '../../../../../shared';
 import { MetaService } from '../../../../../core';
+import { FormatIntervalLabel } from '../../util/price-display';
 
 import { Subscription } from 'rxjs';
 
@@ -43,6 +44,7 @@ export class PriceDetailComponent {
   private readonly priceService = inject(PriceService);
   readonly priceActions = inject(PriceActionsService);
   readonly MetadataToArray = MetadataToArray;
+  readonly FormatIntervalLabel = FormatIntervalLabel;
   private readonly metaService = inject(MetaService);
 
   loading: WritableSignal<boolean> = signal(false);

--- a/apps/web/src/app/features/account/products/views/product-catalogue/product-catalogue.component.ts
+++ b/apps/web/src/app/features/account/products/views/product-catalogue/product-catalogue.component.ts
@@ -20,6 +20,7 @@ import { ProductActionsService } from '../../services/product-actions.service';
 import { ProductActionsHostComponent } from '../../components/product-actions-host/product-actions-host.component';
 import { Subscription } from 'rxjs';
 import { MetaService } from '../../../../../core';
+import { FormatPriceDisplay } from '../../util/price-display';
 
 @Component({
   selector: 'app-product-catalogue',
@@ -59,23 +60,7 @@ export class ProductCatalogueComponent implements OnInit, OnDestroy {
         if (product.default_price === null) {
           return 'No prices';
         }
-        const unitAmount = (product.default_price as Price)?.unit_amount ?? 0;
-        if ((product.default_price as Price)?.recurring) {
-          const recurringData = (product.default_price as Price)?.recurring;
-          if (recurringData?.interval === 'day') {
-            return `$${(unitAmount / 100).toFixed(2)} / day`;
-          }
-          if (recurringData?.interval === 'week') {
-            return `$${(unitAmount / 100).toFixed(2)} / week`;
-          }
-          if (recurringData?.interval === 'month') {
-            return `$${(unitAmount / 100).toFixed(2)} / month`;
-          }
-          if (recurringData?.interval === 'year') {
-            return `$${(unitAmount / 100).toFixed(2)} / year`;
-          }
-        }
-        return `$${(unitAmount / 100).toFixed(2)}`;
+        return FormatPriceDisplay(product.default_price as Price);
       },
     },
     {

--- a/apps/web/src/app/features/account/products/views/product-detail/product-detail.component.html
+++ b/apps/web/src/app/features/account/products/views/product-detail/product-detail.component.html
@@ -35,15 +35,8 @@
             class="icon small-icon"
             alt="Autorenew icon"
           />
-          @switch (price.recurring.interval) { @case ('day') {
-          <span>Per day</span>
-          } @case ('week') {
-          <span>Per week</span>
-          } @case ('month') {
-          <span>Per month</span>
-          } @case ('year') {
-          <span>Per year</span>
-          } } }
+          <span>{{ FormatIntervalPerLabel(price.recurring.interval) }}</span>
+          }
         </div>
         } @else {
         <div>No prices</div>

--- a/apps/web/src/app/features/account/products/views/product-detail/product-detail.component.ts
+++ b/apps/web/src/app/features/account/products/views/product-detail/product-detail.component.ts
@@ -27,6 +27,10 @@ import { PriceActionsHostComponent } from '../../components/price-actions-host/p
 import { MetadataToArray } from '../../../util/metadata';
 import { MetaService } from '../../../../../core';
 import { Subscription } from 'rxjs';
+import {
+  FormatPriceDisplay,
+  FormatIntervalPerLabel,
+} from '../../util/price-display';
 
 @Component({
   selector: 'app-product-detail',
@@ -52,6 +56,7 @@ export class ProductDetailComponent implements OnInit, OnDestroy {
   readonly actions = inject(ProductActionsService);
   readonly priceActions = inject(PriceActionsService);
   readonly MetadataToArray = MetadataToArray;
+  readonly FormatIntervalPerLabel = FormatIntervalPerLabel;
 
   @ViewChild('pricesList') pricesList?: PaginatedListComponent<any>;
 
@@ -168,27 +173,7 @@ export class ProductDetailComponent implements OnInit, OnDestroy {
         type: 'text',
         bolded: true,
         formatter: (item: unknown) => {
-          const price = item as Price;
-          if (price === null) {
-            return 'No prices';
-          }
-          const unitAmount = price.unit_amount ?? 0;
-          if (price.recurring) {
-            const recurringData = price.recurring;
-            if (recurringData?.interval === 'day') {
-              return `$${(unitAmount / 100).toFixed(2)} / day`;
-            }
-            if (recurringData?.interval === 'week') {
-              return `$${(unitAmount / 100).toFixed(2)} / week`;
-            }
-            if (recurringData?.interval === 'month') {
-              return `$${(unitAmount / 100).toFixed(2)} / month`;
-            }
-            if (recurringData?.interval === 'year') {
-              return `$${(unitAmount / 100).toFixed(2)} / year`;
-            }
-          }
-          return `$${(unitAmount / 100).toFixed(2)}`;
+          return FormatPriceDisplay(item as Price);
         },
       },
       {

--- a/libs/shared-schemas/src/lib/CheckoutSessionSchema.ts
+++ b/libs/shared-schemas/src/lib/CheckoutSessionSchema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { ExpandableSchema } from './ExpandableSchema';
+import { RecurringIntervalSchema } from './PriceSchema';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Reusable nested object schemas
@@ -179,7 +180,7 @@ export const CheckoutSessionPriceDataSchema = z
     product_data: CheckoutSessionProductDataSchema.optional(),
     recurring: z
       .object({
-        interval: z.enum(['day', 'week', 'month', 'year']),
+        interval: RecurringIntervalSchema,
         interval_count: z.number().int().positive().optional(),
       })
       .optional(),

--- a/libs/shared-schemas/src/lib/InvoiceSchema.ts
+++ b/libs/shared-schemas/src/lib/InvoiceSchema.ts
@@ -429,6 +429,12 @@ export const PayInvoiceSchema = z
     paid_out_of_band: z.boolean().optional(),
     payment_method: z.string().optional(),
     source: z.string().optional(),
+    /**
+     * When set, skip on-chain collect and record settlement with this signature
+     * (e.g. checkout already collected the first period).
+     * @zoneless_extension
+     */
+    settlement_signature: z.string().optional(),
   })
   .merge(ExpandableSchema);
 

--- a/libs/shared-schemas/src/lib/PriceSchema.ts
+++ b/libs/shared-schemas/src/lib/PriceSchema.ts
@@ -2,6 +2,19 @@ import { z } from 'zod';
 import { ExpandableSchema } from './ExpandableSchema';
 
 /**
+ * Billing frequency for a recurring price.
+ * @zoneless_extension Includes `hour` (not in Stripe) for Solana subscription periods.
+ */
+export const RecurringIntervalSchema = z.enum([
+  'hour',
+  'day',
+  'week',
+  'month',
+  'year',
+]);
+export type RecurringIntervalInput = z.infer<typeof RecurringIntervalSchema>;
+
+/**
  * Schema for retrieving a price.
  */
 export const RetrievePriceSchema = ExpandableSchema;
@@ -19,7 +32,7 @@ export const CreatePriceSchema = z
     product: z.string().min(1).max(32).optional(),
     recurring: z
       .object({
-        interval: z.enum(['day', 'week', 'month', 'year']),
+        interval: RecurringIntervalSchema,
         interval_count: z.number().int().positive().optional(),
         trial_period_days: z.number().int().positive().optional(),
         usage_type: z.enum(['metered', 'licensed']).optional(),
@@ -179,7 +192,7 @@ export const ListPricesSchema = z
     lookup_keys: z.array(z.string()).optional(),
     recurring: z
       .object({
-        interval: z.enum(['day', 'week', 'month', 'year']).optional(),
+        interval: RecurringIntervalSchema.optional(),
         meter: z.string().optional(),
         usage_type: z.enum(['metered', 'licensed']).optional(),
       })
@@ -198,7 +211,7 @@ export const ListPricesFiltersSchema = z.object({
   lookup_keys: z.array(z.string()).optional(),
   recurring: z
     .object({
-      interval: z.enum(['day', 'week', 'month', 'year']).optional(),
+      interval: RecurringIntervalSchema.optional(),
       meter: z.string().optional(),
       usage_type: z.enum(['metered', 'licensed']).optional(),
     })

--- a/libs/shared-schemas/src/lib/ProductSchema.ts
+++ b/libs/shared-schemas/src/lib/ProductSchema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { MarketingFeature } from '@zoneless/shared-types';
 import { ExpandableSchema } from './ExpandableSchema';
+import { RecurringIntervalSchema } from './PriceSchema';
 
 const PackageDimensionsSchema = z.object({
   height: z.number().min(0).max(100000),
@@ -88,7 +89,7 @@ export const CreateProductSchema = z
         metadata: z.record(z.string(), z.string()).optional(),
         recurring: z
           .object({
-            interval: z.enum(['day', 'week', 'month', 'year']),
+            interval: RecurringIntervalSchema,
             interval_count: z.number().int().positive().optional(),
             trial_period_days: z.number().int().positive().optional(),
             usage_type: z.enum(['metered', 'licensed']).optional(),

--- a/libs/shared-schemas/src/lib/SubscriptionItemSchema.ts
+++ b/libs/shared-schemas/src/lib/SubscriptionItemSchema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { ExpandableSchema } from './ExpandableSchema';
 import { InvoiceItemDiscountSchema } from './InvoiceItemSchema';
+import { RecurringIntervalSchema } from './PriceSchema';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Reusable nested object schemas
@@ -48,7 +49,7 @@ export const SubscriptionItemPriceDataSchema = z
     currency: z.string().min(1).max(4).toLowerCase(),
     product: z.string().min(1),
     recurring: z.object({
-      interval: z.enum(['day', 'week', 'month', 'year']),
+      interval: RecurringIntervalSchema,
       interval_count: z.number().int().positive().optional(),
     }),
     tax_behavior: z.enum(['exclusive', 'inclusive', 'unspecified']).optional(),

--- a/libs/shared-schemas/src/lib/SubscriptionSchema.ts
+++ b/libs/shared-schemas/src/lib/SubscriptionSchema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { CheckoutSessionAutomaticTaxSchema } from './CheckoutSessionSchema';
 import { ExpandableSchema } from './ExpandableSchema';
 import { InvoiceItemDiscountSchema } from './InvoiceItemSchema';
+import { RecurringIntervalSchema } from './PriceSchema';
 import {
   SubscriptionItemBillingThresholdsSchema,
   SubscriptionItemPriceDataSchema,
@@ -69,7 +70,7 @@ export const SubscriptionBillingModeSchema = z.object({
 });
 
 const SubscriptionBillingScheduleDurationSchema = z.object({
-  interval: z.enum(['day', 'week', 'month', 'year']),
+  interval: RecurringIntervalSchema,
   interval_count: z.number().int().positive().optional(),
 });
 
@@ -376,7 +377,7 @@ export const SubscriptionPaymentSettingsSchema = z.object({
  * Specifies an interval for how often to bill for any pending invoice items.
  */
 export const SubscriptionPendingInvoiceItemIntervalSchema = z.object({
-  interval: z.enum(['day', 'week', 'month', 'year']),
+  interval: RecurringIntervalSchema,
   interval_count: z.number().int().positive().optional(),
 });
 

--- a/libs/shared-types/src/lib/Event.ts
+++ b/libs/shared-types/src/lib/Event.ts
@@ -84,6 +84,7 @@ export const EVENT_TYPES = [
   'invoice.finalized',
   'invoice.marked_uncollectible',
   'invoice.paid',
+  'invoice.payment_failed',
   'invoice.payment_succeeded',
   'invoice.updated',
   'invoice.voided',

--- a/libs/shared-types/src/lib/Price.ts
+++ b/libs/shared-types/src/lib/Price.ts
@@ -1,6 +1,12 @@
 import { Product } from './Product';
 
 /**
+ * Billing frequency for a recurring price.
+ * @zoneless_extension Includes `hour` (not in Stripe) for Solana subscription periods.
+ */
+export type RecurringInterval = 'hour' | 'day' | 'week' | 'month' | 'year';
+
+/**
  * Stripe-compatible Price object for Zoneless.
  * Represents the price of a product.
  *
@@ -21,8 +27,12 @@ export interface Price {
   product: string | Product | null;
   /** The recurring components of a price such as interval and usage_type. */
   recurring: {
-    /** The frequency at which a subscription is billed. One of day, week, month or year. */
-    interval: 'day' | 'week' | 'month' | 'year';
+    /**
+     * The frequency at which a subscription is billed.
+     * One of hour, day, week, month or year.
+     * @zoneless_extension `hour` is supported for Solana subscription periods.
+     */
+    interval: RecurringInterval;
     /** The number of intervals (specified in the interval attribute) between subscription billings. For example, interval=month and interval_count=3 bills every 3 months. */
     interval_count: number;
     /** The number of trial days before the customer is charged for the first time. */

--- a/libs/shared-types/src/lib/Subscription.ts
+++ b/libs/shared-types/src/lib/Subscription.ts
@@ -6,6 +6,7 @@ import type {
   CustomerTaxRate,
 } from './Customer';
 import type { Invoice } from './Invoice';
+import type { RecurringInterval } from './Price';
 import type {
   SubscriptionItem,
   SubscriptionItemList,
@@ -362,8 +363,11 @@ export interface SubscriptionBillingScheduleBillUntil {
 
 /** Specifies a billing schedule duration. */
 export interface SubscriptionBillingScheduleDuration {
-  /** Specifies billing duration. Either day, week, month or year. */
-  interval: 'day' | 'week' | 'month' | 'year';
+  /**
+   * Specifies billing duration. Either hour, day, week, month or year.
+   * @zoneless_extension `hour` is supported for Solana subscription periods.
+   */
+  interval: RecurringInterval;
   /** The multiplier applied to the interval. */
   interval_count: number | null;
 }
@@ -516,8 +520,11 @@ export interface SubscriptionPaymentSettings {
  * calling Create an invoice for the given subscription at the specified interval.
  */
 export interface SubscriptionPendingInvoiceItemInterval {
-  /** Specifies invoicing frequency. Either day, week, month or year. */
-  interval: 'day' | 'week' | 'month' | 'year';
+  /**
+   * Specifies invoicing frequency. Either hour, day, week, month or year.
+   * @zoneless_extension `hour` is supported for Solana subscription periods.
+   */
+  interval: RecurringInterval;
   /**
    * The number of intervals between invoices. For example, interval=month and interval_count=3
    * bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).

--- a/libs/shared-types/src/lib/Subscription.ts
+++ b/libs/shared-types/src/lib/Subscription.ts
@@ -230,6 +230,13 @@ export interface Subscription {
    * @zoneless_extension
    */
   subscription_delegation_pda: string | null;
+
+  /**
+   * Unix timestamp until which this subscription is claimed by a billing runner.
+   * Used to prevent duplicate cycle invoices across multiple API instances.
+   * @zoneless_extension
+   */
+  billing_lock_until: number | null;
 }
 
 /** A list of subscriptions. */


### PR DESCRIPTION
## Description

- Adds two endpoints to poll for subscriptions that require payment
- Adds the ability to set BILLING_MONITOR_ENABLED environment variable to have recurring subscriptions check on a consistent basis on a live instance.
- Added hourly subscriptions (mainly for testing)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
