### PR TITLE
feat: cancel subscription flow via dashboard

### DIFF
--- a/apps/api/src/__tests__/Subscription.spec.ts
+++ b/apps/api/src/__tests__/Subscription.spec.ts
@@ -331,6 +331,48 @@ describe('SubscriptionModule', () => {
         expect.objectContaining({ previousAttributes: expect.any(Object) })
       );
     });
+
+    it('should schedule cancel at period end without changing status', async () => {
+      const created = await module.CreateSubscription(PLATFORM, {
+        customer: CUSTOMER_ID,
+        items: [{ price: PRICE_ID }],
+      });
+      const periodEnd = created.items.data[0].current_period_end;
+
+      const updated = await module.UpdateSubscription(created.id, {
+        cancel_at_period_end: true,
+      });
+
+      expect(updated.status).toBe('active');
+      expect(updated.cancel_at_period_end).toBe(true);
+      expect(updated.cancel_at).toBe(periodEnd);
+      expect(updated.canceled_at).toBe(GetFixedTimestamp());
+      expect(updated.cancellation_details?.reason).toBe(
+        'cancellation_requested'
+      );
+      expect(updated.ended_at).toBeNull();
+    });
+
+    it('should clear scheduled cancel when cancel_at_period_end is false', async () => {
+      const created = await module.CreateSubscription(PLATFORM, {
+        customer: CUSTOMER_ID,
+        items: [{ price: PRICE_ID }],
+      });
+
+      await module.UpdateSubscription(created.id, {
+        cancel_at_period_end: true,
+      });
+
+      const resumed = await module.UpdateSubscription(created.id, {
+        cancel_at_period_end: false,
+      });
+
+      expect(resumed.status).toBe('active');
+      expect(resumed.cancel_at_period_end).toBe(false);
+      expect(resumed.cancel_at).toBeNull();
+      expect(resumed.canceled_at).toBeNull();
+      expect(resumed.cancellation_details?.reason).toBeNull();
+    });
   });
 
   describe('CancelSubscription', () => {
@@ -347,6 +389,8 @@ describe('SubscriptionModule', () => {
       expect(canceled.status).toBe('canceled');
       expect(canceled.canceled_at).toBe(GetFixedTimestamp());
       expect(canceled.ended_at).toBe(GetFixedTimestamp());
+      expect(canceled.cancel_at).toBeNull();
+      expect(canceled.cancel_at_period_end).toBe(false);
       expect(canceled.cancellation_details?.feedback).toBe('too_expensive');
       expect(canceled.cancellation_details?.reason).toBe(
         'cancellation_requested'
@@ -355,6 +399,19 @@ describe('SubscriptionModule', () => {
         'customer.subscription.deleted',
         PLATFORM,
         expect.objectContaining({ id: created.id })
+      );
+    });
+
+    it('should reject already canceled subscriptions', async () => {
+      const created = await module.CreateSubscription(PLATFORM, {
+        customer: CUSTOMER_ID,
+        items: [{ price: PRICE_ID }],
+      });
+
+      await module.CancelSubscription(created.id, {});
+
+      await expect(module.CancelSubscription(created.id, {})).rejects.toThrow(
+        'Subscription is already canceled'
       );
     });
 
@@ -383,6 +440,30 @@ describe('SubscriptionModule', () => {
         })
       );
       expect(canceled.latest_invoice).toBe('in_z_final');
+    });
+  });
+
+  describe('FinalizeCancelAtPeriodEnd', () => {
+    it('should mark canceled and emit deleted', async () => {
+      const created = await module.CreateSubscription(PLATFORM, {
+        customer: CUSTOMER_ID,
+        items: [{ price: PRICE_ID }],
+      });
+
+      await module.UpdateSubscription(created.id, {
+        cancel_at_period_end: true,
+      });
+
+      const finalized = await module.FinalizeCancelAtPeriodEnd(created.id);
+
+      expect(finalized.status).toBe('canceled');
+      expect(finalized.ended_at).toBe(GetFixedTimestamp());
+      expect(finalized.cancel_at_period_end).toBe(false);
+      expect(eventService.Emit).toHaveBeenCalledWith(
+        'customer.subscription.deleted',
+        PLATFORM,
+        expect.objectContaining({ id: created.id })
+      );
     });
   });
 

