### PR TITLE
feat: show time of next invoice on subscription view

### DIFF
--- a/apps/web/src/app/features/account/subscriptions/util/subscription-display.ts
+++ b/apps/web/src/app/features/account/subscriptions/util/subscription-display.ts
@@ -281,6 +281,17 @@ export function FormatShortDate(unixSeconds: number): string {
   });
 }
 
+/** Short date with 24-hour time, e.g. "21 Aug, 16:08". */
+export function FormatShortDateTime(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toLocaleString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
 export function FormatMediumDate(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toLocaleDateString('en-GB', {
     day: 'numeric',

--- a/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.html
+++ b/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.html
@@ -24,7 +24,7 @@
         <span class="summary-label">Next invoice</span>
         <span class="summary-value">
           {{ FormatSubscriptionAmount(nextInvoiceAmount()) }} on
-          {{ FormatShortDate(nextDate) }}
+          {{ FormatShortDateTime(nextDate) }}
         </span>
       </div>
       }

--- a/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.ts
+++ b/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.ts
@@ -33,6 +33,7 @@ import { SubscriptionActionsService } from '../../services/subscription-actions.
 import { SubscriptionActionsHostComponent } from '../../components/subscription-actions-host/subscription-actions-host.component';
 import {
   FormatShortDate,
+  FormatShortDateTime,
   FormatSubscriptionAmount,
   FormatSubscriptionBillingMethod,
   FormatSubscriptionBillingMode,
@@ -86,6 +87,7 @@ export class SubscriptionDetailComponent implements OnInit, OnDestroy {
   readonly FormatSubscriptionDiscounts = FormatSubscriptionDiscounts;
   readonly FormatSubscriptionAmount = FormatSubscriptionAmount;
   readonly FormatShortDate = FormatShortDate;
+  readonly FormatShortDateTime = FormatShortDateTime;
   readonly GetSubscriptionItemProductId = GetSubscriptionItemProductId;
 
   subscription: WritableSignal<Subscription | null> = signal(null);


### PR DESCRIPTION
## Description

Display the time of the next invoice at the top of the subscription page.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
