### PR TITLE
feat: edit business details + improve setup copy

### DIFF
--- a/apps/web/src/app/data/services/account.service.ts
+++ b/apps/web/src/app/data/services/account.service.ts
@@ -1,26 +1,11 @@
 import { Injectable, signal, WritableSignal, inject } from '@angular/core';
 import { ApiService } from '../../core/services/api.service';
 import { Account, LoginLink } from '@zoneless/shared-types';
-import { CreateAccountInput } from '@zoneless/shared-schemas';
-
-/**
- * Input type for updating an account.
- * All fields are optional - only provided fields will be updated.
- * Protected fields (id, object, created, payouts_enabled, details_submitted, tos_acceptance)
- * cannot be updated directly.
- */
-export type AccountUpdateInput = Partial<
-  Omit<
-    Account,
-    | 'id'
-    | 'object'
-    | 'created'
-    | 'payouts_enabled'
-    | 'details_submitted'
-    | 'tos_acceptance'
-    | 'individual'
-  >
->;
+import {
+  CreateAccountInput,
+  UpdateAccountInput,
+} from '@zoneless/shared-schemas';
+import { SettingsCardRow } from '../../shared';
 
 @Injectable({
   providedIn: 'root',
@@ -59,7 +44,7 @@ export class AccountService {
 
   async UpdateAccount(
     accountId: string,
-    data: AccountUpdateInput
+    data: UpdateAccountInput
   ): Promise<Account> {
     this.loading.set(true);
     try {
@@ -161,5 +146,39 @@ export class AccountService {
     }
 
     return account.email ?? individual?.email ?? account.id;
+  }
+
+  /**
+   * Display title for the Business details settings card.
+   */
+  GetBusinessDetailsTitle(account: Account | null): string {
+    if (!account) return 'Business details';
+    return (
+      account.business_profile?.name?.trim() ||
+      account.settings?.dashboard?.display_name?.trim() ||
+      'Business details'
+    );
+  }
+
+  GetBusinessDetailsCardRows(account: Account | null): SettingsCardRow[] {
+    if (!account) return [];
+
+    return [
+      {
+        label: 'Logo',
+        value: account.settings?.branding?.logo || '—',
+        type: 'text',
+      },
+      {
+        label: 'Terms of Service',
+        value: account.settings?.terms_url || '—',
+        type: 'text',
+      },
+      {
+        label: 'Privacy Policy',
+        value: account.settings?.privacy_url || '—',
+        type: 'text',
+      },
+    ];
   }
 }

--- a/apps/web/src/app/features/account/settings/settings.component.html
+++ b/apps/web/src/app/features/account/settings/settings.component.html
@@ -2,7 +2,21 @@
   <h1>Settings</h1>
 </div>
 
-<!-- Personal Details Card -->
+<!-- Business Details Card (platform only) -->
+@if (authService.isPlatform()) {
+<div class="view-section">
+  <div class="settings-section-title">Business details</div>
+  <app-settings-card
+    [title]="accountService.GetBusinessDetailsTitle(accountService.account())"
+    [rows]="accountService.GetBusinessDetailsCardRows(accountService.account())"
+    [showEditButton]="true"
+    (editClicked)="OnEditBusinessClick()"
+  ></app-settings-card>
+</div>
+}
+
+<!-- Personal Details Card (connected accounts only) -->
+@if (!authService.isPlatform()) {
 <div class="view-section">
   <div class="settings-section-title">Personal details</div>
   <app-settings-card
@@ -12,6 +26,7 @@
     (editClicked)="OnEditPersonClick()"
   ></app-settings-card>
 </div>
+}
 
 <!-- External Wallet Card -->
 @if (externalWalletService.wallet()) {
@@ -37,7 +52,29 @@
   </button>
 </div>
 
+<!-- Edit Business Details Slide Panel -->
+@if (authService.isPlatform()) {
+<app-slide-panel
+  [isOpen]="editBusinessPanelOpen()"
+  title="Edit business details"
+  [loading]="editBusinessLoading()"
+  submitLabel="Save"
+  [submitDisabled]="false"
+  (closed)="OnEditBusinessPanelClosed()"
+  (submitted)="OnEditBusinessSubmit()"
+>
+  <app-business-profile-form
+    #editBusinessForm
+    mode="edit"
+    [account]="accountService.account()"
+    [isOpen]="editBusinessPanelOpen()"
+    [showErrors]="editBusinessShowErrors()"
+  ></app-business-profile-form>
+</app-slide-panel>
+}
+
 <!-- Edit Person Slide Panel -->
+@if (!authService.isPlatform()) {
 <app-slide-panel
   [isOpen]="editPersonPanelOpen()"
   title="Edit personal details"
@@ -55,6 +92,7 @@
     [showErrors]="editPersonShowErrors()"
   ></app-person-form>
 </app-slide-panel>
+}
 
 <!-- Edit Wallet Slide Panel -->
 <app-slide-panel

--- a/apps/web/src/app/features/account/settings/settings.component.ts
+++ b/apps/web/src/app/features/account/settings/settings.component.ts
@@ -20,13 +20,15 @@ import {
   TransactionService,
   WebhookEndpointService,
   TopupService,
+  ConfigService,
 } from '../../../data';
 import {
+  BusinessProfileFormComponent,
   ExternalWalletFormComponent,
   PersonFormComponent,
   SettingsCardComponent,
+  SlidePanelComponent,
 } from '../../../shared';
-import { SlidePanelComponent } from '../../../shared';
 
 @Component({
   selector: 'app-settings',
@@ -34,6 +36,7 @@ import { SlidePanelComponent } from '../../../shared';
     SlidePanelComponent,
     PersonFormComponent,
     ExternalWalletFormComponent,
+    BusinessProfileFormComponent,
     SettingsCardComponent,
   ],
   templateUrl: './settings.component.html',
@@ -43,6 +46,8 @@ import { SlidePanelComponent } from '../../../shared';
 export class SettingsComponent implements OnInit {
   @ViewChild('editPersonForm') editPersonForm!: PersonFormComponent;
   @ViewChild('editWalletForm') editWalletForm!: ExternalWalletFormComponent;
+  @ViewChild('editBusinessForm')
+  editBusinessForm!: BusinessProfileFormComponent;
 
   readonly personService = inject(PersonService);
   readonly externalWalletService = inject(ExternalWalletService);
@@ -53,6 +58,7 @@ export class SettingsComponent implements OnInit {
   readonly webhookEndpointService = inject(WebhookEndpointService);
   readonly apiKeyService = inject(ApiKeyService);
   readonly topupService = inject(TopupService);
+  readonly configService = inject(ConfigService);
   readonly router = inject(Router);
   private readonly metaService = inject(MetaService);
 
@@ -67,8 +73,52 @@ export class SettingsComponent implements OnInit {
   editWalletShowErrors: WritableSignal<boolean> = signal(false);
   walletFormValid: WritableSignal<boolean> = signal(false);
 
+  // Edit business details panel state
+  editBusinessPanelOpen: WritableSignal<boolean> = signal(false);
+  editBusinessLoading: WritableSignal<boolean> = signal(false);
+  editBusinessShowErrors: WritableSignal<boolean> = signal(false);
+
   ngOnInit(): void {
     this.metaService.SetMetaTitle('Settings');
+  }
+
+  // Edit Business Panel
+  OnEditBusinessClick(): void {
+    this.editBusinessShowErrors.set(false);
+    this.editBusinessPanelOpen.set(true);
+  }
+
+  OnEditBusinessPanelClosed(): void {
+    this.editBusinessPanelOpen.set(false);
+    this.editBusinessShowErrors.set(false);
+  }
+
+  async OnEditBusinessSubmit(): Promise<void> {
+    if (!this.editBusinessForm) return;
+
+    this.editBusinessShowErrors.set(true);
+
+    if (!this.editBusinessForm.ValidateAll()) {
+      return;
+    }
+
+    const account = this.GetAccount();
+    if (!account) return;
+
+    this.editBusinessLoading.set(true);
+
+    try {
+      const updateData = this.editBusinessForm.GetUpdateData();
+      await this.accountService.UpdateAccount(account.id, updateData);
+      this.configService.ClearConfig();
+      await this.configService.LoadConfig();
+      this.editBusinessPanelOpen.set(false);
+      this.editBusinessShowErrors.set(false);
+    } catch (error) {
+      console.error('Failed to update business details:', error);
+    } finally {
+      this.editBusinessLoading.set(false);
+    }
   }
 
   // Edit Person Panel

--- a/apps/web/src/app/features/setup/setup.component.html
+++ b/apps/web/src/app/features/setup/setup.component.html
@@ -47,29 +47,29 @@
       />
       <h1>Welcome to Zoneless</h1>
       <p class="welcome-subtitle">
-        The open-source Stripe Connect alternative for USDC payouts.
+        The open-source Stripe, built on stablecoins.
       </p>
 
       <div class="feature-list">
         <div class="feature-item">
           <img class="feature-icon" src="assets/icons/bolt.svg" alt="" />
           <div class="feature-text">
-            <strong>Instant payouts</strong>
-            <span>Instant USDC payouts to your sellers</span>
+            <strong>Instant settlement</strong>
+            <span>Payments settle in seconds, 24/7</span>
           </div>
         </div>
         <div class="feature-item">
           <img class="feature-icon" src="assets/icons/globe.svg" alt="" />
           <div class="feature-text">
-            <strong>Global payouts</strong>
-            <span>Payouts to anywhere in the world</span>
+            <strong>Same API &amp; dashboard</strong>
+            <span>Stripe-compatible — migrate in an afternoon</span>
           </div>
         </div>
         <div class="feature-item">
           <img class="feature-icon" src="assets/icons/savings.svg" alt="" />
           <div class="feature-text">
             <strong>Near-zero fees</strong>
-            <span>No platform fees — just minimal Solana gas</span>
+            <span>Fractions of a cent per payment, not a percentage cut</span>
           </div>
         </div>
         <div class="feature-item">
@@ -79,8 +79,8 @@
             alt=""
           />
           <div class="feature-text">
-            <strong>No lock-in</strong>
-            <span>Fully open-source and free to use</span>
+            <strong>Self-custody</strong>
+            <span>Your keys, your money — fully open-source</span>
           </div>
         </div>
       </div>
@@ -90,8 +90,8 @@
       </button>
 
       <p class="setup-note">
-        This setup will only take a minute. You'll need to configure your
-        platform details and Solana wallet.
+        This setup will only take a minute. You'll configure your business
+        details and Solana wallet.
       </p>
     </div>
     }
@@ -101,73 +101,18 @@
     <div class="setup-content">
       <button type="button" class="back-button" (click)="Back()">← Back</button>
 
-      <h1>Platform Details</h1>
+      <h1>Business Details</h1>
       <p class="step-description">
-        Configure your platform's name and branding.
+        Configure your business name and branding. These appear on Checkout,
+        Payment Links, and your dashboard.
       </p>
 
-      <div class="form-group">
-        <label for="platformName">Platform Name *</label>
-        <input
-          type="text"
-          id="platformName"
-          [ngModel]="platformName()"
-          (ngModelChange)="platformName.set($event)"
-          placeholder="My Marketplace"
-          class="form-input"
-        />
-        <span class="field-help"
-          >This will be shown to your users during onboarding.</span
-        >
-      </div>
-
-      <div class="form-group">
-        <label for="platformLogo">Logo URL (optional)</label>
-        <input
-          type="url"
-          id="platformLogo"
-          [ngModel]="platformLogoUrl()"
-          (ngModelChange)="platformLogoUrl.set($event)"
-          placeholder="https://example.com/logo.png"
-          class="form-input"
-        />
-        <span class="field-help"
-          >A square image works best. If not provided, initials will be
-          shown.</span
-        >
-      </div>
-
-      <div class="form-group">
-        <label for="termsUrl">Terms of Service URL (optional)</label>
-        <input
-          type="url"
-          id="termsUrl"
-          [ngModel]="termsUrl()"
-          (ngModelChange)="termsUrl.set($event)"
-          placeholder="https://example.com/terms"
-          class="form-input"
-        />
-        <span class="field-help"
-          >Your platform's Terms of Service page. Shown to sellers during
-          onboarding.</span
-        >
-      </div>
-
-      <div class="form-group">
-        <label for="privacyUrl">Privacy Policy URL (optional)</label>
-        <input
-          type="url"
-          id="privacyUrl"
-          [ngModel]="privacyUrl()"
-          (ngModelChange)="privacyUrl.set($event)"
-          placeholder="https://example.com/privacy"
-          class="form-input"
-        />
-        <span class="field-help"
-          >Your platform's Privacy Policy page. Shown to sellers during
-          onboarding.</span
-        >
-      </div>
+      <app-business-profile-form
+        #platformDetailsForm
+        mode="setup"
+        [initialData]="platformDetails()"
+        [showErrors]="platformShowErrors()"
+      ></app-business-profile-form>
 
       @if(error()) {
       <div class="error-message">{{ error() }}</div>
@@ -186,9 +131,9 @@
 
       <h1>Solana Wallet</h1>
       <p class="step-description">
-        Configure your platform's Solana wallet for receiving USDC deposits and
-        sending payouts. Your wallet's secret key is generated locally and never
-        sent to Zoneless.
+        Configure the Solana wallet that holds your USDC balance. Your secret
+        key is generated locally and never sent to Zoneless — self-custody by
+        default.
       </p>
 
       <div class="wallet-options">
@@ -274,7 +219,7 @@
           </div>
           <div class="credential-value mono">{{ generatedPublicKey() }}</div>
           <span class="credential-help">
-            Send USDC to this address to top up your platform balance.
+            Send USDC to this address to fund your balance.
           </span>
         </div>
 
@@ -293,7 +238,7 @@
             {{ generatedSecretKey() }}
           </div>
           <span class="credential-help warning">
-            Store this securely on your server. You'll use it to sign payout
+            Store this securely on your server. You'll use it to sign
             transactions. This key is never sent to Zoneless.
           </span>
         </div>
@@ -312,7 +257,7 @@
           />
           <span class="field-help">
             Enter your Solana wallet address. Keep your secret key safe on your
-            own server - you'll use it to sign payout transactions.
+            own server — you'll use it to sign transactions.
           </span>
         </div>
       </div>
@@ -344,7 +289,7 @@
       />
       <h1>Setup Complete!</h1>
       <p class="step-description">
-        Your platform is configured and ready to use. Save your API key below -
+        Your payments stack is ready. Save your API key below —
         <strong>it won't be shown again.</strong>
       </p>
 
@@ -389,7 +334,7 @@
             {{ setupResult()!.solana_public_key }}
           </div>
           <span class="credential-help">
-            Send USDC to this address to top up your platform balance.
+            Send USDC to this address to fund your balance.
           </span>
         </div>
       </div>
@@ -397,7 +342,7 @@
       <div class="next-steps">
         <h3>Next Steps</h3>
         <ol>
-          <li>Save your API key - you'll need it to make API requests</li>
+          <li>Save your API key — you'll need it to make API requests</li>
           @if(walletOption() === 'generate') {
           <li>
             Save your secret key securely on your server (shown in previous
@@ -405,7 +350,10 @@
           </li>
           }
           <li>Fund your Solana wallet with SOL (for fees) and USDC</li>
-          <li>Integrate the Zoneless API into your application</li>
+          <li>
+            Point your Stripe integration at this instance, or explore the
+            dashboard
+          </li>
         </ol>
       </div>
 

--- a/apps/web/src/app/features/setup/setup.component.ts
+++ b/apps/web/src/app/features/setup/setup.component.ts
@@ -5,13 +5,19 @@ import {
   inject,
   signal,
   WritableSignal,
+  ViewChild,
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 
 import { MetaService, StorageService } from '../../core';
 import { SetupService } from '../../data';
-import { PageLoaderComponent, LoaderComponent } from '../../shared';
+import {
+  BusinessProfileFormComponent,
+  BusinessProfileSetupData,
+  PageLoaderComponent,
+  LoaderComponent,
+} from '../../shared';
 import { SetupResponse } from '@zoneless/shared-types';
 
 enum SetupStep {
@@ -26,10 +32,18 @@ enum SetupStep {
   templateUrl: './setup.component.html',
   styleUrls: ['./setup.component.scss'],
   standalone: true,
-  imports: [FormsModule, PageLoaderComponent, LoaderComponent],
+  imports: [
+    FormsModule,
+    PageLoaderComponent,
+    LoaderComponent,
+    BusinessProfileFormComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SetupComponent implements OnInit {
+  @ViewChild('platformDetailsForm')
+  platformDetailsForm!: BusinessProfileFormComponent;
+
   private readonly meta = inject(MetaService);
   private readonly router = inject(Router);
   private readonly storage = inject(StorageService);
@@ -42,12 +56,9 @@ export class SetupComponent implements OnInit {
   submitting: WritableSignal<boolean> = signal(false);
   error: WritableSignal<string> = signal('');
   operatorMode: WritableSignal<boolean> = signal(false);
-
-  // Form data
-  platformName: WritableSignal<string> = signal('');
-  platformLogoUrl: WritableSignal<string> = signal('');
-  termsUrl: WritableSignal<string> = signal('');
-  privacyUrl: WritableSignal<string> = signal('');
+  platformShowErrors: WritableSignal<boolean> = signal(false);
+  platformDetails: WritableSignal<BusinessProfileSetupData | null> =
+    signal(null);
 
   // Wallet options
   walletOption: WritableSignal<'generate' | 'import'> = signal('generate');
@@ -124,10 +135,12 @@ export class SetupComponent implements OnInit {
         return true;
 
       case SetupStep.PLATFORM:
-        if (!this.platformName().trim()) {
-          this.error.set('Platform name is required');
+        this.platformShowErrors.set(true);
+        if (!this.platformDetailsForm?.ValidateAll()) {
           return false;
         }
+        this.platformDetails.set(this.platformDetailsForm.GetSetupData());
+        this.platformShowErrors.set(false);
         return true;
 
       case SetupStep.WALLET:
@@ -199,11 +212,14 @@ export class SetupComponent implements OnInit {
           ? this.generatedPublicKey()
           : this.importPublicKey().trim();
 
+      const platformDetails = this.platformDetails();
+      if (!platformDetails) {
+        this.error.set('Platform details are missing. Please go back.');
+        return;
+      }
+
       const response = await this.setupService.CompleteSetup({
-        platform_name: this.platformName().trim(),
-        platform_logo_url: this.platformLogoUrl().trim() || undefined,
-        terms_url: this.termsUrl().trim() || undefined,
-        privacy_url: this.privacyUrl().trim() || undefined,
+        ...platformDetails,
         solana_public_key: publicKey,
       });
 

--- a/apps/web/src/app/shared/forms/business-profile-form/business-profile-form.component.html
+++ b/apps/web/src/app/shared/forms/business-profile-form/business-profile-form.component.html
@@ -1,0 +1,92 @@
+<div class="business-profile-form">
+  <div class="field">
+    <div class="field-title">Business name</div>
+    @if (mode === 'setup') {
+    <p class="field-help">
+      This will be shown on Checkout, Payment Links, and your dashboard.
+    </p>
+    }
+    <input
+      [ngModel]="businessName()"
+      (ngModelChange)="OnBusinessNameChange($event)"
+      class="field-value"
+      type="text"
+      placeholder="Acme Inc"
+      name="organization"
+      autocomplete="organization"
+      [class.field-error]="showErrors && businessNameError()"
+    />
+    @if (showErrors && businessNameError()) {
+    <div class="error">{{ businessNameError() }}</div>
+    }
+  </div>
+
+  <div class="field">
+    <div class="field-title">
+      Logo URL <span class="field-optional">Optional</span>
+    </div>
+    @if (mode === 'setup') {
+    <p class="field-help">
+      A square image works best. If not provided, initials will be shown.
+    </p>
+    }
+    <input
+      [ngModel]="logoUrl()"
+      (ngModelChange)="OnLogoUrlChange($event)"
+      class="field-value"
+      type="url"
+      placeholder="https://example.com/logo.png"
+      name="logo-url"
+      [class.field-error]="showErrors && logoUrlError()"
+    />
+    @if (showErrors && logoUrlError()) {
+    <div class="error">{{ logoUrlError() }}</div>
+    }
+  </div>
+
+  <div class="field">
+    <div class="field-title">
+      Terms of Service URL <span class="field-optional">Optional</span>
+    </div>
+    @if (mode === 'setup') {
+    <p class="field-help">
+      Your Terms of Service page. Linked from Checkout and onboarding.
+    </p>
+    }
+    <input
+      [ngModel]="termsUrl()"
+      (ngModelChange)="OnTermsUrlChange($event)"
+      class="field-value"
+      type="url"
+      placeholder="https://example.com/terms"
+      name="terms-url"
+      [class.field-error]="showErrors && termsUrlError()"
+    />
+    @if (showErrors && termsUrlError()) {
+    <div class="error">{{ termsUrlError() }}</div>
+    }
+  </div>
+
+  <div class="field">
+    <div class="field-title">
+      Privacy Policy URL <span class="field-optional">Optional</span>
+    </div>
+    @if (mode === 'setup') {
+    <p class="field-help">
+      Your Privacy Policy page. Linked from Checkout and onboarding.
+    </p>
+    }
+    <input
+      [ngModel]="privacyUrl()"
+      (ngModelChange)="OnPrivacyUrlChange($event)"
+      class="field-value"
+      type="url"
+      placeholder="https://example.com/privacy"
+      name="privacy-url"
+      [class.field-error]="showErrors && privacyUrlError()"
+    />
+    @if (showErrors && privacyUrlError()) {
+    <div class="error">{{ privacyUrlError() }}</div>
+    }
+  </div>
+</div>

--- a/apps/web/src/app/shared/forms/business-profile-form/business-profile-form.component.scss
+++ b/apps/web/src/app/shared/forms/business-profile-form/business-profile-form.component.scss
@@ -1,0 +1,18 @@
+@use '../../../styles/base.scss' as *;
+@use '../../../styles/forms.scss' as *;
+
+.business-profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing;
+}
+
+.field-optional {
+  font-size: $font-size-small;
+  font-weight: normal;
+  color: $text-color;
+  opacity: $dimmed-extra;
+  background-color: $darker-background-color;
+  padding: 2px $spacing-small;
+  border-radius: $border-radius-small;
+}

--- a/apps/web/src/app/shared/forms/business-profile-form/business-profile-form.component.ts
+++ b/apps/web/src/app/shared/forms/business-profile-form/business-profile-form.component.ts
@@ -1,0 +1,233 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  signal,
+  WritableSignal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Account } from '@zoneless/shared-types';
+import { UpdateAccountInput } from '@zoneless/shared-schemas';
+
+export type BusinessProfileFormMode = 'setup' | 'edit';
+
+export interface BusinessProfileFormData {
+  businessName: string;
+  logoUrl: string;
+  termsUrl: string;
+  privacyUrl: string;
+}
+
+export interface BusinessProfileSetupData {
+  platform_name: string;
+  platform_logo_url?: string;
+  terms_url?: string;
+  privacy_url?: string;
+}
+
+@Component({
+  selector: 'app-business-profile-form',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './business-profile-form.component.html',
+  styleUrls: ['./business-profile-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BusinessProfileFormComponent implements OnInit, OnChanges {
+  @Input() mode: BusinessProfileFormMode = 'edit';
+  @Input() account: Account | null = null;
+  @Input() initialData: BusinessProfileSetupData | null = null;
+  @Input() showErrors = false;
+  @Input() isOpen = false;
+
+  @Output() formChange = new EventEmitter<BusinessProfileFormData>();
+  @Output() validationChange = new EventEmitter<boolean>();
+
+  businessName: WritableSignal<string> = signal('');
+  businessNameError: WritableSignal<string> = signal('');
+
+  logoUrl: WritableSignal<string> = signal('');
+  logoUrlError: WritableSignal<string> = signal('');
+
+  termsUrl: WritableSignal<string> = signal('');
+  termsUrlError: WritableSignal<string> = signal('');
+
+  privacyUrl: WritableSignal<string> = signal('');
+  privacyUrlError: WritableSignal<string> = signal('');
+
+  ngOnInit(): void {
+    this.InitializeForm();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['isOpen'] && this.isOpen) {
+      this.InitializeForm();
+    }
+    if (changes['account'] && this.mode === 'edit') {
+      this.InitializeForm();
+    }
+  }
+
+  InitializeForm(): void {
+    if (this.mode === 'edit' && this.account) {
+      const name =
+        this.account.business_profile?.name?.trim() ||
+        this.account.settings?.dashboard?.display_name?.trim() ||
+        '';
+      this.businessName.set(name);
+      this.logoUrl.set(this.account.settings?.branding?.logo || '');
+      this.termsUrl.set(this.account.settings?.terms_url || '');
+      this.privacyUrl.set(this.account.settings?.privacy_url || '');
+    } else if (this.mode === 'setup' && this.initialData) {
+      this.businessName.set(this.initialData.platform_name || '');
+      this.logoUrl.set(this.initialData.platform_logo_url || '');
+      this.termsUrl.set(this.initialData.terms_url || '');
+      this.privacyUrl.set(this.initialData.privacy_url || '');
+    }
+
+    this.businessNameError.set('');
+    this.logoUrlError.set('');
+    this.termsUrlError.set('');
+    this.privacyUrlError.set('');
+
+    this.EmitFormChange();
+  }
+
+  OnBusinessNameChange(value: string): void {
+    this.businessName.set(value);
+    this.ValidateBusinessName();
+    this.EmitFormChange();
+  }
+
+  OnLogoUrlChange(value: string): void {
+    this.logoUrl.set(value);
+    this.ValidateOptionalUrl(value, this.logoUrlError);
+    this.EmitFormChange();
+  }
+
+  OnTermsUrlChange(value: string): void {
+    this.termsUrl.set(value);
+    this.ValidateOptionalUrl(value, this.termsUrlError);
+    this.EmitFormChange();
+  }
+
+  OnPrivacyUrlChange(value: string): void {
+    this.privacyUrl.set(value);
+    this.ValidateOptionalUrl(value, this.privacyUrlError);
+    this.EmitFormChange();
+  }
+
+  ValidateBusinessName(): void {
+    const name = this.businessName().trim();
+    if (!name) {
+      this.businessNameError.set('Business name is required');
+      return;
+    }
+    this.businessNameError.set('');
+  }
+
+  ValidateOptionalUrl(
+    value: string,
+    errorSignal: WritableSignal<string>
+  ): void {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      errorSignal.set('');
+      return;
+    }
+    if (!this.IsValidUrl(trimmed)) {
+      errorSignal.set('Please enter a valid URL');
+      return;
+    }
+    errorSignal.set('');
+  }
+
+  ValidateAll(): boolean {
+    this.ValidateBusinessName();
+    this.ValidateOptionalUrl(this.logoUrl(), this.logoUrlError);
+    this.ValidateOptionalUrl(this.termsUrl(), this.termsUrlError);
+    this.ValidateOptionalUrl(this.privacyUrl(), this.privacyUrlError);
+
+    return (
+      !this.businessNameError() &&
+      !this.logoUrlError() &&
+      !this.termsUrlError() &&
+      !this.privacyUrlError()
+    );
+  }
+
+  IsValid(): boolean {
+    return (
+      !!this.businessName().trim() &&
+      !this.businessNameError() &&
+      !this.logoUrlError() &&
+      !this.termsUrlError() &&
+      !this.privacyUrlError()
+    );
+  }
+
+  GetFormData(): BusinessProfileFormData {
+    return {
+      businessName: this.businessName(),
+      logoUrl: this.logoUrl(),
+      termsUrl: this.termsUrl(),
+      privacyUrl: this.privacyUrl(),
+    };
+  }
+
+  /**
+   * Account update payload for Settings edit mode.
+   * Empty optional URLs are sent as null so they clear existing values.
+   */
+  GetUpdateData(): UpdateAccountInput {
+    const name = this.businessName().trim();
+    return {
+      business_profile: { name },
+      settings: {
+        branding: { logo: this.logoUrl().trim() || null },
+        dashboard: { display_name: name },
+        terms_url: this.termsUrl().trim() || null,
+        privacy_url: this.privacyUrl().trim() || null,
+      },
+    };
+  }
+
+  /**
+   * Setup request fields for the Platform Details step.
+   */
+  GetSetupData(): BusinessProfileSetupData {
+    const data: BusinessProfileSetupData = {
+      platform_name: this.businessName().trim(),
+    };
+
+    const logo = this.logoUrl().trim();
+    if (logo) data.platform_logo_url = logo;
+
+    const terms = this.termsUrl().trim();
+    if (terms) data.terms_url = terms;
+
+    const privacy = this.privacyUrl().trim();
+    if (privacy) data.privacy_url = privacy;
+
+    return data;
+  }
+
+  private IsValidUrl(value: string): boolean {
+    try {
+      const url = new URL(value);
+      return url.protocol === 'http:' || url.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  private EmitFormChange(): void {
+    this.formChange.emit(this.GetFormData());
+    this.validationChange.emit(this.IsValid());
+  }
+}

--- a/apps/web/src/app/shared/forms/index.ts
+++ b/apps/web/src/app/shared/forms/index.ts
@@ -1,2 +1,3 @@
 export * from './person-form/person-form.component';
 export * from './external-wallet-form/external-wallet-form.component';
+export * from './business-profile-form/business-profile-form.component';

--- a/apps/web/src/app/styles/forms.scss
+++ b/apps/web/src/app/styles/forms.scss
@@ -149,6 +149,7 @@ input[type='date'],
 input[type='number'],
 input[type='email'],
 input[type='password'],
+input[type='url'],
 input[type='time'],
 input[type='datetime-local'],
 input[type='tel'] {


### PR DESCRIPTION
## Description

- Edit business details (e.g. links, logo, name) from the dashboard.
- Created a shared business details editor form shared between dashboard and setup.
- Tweak self-host setup copy to not be so Connect oriented.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