--- a/apps/api/src/__tests__/SubscriptionBilling.spec.ts
+++ b/apps/api/src/__tests__/SubscriptionBilling.spec.ts
@@ -38,6 +38,7 @@ describe('SubscriptionBillingModule', () => {
       AdvanceSubscriptionPeriod: jest.fn(),
       MarkSubscriptionPastDue: jest.fn(),
       MarkSubscriptionUnpaid: jest.fn(),
+      FinalizeCancelAtPeriodEnd: jest.fn(),
     } as unknown as jest.Mocked<SubscriptionModule>;
 
     invoiceModule = {
@@ -230,5 +231,59 @@ describe('SubscriptionBillingModule', () => {
     expect(subscriptionModule.CreateCycleInvoice).not.toHaveBeenCalled();
     expect(result.skipped).toBe(1);
     expect(result.processed).toBe(0);
+  });
+
+  it('should finalize cancel_at_period_end instead of renewing', async () => {
+    const now = GetFixedTimestamp();
+    mockDb.Query = jest
+      .fn()
+      .mockResolvedValueOnce([]) // retry invoices
+      .mockResolvedValueOnce([
+        {
+          id: 'si_z_1',
+          subscription: SUB_ID,
+          current_period_end: now - 10,
+          platform_account: PLATFORM,
+        },
+      ])
+      .mockResolvedValueOnce([]); // open cycle invoices
+
+    const claimed = {
+      id: SUB_ID,
+      platform_account: PLATFORM,
+      status: 'active',
+      collection_method: 'charge_automatically',
+      subscription_delegation_pda: 'SubPda111',
+      pause_collection: null,
+      cancel_at_period_end: true,
+      cancel_at: now - 10,
+      items: {
+        object: 'list',
+        data: [
+          {
+            id: 'si_z_1',
+            current_period_start: now - 1000,
+            current_period_end: now - 10,
+          },
+        ],
+      },
+    };
+
+    subscriptionModule.ClaimForBilling.mockResolvedValue(claimed as never);
+    subscriptionModule.FinalizeCancelAtPeriodEnd.mockResolvedValue({
+      ...claimed,
+      status: 'canceled',
+      ended_at: now,
+      cancel_at_period_end: false,
+    } as never);
+
+    const result = await module.Run({ batchSize: 10 });
+
+    expect(subscriptionModule.FinalizeCancelAtPeriodEnd).toHaveBeenCalledWith(
+      SUB_ID
+    );
+    expect(subscriptionModule.CreateCycleInvoice).not.toHaveBeenCalled();
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
   });
 });

--- a/apps/api/src/modules/Subscription.ts
+++ b/apps/api/src/modules/Subscription.ts
@@ -477,6 +477,8 @@ export class SubscriptionModule {
 
   /**
    * Cancel a subscription immediately.
+   * Off-chain stop-collect: billing will no longer pull; the Solana
+   * delegation PDA is left in place until a later customer-signed revoke.
    * Emits `customer.subscription.deleted`.
    */
   async CancelSubscription(
@@ -485,9 +487,16 @@ export class SubscriptionModule {
   ): Promise<SubscriptionType> {
     const validatedInput = ValidateUpdate(CancelSubscriptionSchema, input);
     const previous = await this.RequireSubscription(id);
-    const now = Now();
 
-    // TODO: Solana USDC — cancel on-chain delegation / subscription PDA
+    if (previous.status === 'canceled') {
+      throw new AppError(
+        'Subscription is already canceled',
+        ERRORS.INVALID_REQUEST.status,
+        ERRORS.INVALID_REQUEST.type
+      );
+    }
+
+    const now = Now();
 
     let latestInvoiceId =
       typeof previous.latest_invoice === 'string'
@@ -515,6 +524,7 @@ export class SubscriptionModule {
       status: 'canceled',
       canceled_at: now,
       ended_at: now,
+      cancel_at: null,
       cancel_at_period_end: false,
       latest_invoice: latestInvoiceId,
       cancellation_details: {
@@ -522,6 +532,61 @@ export class SubscriptionModule {
         feedback: validatedInput.cancellation_details?.feedback ?? null,
         reason: 'cancellation_requested',
       },
+    };
+
+    await this.db.Update<SubscriptionType>('Subscriptions', id, updatePayload);
+
+    const subscription = await this.GetSubscription(id);
+    if (!subscription) {
+      throw new AppError(
+        ERRORS.SUBSCRIPTION_NOT_FOUND.message,
+        ERRORS.SUBSCRIPTION_NOT_FOUND.status,
+        ERRORS.SUBSCRIPTION_NOT_FOUND.type
+      );
+    }
+
+    if (this.eventService) {
+      const previousAttributes = ExtractChangedFields(
+        previous as unknown as Record<string, unknown>,
+        updatePayload as Record<string, unknown>
+      );
+      await this.eventService.Emit(
+        'customer.subscription.updated',
+        subscription.platform_account,
+        subscription,
+        { previousAttributes }
+      );
+      await this.eventService.Emit(
+        'customer.subscription.deleted',
+        subscription.platform_account,
+        subscription
+      );
+    }
+
+    return subscription;
+  }
+
+  /**
+   * Finalize a subscription scheduled to cancel at period end.
+   * Called by the billing runner when the current period has elapsed.
+   */
+  async FinalizeCancelAtPeriodEnd(id: string): Promise<SubscriptionType> {
+    const previous = await this.RequireSubscription(id);
+    const now = Now();
+
+    const updatePayload: Partial<SubscriptionType> = {
+      status: 'canceled',
+      ended_at: now,
+      cancel_at: null,
+      cancel_at_period_end: false,
+      canceled_at: previous.canceled_at ?? now,
+      cancellation_details: {
+        comment: previous.cancellation_details?.comment ?? null,
+        feedback: previous.cancellation_details?.feedback ?? null,
+        reason:
+          previous.cancellation_details?.reason ?? 'cancellation_requested',
+      },
+      billing_lock_until: null,
     };
 
     await this.db.Update<SubscriptionType>('Subscriptions', id, updatePayload);
@@ -897,8 +962,43 @@ export class SubscriptionModule {
     }
     if (input.cancel_at_period_end !== undefined) {
       payload.cancel_at_period_end = input.cancel_at_period_end;
+      if (input.cancel_at_period_end) {
+        const periodEnd = this.GetCurrentPeriodEnd(existing);
+        if (input.cancel_at === undefined) {
+          payload.cancel_at = periodEnd;
+        }
+        payload.canceled_at = Now();
+        payload.cancellation_details = {
+          comment:
+            input.cancellation_details?.comment ??
+            existing.cancellation_details?.comment ??
+            null,
+          feedback:
+            input.cancellation_details?.feedback ??
+            existing.cancellation_details?.feedback ??
+            null,
+          reason:
+            existing.cancellation_details?.reason ?? 'cancellation_requested',
+        };
+      } else if (
+        existing.status === 'active' ||
+        existing.status === 'trialing'
+      ) {
+        if (input.cancel_at === undefined) {
+          payload.cancel_at = null;
+        }
+        payload.canceled_at = null;
+        payload.cancellation_details = {
+          comment: null,
+          feedback: null,
+          reason: null,
+        };
+      }
     }
-    if (input.cancellation_details !== undefined) {
+    if (
+      input.cancellation_details !== undefined &&
+      input.cancel_at_period_end === undefined
+    ) {
       payload.cancellation_details = {
         comment: input.cancellation_details.comment ?? null,
         feedback: input.cancellation_details.feedback ?? null,
@@ -1628,6 +1728,16 @@ export class SubscriptionModule {
         ERRORS.INVALID_REQUEST.type
       );
     }
+  }
+
+  private GetCurrentPeriodEnd(subscription: SubscriptionType): number {
+    const ends = subscription.items?.data?.map(
+      (item) => item.current_period_end
+    );
+    if (!ends?.length) {
+      return Now();
+    }
+    return Math.min(...ends);
   }
 
   private async RequireSubscription(id: string): Promise<SubscriptionType> {

--- a/apps/api/src/modules/SubscriptionBilling.ts
+++ b/apps/api/src/modules/SubscriptionBilling.ts
@@ -245,6 +245,22 @@ export class SubscriptionBillingModule {
     return true;
   }
 
+  private ShouldFinalizeCancelAtPeriodEnd(
+    subscription: SubscriptionType,
+    now: number
+  ): boolean {
+    if (subscription.status === 'canceled') {
+      return false;
+    }
+    if (subscription.cancel_at_period_end) {
+      return true;
+    }
+    if (subscription.cancel_at != null && subscription.cancel_at <= now) {
+      return true;
+    }
+    return false;
+  }
+
   private async CollectOrCreateCycleInvoice(
     claimed: SubscriptionType,
     result: BillingRunResult
@@ -264,16 +280,24 @@ export class SubscriptionBillingModule {
       return;
     }
 
+    const now = Now();
     const minPeriodEnd = Math.min(
       ...claimed.items.data.map((item) => item.current_period_end)
     );
     const dueForTrialEnd =
       claimed.status === 'trialing' &&
       !!claimed.trial_end &&
-      claimed.trial_end <= Now();
-    if (minPeriodEnd > Now() && !dueForTrialEnd) {
+      claimed.trial_end <= now;
+    if (minPeriodEnd > now && !dueForTrialEnd) {
       result.skipped += 1;
       await this.subscriptionModule.ReleaseBillingLock(claimed.id);
+      return;
+    }
+
+    if (this.ShouldFinalizeCancelAtPeriodEnd(claimed, now)) {
+      await this.subscriptionModule.FinalizeCancelAtPeriodEnd(claimed.id);
+      await this.subscriptionModule.ReleaseBillingLock(claimed.id);
+      result.succeeded += 1;
       return;
     }
 

--- a/apps/web/src/app/features/account/subscriptions/components/subscription-actions-host/subscription-actions-host.component.html
+++ b/apps/web/src/app/features/account/subscriptions/components/subscription-actions-host/subscription-actions-host.component.html
@@ -7,3 +7,11 @@
   (confirmed)="actions.ConfirmEditMetadata()"
   (cancelled)="actions.metadataDialogOpen.set(false)"
 ></app-metadata-edit-modal>
+
+<app-subscription-cancel-modal
+  [isOpen]="actions.cancelDialogOpen()"
+  [loading]="actions.cancelSaving()"
+  [subscription]="actions.cancelTarget()"
+  (confirmed)="actions.ConfirmCancel($event)"
+  (cancelled)="actions.CloseCancel()"
+></app-subscription-cancel-modal>

--- a/apps/web/src/app/features/account/subscriptions/components/subscription-actions-host/subscription-actions-host.component.ts
+++ b/apps/web/src/app/features/account/subscriptions/components/subscription-actions-host/subscription-actions-host.component.ts
@@ -1,10 +1,11 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MetadataEditModalComponent } from '../../../components';
 import { SubscriptionActionsService } from '../../services/subscription-actions.service';
+import { SubscriptionCancelModalComponent } from '../subscription-cancel-modal/subscription-cancel-modal.component';
 
 @Component({
   selector: 'app-subscription-actions-host',
-  imports: [MetadataEditModalComponent],
+  imports: [MetadataEditModalComponent, SubscriptionCancelModalComponent],
   templateUrl: './subscription-actions-host.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/web/src/app/features/account/subscriptions/components/subscription-cancel-modal/subscription-cancel-modal.component.html
+++ b/apps/web/src/app/features/account/subscriptions/components/subscription-cancel-modal/subscription-cancel-modal.component.html
@@ -1,0 +1,43 @@
+<app-modal
+  [isOpen]="isOpen"
+  title="Cancel subscription"
+  closeLabel="Don't cancel"
+  submitLabel="Cancel subscription"
+  [destructive]="true"
+  [loading]="loading"
+  (submitted)="OnConfirm()"
+  (closed)="cancelled.emit()"
+>
+  <div class="cancel-row">
+    <div class="cancel-label">Cancel</div>
+    <div class="cancel-options" role="radiogroup" aria-label="Cancel timing">
+      <label class="cancel-option">
+        <input
+          type="radio"
+          name="subscription-cancel-mode"
+          [checked]="selectedMode() === 'immediately'"
+          [disabled]="loading"
+          (change)="SelectMode('immediately')"
+        />
+        <span class="cancel-option-text">
+          <span class="cancel-option-title">Immediately</span>
+          <span class="cancel-option-date">{{ GetImmediateDateLabel() }}</span>
+        </span>
+      </label>
+      <label class="cancel-option">
+        <input
+          type="radio"
+          name="subscription-cancel-mode"
+          [checked]="selectedMode() === 'period_end'"
+          [disabled]="loading"
+          (change)="SelectMode('period_end')"
+        />
+        <span class="cancel-option-text">
+          <span class="cancel-option-title">End of the current period</span>
+          <span class="cancel-option-date">{{ GetPeriodEndDateLabel() }}</span>
+        </span>
+      </label>
+    </div>
+  </div>
+  <div class="cancel-divider"></div>
+</app-modal>

--- a/apps/web/src/app/features/account/subscriptions/components/subscription-cancel-modal/subscription-cancel-modal.component.scss
+++ b/apps/web/src/app/features/account/subscriptions/components/subscription-cancel-modal/subscription-cancel-modal.component.scss
@@ -1,0 +1,77 @@
+@use '../../../../../styles/base.scss' as *;
+
+:host {
+  display: contents;
+}
+
+:host ::ng-deep .modal-surface {
+  max-width: 560px;
+}
+
+.cancel-row {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: $spacing-medium;
+  align-items: start;
+}
+
+.cancel-label {
+  font-size: $font-size;
+  font-weight: $medium-weight;
+  color: $text-color;
+  padding-top: 2px;
+}
+
+.cancel-options {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing;
+}
+
+.cancel-option {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-small;
+  margin: 0;
+  cursor: pointer;
+
+  input[type='radio'] {
+    width: 18px;
+    height: 18px;
+    margin: 2px $spacing-small 0 0;
+    flex-shrink: 0;
+    accent-color: $button-color;
+  }
+}
+
+.cancel-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-extra-small;
+}
+
+.cancel-option-title {
+  font-size: $font-size;
+  font-weight: $medium-weight;
+  color: $text-color;
+  line-height: 1.4;
+}
+
+.cancel-option-date {
+  font-size: $font-size-small;
+  color: $text-color;
+  opacity: $dimmed-extra;
+  line-height: 1.4;
+}
+
+.cancel-divider {
+  margin-top: $spacing-medium;
+  border-top: 1px solid $darkest-background-color;
+}
+
+@media only screen and (max-width: 600px) {
+  .cancel-row {
+    grid-template-columns: 1fr;
+    gap: $spacing-small;
+  }
+}

--- a/apps/web/src/app/features/account/subscriptions/components/subscription-cancel-modal/subscription-cancel-modal.component.ts
+++ b/apps/web/src/app/features/account/subscriptions/components/subscription-cancel-modal/subscription-cancel-modal.component.ts
@@ -1,0 +1,64 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  signal,
+  WritableSignal,
+} from '@angular/core';
+import type { Subscription } from '@zoneless/shared-types';
+import { ModalComponent } from '../../../../../shared';
+import {
+  FormatMediumDate,
+  GetSubscriptionCurrentPeriod,
+} from '../../util/subscription-display';
+
+export type SubscriptionCancelMode = 'immediately' | 'period_end';
+
+@Component({
+  selector: 'app-subscription-cancel-modal',
+  imports: [ModalComponent],
+  templateUrl: './subscription-cancel-modal.component.html',
+  styleUrl: './subscription-cancel-modal.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubscriptionCancelModalComponent implements OnChanges {
+  @Input() isOpen = false;
+  @Input() loading = false;
+  @Input() subscription: Subscription | null = null;
+
+  @Output() confirmed = new EventEmitter<SubscriptionCancelMode>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  readonly selectedMode: WritableSignal<SubscriptionCancelMode> =
+    signal('immediately');
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['isOpen'] && this.isOpen) {
+      this.selectedMode.set('immediately');
+    }
+  }
+
+  GetImmediateDateLabel(): string {
+    return FormatMediumDate(Math.floor(Date.now() / 1000));
+  }
+
+  GetPeriodEndDateLabel(): string {
+    const periodEnd = this.subscription
+      ? GetSubscriptionCurrentPeriod(this.subscription).end
+      : null;
+    if (!periodEnd) return '—';
+    return FormatMediumDate(periodEnd);
+  }
+
+  SelectMode(mode: SubscriptionCancelMode): void {
+    this.selectedMode.set(mode);
+  }
+
+  OnConfirm(): void {
+    this.confirmed.emit(this.selectedMode());
+  }
+}

--- a/apps/web/src/app/features/account/subscriptions/services/subscription-actions.service.ts
+++ b/apps/web/src/app/features/account/subscriptions/services/subscription-actions.service.ts
@@ -2,11 +2,13 @@ import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import type { Subscription } from '@zoneless/shared-types';
 import { Subject } from 'rxjs';
 import { SubscriptionService } from '../../../../data';
+import type { PopupMenuAction } from '../../../../shared';
+import type { SubscriptionCancelMode } from '../components/subscription-cancel-modal/subscription-cancel-modal.component';
+import { IsSubscriptionCancelingAtPeriodEnd } from '../util/subscription-display';
 
-export type SubscriptionActionEvent = {
-  type: 'updated';
-  subscription: Subscription;
-};
+export type SubscriptionActionEvent =
+  | { type: 'updated'; subscription: Subscription }
+  | { type: 'canceled'; subscription: Subscription };
 
 @Injectable()
 export class SubscriptionActionsService {
@@ -17,7 +19,43 @@ export class SubscriptionActionsService {
   metadataTarget: WritableSignal<Subscription | null> = signal(null);
   metadataDraft: WritableSignal<Record<string, string>> = signal({});
 
+  cancelDialogOpen: WritableSignal<boolean> = signal(false);
+  cancelSaving: WritableSignal<boolean> = signal(false);
+  cancelTarget: WritableSignal<Subscription | null> = signal(null);
+
   readonly events$ = new Subject<SubscriptionActionEvent>();
+
+  GetMenuActions(): PopupMenuAction[] {
+    return [
+      {
+        title: 'Copy subscription ID',
+        action: (item: Subscription) => this.CopySubscriptionId(item),
+      },
+      {
+        title: 'Cancel subscription',
+        destructive: true,
+        action: (item: Subscription) => this.OpenCancel(item),
+        hidden: (item: Subscription) =>
+          item.status === 'canceled' ||
+          IsSubscriptionCancelingAtPeriodEnd(item),
+      },
+      {
+        title: "Don't cancel",
+        action: (item: Subscription) => {
+          void this.UnscheduleCancel(item);
+        },
+        hidden: (item: Subscription) =>
+          !IsSubscriptionCancelingAtPeriodEnd(item),
+      },
+      {
+        title: 'Cancel now',
+        destructive: true,
+        action: (item: Subscription) => this.OpenCancel(item),
+        hidden: (item: Subscription) =>
+          !IsSubscriptionCancelingAtPeriodEnd(item),
+      },
+    ];
+  }
 
   OpenEditMetadata(subscription: Subscription): void {
     this.metadataTarget.set(subscription);
@@ -42,6 +80,47 @@ export class SubscriptionActionsService {
       this.metadataDialogOpen.set(false);
     } finally {
       this.metadataSaving.set(false);
+    }
+  }
+
+  OpenCancel(subscription: Subscription): void {
+    this.cancelTarget.set(subscription);
+    this.cancelDialogOpen.set(true);
+  }
+
+  CloseCancel(): void {
+    if (this.cancelSaving()) return;
+    this.cancelDialogOpen.set(false);
+    this.cancelTarget.set(null);
+  }
+
+  async UnscheduleCancel(subscription: Subscription): Promise<void> {
+    const updated = await this.subscriptionService.UpdateSubscription(
+      subscription.id,
+      { cancel_at_period_end: false }
+    );
+    this.events$.next({ type: 'updated', subscription: updated });
+  }
+
+  async ConfirmCancel(mode: SubscriptionCancelMode): Promise<void> {
+    const subscription = this.cancelTarget();
+    if (!subscription) return;
+    this.cancelSaving.set(true);
+    try {
+      const updated =
+        mode === 'immediately'
+          ? await this.subscriptionService.CancelSubscription(subscription.id)
+          : await this.subscriptionService.UpdateSubscription(subscription.id, {
+              cancel_at_period_end: true,
+            });
+      this.events$.next({
+        type: mode === 'immediately' ? 'canceled' : 'updated',
+        subscription: updated,
+      });
+      this.cancelDialogOpen.set(false);
+      this.cancelTarget.set(null);
+    } finally {
+      this.cancelSaving.set(false);
     }
   }
 

--- a/apps/web/src/app/features/account/subscriptions/util/subscription-display.ts
+++ b/apps/web/src/app/features/account/subscriptions/util/subscription-display.ts
@@ -1,5 +1,4 @@
 import type {
-  Customer,
   Price,
   Product,
   RecurringInterval,
@@ -16,19 +15,44 @@ import {
  * Mirrors Stripe: active subscriptions set to cancel show "Cancels {date}".
  */
 export function GetSubscriptionListStatus(subscription: Subscription): string {
-  if (
-    subscription.cancel_at_period_end &&
-    (subscription.status === 'active' || subscription.status === 'trialing')
-  ) {
-    const cancelAt =
-      subscription.cancel_at ??
-      subscription.items?.data?.[0]?.current_period_end ??
-      null;
+  if (IsSubscriptionCancelingAtPeriodEnd(subscription)) {
+    const cancelAt = GetSubscriptionCancelAt(subscription);
     if (cancelAt) {
       return `Cancels ${FormatShortDate(cancelAt)}`;
     }
   }
   return subscription.status;
+}
+
+/** True when an active/trialing subscription is scheduled to end at period end. */
+export function IsSubscriptionCancelingAtPeriodEnd(
+  subscription: Subscription
+): boolean {
+  return (
+    !!subscription.cancel_at_period_end &&
+    (subscription.status === 'active' || subscription.status === 'trialing')
+  );
+}
+
+/** Effective cancel timestamp for a scheduled period-end cancel. */
+export function GetSubscriptionCancelAt(
+  subscription: Subscription
+): number | null {
+  return (
+    subscription.cancel_at ??
+    subscription.items?.data?.[0]?.current_period_end ??
+    null
+  );
+}
+
+/** Chip label, e.g. "Cancels 10 Aug". */
+export function FormatSubscriptionCancelChipLabel(
+  subscription: Subscription
+): string | null {
+  if (!IsSubscriptionCancelingAtPeriodEnd(subscription)) return null;
+  const cancelAt = GetSubscriptionCancelAt(subscription);
+  if (!cancelAt) return null;
+  return `Cancels ${FormatShortDate(cancelAt)}`;
 }
 
 /** Customer email or ID for list/detail displays. */
@@ -61,14 +85,6 @@ export function FormatSubscriptionCustomerTitle(
   if (!customer) return '—';
   if (typeof customer === 'string') return customer;
   return customer.name ?? customer.id;
-}
-
-export function FormatSubscriptionCustomerDescription(
-  subscription: Subscription
-): string {
-  const customer = subscription.customer;
-  if (!customer || typeof customer === 'string') return '—';
-  return (customer as Customer).description ?? '—';
 }
 
 export function GetSubscriptionCustomerId(
@@ -288,7 +304,8 @@ export function GetUpcomingInvoicePreview(subscription: Subscription): {
   if (
     subscription.status === 'canceled' ||
     subscription.status === 'incomplete_expired' ||
-    subscription.status === 'incomplete'
+    subscription.status === 'incomplete' ||
+    IsSubscriptionCancelingAtPeriodEnd(subscription)
   ) {
     return null;
   }

--- a/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.html
+++ b/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.html
@@ -11,21 +11,10 @@
         <span>{{ productName() }}</span>
       </h1>
       <app-status-chip [status]="s.status"></app-status-chip>
-    </div>
-    <div class="flex align-vert gap-extra-large summary-row">
-      <div class="summary-item">
-        <span class="summary-label">Started</span>
-        <span class="summary-value">{{
-          FormatShortDate(s.start_date || s.created)
-        }}</span>
-      </div>
-      @if (nextInvoiceDate(); as nextDate) {
-      <div class="summary-item">
-        <span class="summary-label">Next invoice</span>
-        <span class="summary-value">
-          {{ FormatSubscriptionAmount(nextInvoiceAmount()) }} on
-          {{ FormatShortDateTime(nextDate) }}
-        </span>
+      @if (cancelChipLabel(); as cancelLabel) {
+      <div class="chip grey-chip cancels-chip">
+        <span>{{ cancelLabel }}</span>
+        <img src="assets/icons/clock.svg" alt="" />
       </div>
       }
     </div>
@@ -47,8 +36,58 @@
   </div>
 </div>
 
+<div class="summary-metrics">
+  <div class="summary-metric">
+    <span class="summary-label">Started</span>
+    <span class="summary-value">{{
+      FormatShortDate(s.start_date || s.created)
+    }}</span>
+  </div>
+  <div class="summary-metric">
+    <span class="summary-label">Next invoice</span>
+    @if (isCancelingAtPeriodEnd()) {
+    <span class="summary-value">No further invoice</span>
+    } @else if (nextInvoiceDate(); as nextDate) {
+    <span class="summary-value">
+      {{ FormatSubscriptionAmount(nextInvoiceAmount()) }} on
+      {{ FormatShortDateTime(nextDate) }}
+    </span>
+    } @else {
+    <span class="summary-value">—</span>
+    }
+  </div>
+  @if (isCancelingAtPeriodEnd()) {
+  <div class="summary-metric">
+    <span class="summary-label">Ends</span>
+    <span class="summary-value">At period end</span>
+  </div>
+  } @if (autoCancelAt(); as autoCancelDate) {
+  <div class="summary-metric">
+    <span class="summary-label summary-label-with-icon">
+      Auto-cancels
+      <app-more-info-hover
+        text="Unless marked as exempt, test subscriptions created at least 90 days ago will automatically be cancelled. 30 days after, these subscriptions will be deleted."
+      ></app-more-info-hover>
+    </span>
+    <span class="summary-value summary-value-link">{{
+      FormatShortDate(autoCancelDate)
+    }}</span>
+  </div>
+  }
+</div>
+
 <div class="flex gap-extra-large view-panels">
   <div class="view-left-panel">
+    @if (isCancelingAtPeriodEnd() && cancelAt(); as cancelDate) {
+    <div class="view-section">
+      <h2 class="section-title">Cancellation details</h2>
+      <div class="mb">
+        <div class="bolded mb-small">Scheduled to cancel on</div>
+        <div class="link-highlight">{{ FormatShortDateTime(cancelDate) }}</div>
+      </div>
+    </div>
+    }
+
     <!-- Pricing -->
     <div class="view-section">
       <h2 class="section-title">Pricing</h2>

--- a/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.scss
+++ b/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.scss
@@ -22,23 +22,67 @@
   opacity: $dimmed;
 }
 
-.summary-row {
-  margin-top: $spacing-extra-small;
+.cancels-chip {
+  gap: $spacing-extra-small;
+
+  img {
+    width: 12px;
+    height: 12px;
+  }
 }
 
-.summary-item {
+.summary-metrics {
   display: flex;
-  align-items: baseline;
+  flex-wrap: wrap;
+  align-items: stretch;
+  margin-top: $spacing;
+  margin-bottom: $spacing-large;
+  padding-top: $spacing;
+  border-top: 1px solid $darkest-background-color;
+}
+
+.summary-metric {
+  display: flex;
+  flex-direction: column;
   gap: $spacing-extra-small;
-  font-size: $font-size;
+  padding: 0 $spacing-medium;
+  min-width: 120px;
+
+  &:first-child {
+    padding-left: 0;
+  }
+
+  &:not(:first-child) {
+    border-left: 1px solid $darkest-background-color;
+  }
 }
 
 .summary-label {
-  opacity: $dimmed;
+  font-size: $font-size-small;
+  color: $text-color;
+  opacity: $dimmed-extra;
+  font-weight: $text-weight;
+  line-height: 1.3;
+}
+
+.summary-label-with-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-extra-small;
 }
 
 .summary-value {
-  font-weight: 500;
+  font-size: $font-size;
+  color: $text-color;
+  font-weight: $text-weight;
+  line-height: 1.4;
+}
+
+.summary-value-link {
+  color: $base-color;
+  font-weight: $medium-weight;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .section-edit-top {
@@ -115,4 +159,22 @@
   border-top: 1px solid $darkest-background-color;
   padding-top: $spacing-small;
   margin-top: $spacing-extra-small;
+}
+
+@media only screen and (max-width: 700px) {
+  .summary-metrics {
+    flex-direction: column;
+    gap: $spacing;
+  }
+
+  .summary-metric {
+    padding: 0;
+    min-width: 0;
+
+    &:not(:first-child) {
+      border-left: none;
+      padding-top: $spacing-small;
+      border-top: 1px solid $darker-background-color;
+    }
+  }
 }

--- a/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.ts
+++ b/apps/web/src/app/features/account/subscriptions/views/subscription-detail/subscription-detail.component.ts
@@ -16,6 +16,7 @@ import { SubscriptionService } from '../../../../../data';
 import { MetaService } from '../../../../../core';
 import {
   CopyTextComponent,
+  MoreInfoHoverComponent,
   PaginatedListComponent,
   PaginatedListColumn,
   PopupMenuAction,
@@ -37,6 +38,7 @@ import {
   FormatSubscriptionAmount,
   FormatSubscriptionBillingMethod,
   FormatSubscriptionBillingMode,
+  FormatSubscriptionCancelChipLabel,
   FormatSubscriptionCustomerTitle,
   FormatSubscriptionDateRange,
   FormatSubscriptionDiscounts,
@@ -45,11 +47,13 @@ import {
   FormatSubscriptionItemTotal,
   FormatSubscriptionPeriodRange,
   FormatSubscriptionProduct,
+  GetSubscriptionCancelAt,
   GetSubscriptionCurrentPeriod,
   GetSubscriptionCustomerId,
   GetSubscriptionItemProductId,
   GetSubscriptionItemsTotalCents,
   GetUpcomingInvoicePreview,
+  IsSubscriptionCancelingAtPeriodEnd,
 } from '../../util/subscription-display';
 
 @Component({
@@ -64,6 +68,7 @@ import {
     EventsListComponent,
     CopyTextComponent,
     StatusChipComponent,
+    MoreInfoHoverComponent,
   ],
   templateUrl: './subscription-detail.component.html',
   styleUrl: './subscription-detail.component.scss',
@@ -125,6 +130,28 @@ export class SubscriptionDetailComponent implements OnInit, OnDestroy {
     return sub ? GetUpcomingInvoicePreview(sub) : null;
   });
 
+  readonly isCancelingAtPeriodEnd = computed(() => {
+    const sub = this.subscription();
+    return sub ? IsSubscriptionCancelingAtPeriodEnd(sub) : false;
+  });
+
+  readonly cancelAt = computed(() => {
+    const sub = this.subscription();
+    return sub ? GetSubscriptionCancelAt(sub) : null;
+  });
+
+  /** Test-mode cleanup date: created + 90 days (Stripe auto-cancels). */
+  readonly autoCancelAt = computed(() => {
+    const sub = this.subscription();
+    if (!sub || sub.livemode || sub.status === 'canceled') return null;
+    return sub.created + 90 * 24 * 60 * 60;
+  });
+
+  readonly cancelChipLabel = computed(() => {
+    const sub = this.subscription();
+    return sub ? FormatSubscriptionCancelChipLabel(sub) : null;
+  });
+
   readonly nextInvoiceAmount = computed(() => {
     const upcoming = this.upcomingInvoice();
     if (upcoming) return upcoming.total;
@@ -147,15 +174,7 @@ export class SubscriptionDetailComponent implements OnInit, OnDestroy {
 
   private sub?: RxSubscription;
 
-  subscriptionActions: PopupMenuAction[] = [
-    {
-      title: 'Copy subscription ID',
-      action: () => {
-        const subscription = this.subscription();
-        if (subscription) this.actions.CopySubscriptionId(subscription);
-      },
-    },
-  ];
+  subscriptionActions: PopupMenuAction[] = this.actions.GetMenuActions();
 
   async ngOnInit(): Promise<void> {
     const id = this.route.snapshot.paramMap.get('subscriptionId');
@@ -164,7 +183,10 @@ export class SubscriptionDetailComponent implements OnInit, OnDestroy {
     this.metaService.SetMetaTitle(this.GetMetaTitle());
     this.InitInvoiceList(id);
     this.sub = this.actions.events$.subscribe((event) => {
-      if (event.type === 'updated' && event.subscription.id === id) {
+      if (
+        (event.type === 'updated' || event.type === 'canceled') &&
+        event.subscription.id === id
+      ) {
         void this.LoadSubscription(id);
       }
     });

--- a/apps/web/src/app/features/account/subscriptions/views/subscription-list/subscription-list.component.html
+++ b/apps/web/src/app/features/account/subscriptions/views/subscription-list/subscription-list.component.html
@@ -62,6 +62,7 @@
 </div>
 
 <app-paginated-list
+  #subscriptionsList
   endpoint="subscriptions"
   [columns]="subscriptionColumns"
   [limit]="10"
@@ -69,3 +70,5 @@
   [expand]="subscriptionsExpand()"
   (rowClick)="OnSubscriptionClick($event)"
 ></app-paginated-list>
+
+<app-subscription-actions-host></app-subscription-actions-host>

--- a/apps/web/src/app/features/account/subscriptions/views/subscription-list/subscription-list.component.ts
+++ b/apps/web/src/app/features/account/subscriptions/views/subscription-list/subscription-list.component.ts
@@ -5,6 +5,8 @@ import {
   signal,
   inject,
   OnInit,
+  OnDestroy,
+  ViewChild,
 } from '@angular/core';
 import { Router } from '@angular/router';
 import {
@@ -12,30 +14,35 @@ import {
   PaginatedListColumn,
 } from '../../../../../shared';
 import type { Subscription } from '@zoneless/shared-types';
+import { Subscription as RxSubscription } from 'rxjs';
 import { MetaService } from '../../../../../core';
 import {
   FormatSubscriptionCollectionMethod,
-  FormatSubscriptionCustomerDescription,
   FormatSubscriptionCustomerEmail,
   FormatSubscriptionCustomerName,
   FormatSubscriptionProduct,
   GetSubscriptionListStatus,
 } from '../../util/subscription-display';
 import { SubscriptionActionsService } from '../../services/subscription-actions.service';
+import { SubscriptionActionsHostComponent } from '../../components/subscription-actions-host/subscription-actions-host.component';
 
 type SubscriptionsStatusTab = 'active' | 'paused' | 'canceled' | 'all';
 
 @Component({
   selector: 'app-subscription-list',
-  imports: [PaginatedListComponent],
+  imports: [PaginatedListComponent, SubscriptionActionsHostComponent],
   templateUrl: './subscription-list.component.html',
   styleUrl: './subscription-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SubscriptionListComponent implements OnInit {
+export class SubscriptionListComponent implements OnInit, OnDestroy {
   private readonly metaService = inject(MetaService);
   private readonly router = inject(Router);
   private readonly actions = inject(SubscriptionActionsService);
+  @ViewChild('subscriptionsList')
+  subscriptionsList?: PaginatedListComponent<any>;
+
+  private sub?: RxSubscription;
 
   subscriptionsStatusTab: WritableSignal<SubscriptionsStatusTab> =
     signal('active');
@@ -65,14 +72,6 @@ export class SubscriptionListComponent implements OnInit {
         FormatSubscriptionCustomerName(item as Subscription),
     },
     {
-      header: 'Customer description',
-      field: 'customer.description',
-      type: 'text',
-      dimmed: true,
-      formatter: (item: unknown) =>
-        FormatSubscriptionCustomerDescription(item as Subscription),
-    },
-    {
       header: 'Collection method',
       field: 'collection_method',
       type: 'text',
@@ -99,12 +98,7 @@ export class SubscriptionListComponent implements OnInit {
       header: '',
       field: '',
       type: 'actions',
-      actions: [
-        {
-          title: 'Copy subscription ID',
-          action: (item: Subscription) => this.actions.CopySubscriptionId(item),
-        },
-      ],
+      actions: this.actions.GetMenuActions(),
     },
   ];
 
@@ -118,6 +112,13 @@ export class SubscriptionListComponent implements OnInit {
 
   ngOnInit(): void {
     this.metaService.SetMetaTitle('Subscriptions');
+    this.sub = this.actions.events$.subscribe(() => {
+      void this.subscriptionsList?.Reload();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
   }
 
   SetSubscriptionsStatusTab(tab: SubscriptionsStatusTab): void {

--- a/apps/web/src/app/shared/ui/popup-menu/popup-menu.component.html
+++ b/apps/web/src/app/shared/ui/popup-menu/popup-menu.component.html
@@ -27,6 +27,7 @@
       tabindex="0"
       [class.popup-menu-item-disabled]="isDisabled"
       [class.popup-menu-item-hidden]="isHidden"
+      [class.popup-menu-item-destructive]="action.destructive"
       (click)="OnActionClick($event, action, item, isDisabled)"
       (keydown.enter)="OnActionClick($event, action, item, isDisabled)"
       (keydown.space)="OnActionClick($event, action, item, isDisabled)"

--- a/apps/web/src/app/shared/ui/popup-menu/popup-menu.component.ts
+++ b/apps/web/src/app/shared/ui/popup-menu/popup-menu.component.ts
@@ -19,6 +19,8 @@ export interface PopupMenuAction {
   disabled?: (item: any) => boolean;
   /** Optional predicate to hide the action for a given item */
   hidden?: (item: any) => boolean;
+  /** Style the action as destructive (red) */
+  destructive?: boolean;
 }
 
 @Component({

--- a/apps/web/src/app/styles/chips.scss
+++ b/apps/web/src/app/styles/chips.scss
@@ -10,6 +10,7 @@
   align-items: center;
   height: 20px;
   gap: 2px;
+  white-space: nowrap;
 }
 
 .chip a {

--- a/apps/web/src/app/styles/popup-menu.scss
+++ b/apps/web/src/app/styles/popup-menu.scss
@@ -59,6 +59,18 @@
   display: none;
 }
 
+.popup-menu-item-destructive {
+  color: #dc2626;
+
+  .popup-menu-item-title {
+    color: #dc2626;
+  }
+
+  &:hover {
+    background-color: rgba(220, 38, 38, 0.06);
+  }
+}
+
 @keyframes popupMenuFadeIn {
   from {
     opacity: 0;


### PR DESCRIPTION
## Description

Adds the ability to cancel / resume a subscription, and menu buttons to do this via the dashboard.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
