### PR TITLE
feat: anonymous opt-in telemetry module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,7 @@ LIVEMODE=
 # hosting, POST /v1/billing/run with x-operator-key via cron / Cloud Scheduler.
 # BILLING_MONITOR_ENABLED=false
 # BILLING_POLL_INTERVAL_MS=60000
+
+# Anonymous usage telemetry (opt-in via setup/settings; off by default).
+# Set to 0 to force disable.
+# ZONELESS_TELEMETRY=

--- a/.env.production.example
+++ b/.env.production.example
@@ -60,3 +60,7 @@ LIVEMODE=true
 # or POST /v1/billing/run_for_platform with a platform API key.
 # BILLING_MONITOR_ENABLED=false
 # BILLING_POLL_INTERVAL_MS=60000
+
+# Anonymous usage telemetry (opt-in via setup/settings; off by default).
+# Set to 0 to force disable.
+# ZONELESS_TELEMETRY=

--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ zoneless/
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup, style guidelines, and the pull request process.
 
+## Anonymous usage telemetry
+
+Self-hosted Zoneless can optionally share anonymous usage heartbeats with
+maintainers (opt-in, off by default). See [TELEMETRY.md](./TELEMETRY.md).
+
 ## Security
 
 See [SECURITY.md](./SECURITY.md) to report vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,11 @@ Key points:
 - Never commit `.env` files to version control
 - Rotate API keys periodically
 
+### Anonymous usage telemetry
+
+Opt-in anonymous usage heartbeats may be sent to zoneless.com (off by default).
+Force disable with `ZONELESS_TELEMETRY=0`. See [TELEMETRY.md](./TELEMETRY.md).
+
 ## Acknowledgments
 
 We would like to thank the following individuals for responsibly disclosing security issues.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,34 @@
+# Anonymous Usage Telemetry
+
+Zoneless can optionally send **anonymous, aggregate usage heartbeats** to
+[zoneless.com](https://zoneless.com). Telemetry is **opt-in and off by default**,
+and only applies to **self-hosted** instances (not operator-managed hosting).
+
+## Consent
+
+Enable via the checkbox during setup or under **Settings → Anonymous usage**,
+or `POST /v1/telemetry` with `{ "enabled": true }` as a platform user.
+
+Disable the same way, or set `ZONELESS_TELEMETRY=0`.
+
+## What is sent
+
+One HTTPS POST roughly once per day when enabled:
+
+| Field                | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `instance_id`        | Random UUID generated at opt-in                              |
+| `zoneless_version`   | Package version string                                       |
+| `livemode`           | Whether `LIVEMODE=true`                                      |
+| `single_tenant`      | Whether single-tenant mode is on                             |
+| `setup_completed`    | Whether at least one platform account exists                 |
+| `os`                 | `process.platform` (e.g. `linux`)                            |
+| `node_major`         | Major Node.js version number                                 |
+| `payment_count_7d`   | Bucket: `0`, `1-10`, `11-100`, `101-1000`, `1000+`           |
+| `usdc_volume_7d`     | Bucket: `0`, `lt_1k`, `lt_10k`, `lt_100k`, `lt_1m`, `gte_1m` |
+| `connected_accounts` | Bucket: `0`, `1`, `2-10`, `11-100`, `100+`                   |
+
+## What is never sent
+
+Emails, business names, domains, API keys, wallet addresses, customer PII,
+exact dollar amounts, request bodies, logs, or IP addresses.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -17,19 +17,19 @@ One HTTPS POST roughly once per day when enabled **and** `LIVEMODE=true`.
 Test-mode instances (`LIVEMODE` unset/false) never send; consent can still be
 saved and will take effect after switching to live mode.
 
-| Field | Description |
-| ----- | ----------- |
-| `instance_id` | Random UUID generated at opt-in |
-| `zoneless_version` | Package version string |
-| `livemode` | Always `true` when a report is sent (test mode never reports) |
-| `single_tenant` | Whether single-tenant mode is on |
-| `setup_completed` | Whether at least one platform account exists |
-| `os` | `process.platform` (e.g. `linux`) |
-| `node_major` | Major Node.js version number |
-| `payment_count_7d` | Bucket: `0`, `1-10`, `11-100`, `101-1000`, `1000+` (payment/charge BTs) |
-| `usdc_volume_7d` | Payment/charge volume bucket: `0`, `lt_10`, `lt_100`, `lt_1k`, `lt_10k`, `lt_100k`, `lt_1m`, `gte_1m` |
-| `usdc_payout_volume_7d` | Payout volume bucket (same bands; absolute amount) |
-| `connected_accounts` | Bucket: `0`, `1`, `2-10`, `11-100`, `100+` |
+| Field                   | Description                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| `instance_id`           | Random UUID generated at opt-in                                                                       |
+| `zoneless_version`      | Package version string                                                                                |
+| `livemode`              | Always `true` when a report is sent (test mode never reports)                                         |
+| `single_tenant`         | Whether single-tenant mode is on                                                                      |
+| `setup_completed`       | Whether at least one platform account exists                                                          |
+| `os`                    | `process.platform` (e.g. `linux`)                                                                     |
+| `node_major`            | Major Node.js version number                                                                          |
+| `payment_count_7d`      | Bucket: `0`, `1-10`, `11-100`, `101-1000`, `1000+` (payment/charge BTs)                               |
+| `usdc_volume_7d`        | Payment/charge volume bucket: `0`, `lt_10`, `lt_100`, `lt_1k`, `lt_10k`, `lt_100k`, `lt_1m`, `gte_1m` |
+| `usdc_payout_volume_7d` | Payout volume bucket (same bands; absolute amount)                                                    |
+| `connected_accounts`    | Bucket: `0`, `1`, `2-10`, `11-100`, `100+`                                                            |
 
 ## What is never sent
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -13,20 +13,23 @@ Disable the same way, or set `ZONELESS_TELEMETRY=0`.
 
 ## What is sent
 
-One HTTPS POST roughly once per day when enabled:
+One HTTPS POST roughly once per day when enabled **and** `LIVEMODE=true`.
+Test-mode instances (`LIVEMODE` unset/false) never send; consent can still be
+saved and will take effect after switching to live mode.
 
-| Field                | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `instance_id`        | Random UUID generated at opt-in                              |
-| `zoneless_version`   | Package version string                                       |
-| `livemode`           | Whether `LIVEMODE=true`                                      |
-| `single_tenant`      | Whether single-tenant mode is on                             |
-| `setup_completed`    | Whether at least one platform account exists                 |
-| `os`                 | `process.platform` (e.g. `linux`)                            |
-| `node_major`         | Major Node.js version number                                 |
-| `payment_count_7d`   | Bucket: `0`, `1-10`, `11-100`, `101-1000`, `1000+`           |
-| `usdc_volume_7d`     | Bucket: `0`, `lt_1k`, `lt_10k`, `lt_100k`, `lt_1m`, `gte_1m` |
-| `connected_accounts` | Bucket: `0`, `1`, `2-10`, `11-100`, `100+`                   |
+| Field | Description |
+| ----- | ----------- |
+| `instance_id` | Random UUID generated at opt-in |
+| `zoneless_version` | Package version string |
+| `livemode` | Always `true` when a report is sent (test mode never reports) |
+| `single_tenant` | Whether single-tenant mode is on |
+| `setup_completed` | Whether at least one platform account exists |
+| `os` | `process.platform` (e.g. `linux`) |
+| `node_major` | Major Node.js version number |
+| `payment_count_7d` | Bucket: `0`, `1-10`, `11-100`, `101-1000`, `1000+` (payment/charge BTs) |
+| `usdc_volume_7d` | Payment/charge volume bucket: `0`, `lt_10`, `lt_100`, `lt_1k`, `lt_10k`, `lt_100k`, `lt_1m`, `gte_1m` |
+| `usdc_payout_volume_7d` | Payout volume bucket (same bands; absolute amount) |
+| `connected_accounts` | Bucket: `0`, `1`, `2-10`, `11-100`, `100+` |
 
 ## What is never sent
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -26,6 +26,10 @@ import {
 import { db } from './modules/Database';
 import { GetTopUpMonitor, TopUpMonitor } from './modules/TopUpMonitor';
 import { GetBillingMonitor, BillingMonitor } from './modules/BillingMonitor';
+import {
+  GetTelemetryMonitor,
+  TelemetryMonitor,
+} from './modules/TelemetryMonitor';
 import { AccountModule } from './modules/Account';
 import { ExternalWalletModule } from './modules/ExternalWallet';
 
@@ -207,6 +211,11 @@ async function StartServer() {
       );
     }
 
+    // Daily anonymous usage heartbeats (no-ops unless opted in)
+    if (TelemetryMonitor.ShouldStart()) {
+      GetTelemetryMonitor(db).Start();
+    }
+
     const server = app.listen(port, () => {
       console.log(`🚀 API running at http://localhost:${port}/v1`);
       console.log(`📊 Health check at http://localhost:${port}/api/health`);
@@ -239,6 +248,11 @@ async function StartServer() {
       if (BillingMonitor.IsEnabled()) {
         const billingMonitor = GetBillingMonitor(db);
         billingMonitor.Stop();
+      }
+
+      if (TelemetryMonitor.ShouldStart()) {
+        const telemetryMonitor = GetTelemetryMonitor(db);
+        telemetryMonitor.Stop();
       }
 
       server.close(async () => {

--- a/apps/api/src/modules/Database.ts
+++ b/apps/api/src/modules/Database.ts
@@ -449,6 +449,7 @@ export class Database {
       'TopUps',
       'Transfers',
       'UsageCounters',
+      'TelemetryConfigs',
       'WebhookEndpoints',
     ];
 

--- a/apps/api/src/modules/Setup.ts
+++ b/apps/api/src/modules/Setup.ts
@@ -16,8 +16,10 @@ import { ExternalWalletModule } from './ExternalWallet';
 import { SignToken } from '../utils/Token';
 import { SetupRequest, SetupResponse } from '@zoneless/shared-types';
 import { GetJwtSecret } from './AppConfig';
+import { GetTelemetryModule } from './Telemetry';
 import { AppError } from '../utils/AppError';
 import { ERRORS } from '../utils/Errors';
+import { Logger } from '../utils/Logger';
 
 /**
  * Validates a setup request body.
@@ -158,6 +160,17 @@ export class SetupModule {
       GetJwtSecret(),
       '7d'
     );
+
+    // Persist telemetry consent from setup (default off)
+    if (request.telemetry_enabled === true) {
+      try {
+        await GetTelemetryModule(this.db).SetEnabled(true);
+      } catch (err) {
+        Logger.warn('Failed to enable telemetry during setup', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
 
     return {
       object: 'setup_response',

--- a/apps/api/src/modules/Telemetry.ts
+++ b/apps/api/src/modules/Telemetry.ts
@@ -1,0 +1,320 @@
+/**
+ * @fileOverview Anonymous usage telemetry for self-hosted instances
+ *
+ * Opt-in heartbeats to zoneless.com. Never runs in operator mode.
+ * See TELEMETRY.md for the field whitelist and kill switches.
+ *
+ * @module Telemetry
+ */
+
+import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  TelemetryConfig,
+  TelemetryConnectedAccountsBucket,
+  TelemetryPaymentCountBucket,
+  TelemetryReport,
+  TelemetryStatus,
+  TelemetryVolumeBucket,
+} from '@zoneless/shared-types';
+import { Database } from './Database';
+import { GetAppConfig, IsOperatorMode, IsSingleTenantMode } from './AppConfig';
+import { AccountModule } from './Account';
+import { Logger } from '../utils/Logger';
+import { Now } from '../utils/Timestamp';
+
+const CONFIG_COLLECTION = 'TelemetryConfigs';
+const CONFIG_ID = 'telemetry' as const;
+
+const SEND_TIMEOUT_MS = 10_000;
+const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
+
+/** Amounts in BalanceTransactions are Stripe-style cents. */
+const VOLUME_BUCKETS: { maxCents: number; bucket: TelemetryVolumeBucket }[] = [
+  { maxCents: 0, bucket: '0' },
+  { maxCents: 100_000, bucket: 'lt_1k' }, // < $1,000
+  { maxCents: 1_000_000, bucket: 'lt_10k' },
+  { maxCents: 10_000_000, bucket: 'lt_100k' },
+  { maxCents: 100_000_000, bucket: 'lt_1m' },
+];
+
+/** True when telemetry UI/reporting is available (self-host only). */
+export function IsTelemetryAvailable(): boolean {
+  return !IsOperatorMode();
+}
+
+export function IsTelemetryForcedOff(): boolean {
+  if (!IsTelemetryAvailable()) {
+    return true;
+  }
+  return process.env.ZONELESS_TELEMETRY === '0';
+}
+
+const TELEMETRY_URL = 'https://zoneless.com/api/telemetry';
+
+function GetZonelessVersion(): string {
+  try {
+    const pkgPath = join(process.cwd(), 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+      version?: string;
+    };
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function BucketPaymentCount(count: number): TelemetryPaymentCountBucket {
+  if (count <= 0) return '0';
+  if (count <= 10) return '1-10';
+  if (count <= 100) return '11-100';
+  if (count <= 1000) return '101-1000';
+  return '1000+';
+}
+
+function BucketVolumeCents(cents: number): TelemetryVolumeBucket {
+  if (cents <= 0) return '0';
+  for (const { maxCents, bucket } of VOLUME_BUCKETS) {
+    if (maxCents === 0) continue;
+    if (cents < maxCents) return bucket;
+  }
+  return 'gte_1m';
+}
+
+function BucketConnectedAccounts(
+  count: number
+): TelemetryConnectedAccountsBucket {
+  if (count <= 0) return '0';
+  if (count === 1) return '1';
+  if (count <= 10) return '2-10';
+  if (count <= 100) return '11-100';
+  return '100+';
+}
+
+export class TelemetryModule {
+  private readonly db: Database;
+  private readonly accountModule: AccountModule;
+  private sending = false;
+
+  constructor(db: Database) {
+    this.db = db;
+    this.accountModule = new AccountModule(db);
+  }
+
+  async GetConfig(): Promise<TelemetryConfig | null> {
+    return this.db.Get<TelemetryConfig>(CONFIG_COLLECTION, CONFIG_ID);
+  }
+
+  async GetStatus(): Promise<TelemetryStatus> {
+    const config = await this.GetConfig();
+    const available = IsTelemetryAvailable();
+    const forcedOff = IsTelemetryForcedOff();
+    const consented = !!config?.enabled;
+    return {
+      object: 'telemetry_status',
+      available,
+      enabled: available && consented && !forcedOff,
+      consented,
+      forced_off: forcedOff,
+      instance_id: config?.instance_id ?? null,
+      last_sent_at: config?.last_sent_at ?? null,
+    };
+  }
+
+  /**
+   * Persist consent. Generates instance_id on first enable.
+   * Clears instance_id when disabled (fresh identity if re-enabled).
+   * No-ops on operator-managed instances.
+   */
+  async SetEnabled(enabled: boolean): Promise<TelemetryStatus> {
+    if (!IsTelemetryAvailable()) {
+      return this.GetStatus();
+    }
+
+    const now = Now();
+    const existing = await this.GetConfig();
+
+    if (enabled) {
+      const instanceId = existing?.instance_id || randomUUID();
+      const config: TelemetryConfig = {
+        id: CONFIG_ID,
+        object: 'telemetry_config',
+        enabled: true,
+        instance_id: instanceId,
+        last_sent_at: existing?.last_sent_at ?? null,
+        created: existing?.created ?? now,
+        updated: now,
+      };
+      await this.db.Set<TelemetryConfig>(CONFIG_COLLECTION, CONFIG_ID, config);
+
+      // Fire-and-forget immediate report after opt-in
+      this.SendReport().catch((err) => {
+        Logger.warn('Telemetry immediate send failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    } else {
+      const config: TelemetryConfig = {
+        id: CONFIG_ID,
+        object: 'telemetry_config',
+        enabled: false,
+        instance_id: null,
+        last_sent_at: null,
+        created: existing?.created ?? now,
+        updated: now,
+      };
+      await this.db.Set<TelemetryConfig>(CONFIG_COLLECTION, CONFIG_ID, config);
+    }
+
+    return this.GetStatus();
+  }
+
+  async IsEffectivelyEnabled(): Promise<boolean> {
+    if (IsTelemetryForcedOff()) {
+      return false;
+    }
+    const config = await this.GetConfig();
+    return !!config?.enabled && !!config.instance_id;
+  }
+
+  async BuildReport(): Promise<TelemetryReport | null> {
+    const config = await this.GetConfig();
+    if (!config?.enabled || !config.instance_id) {
+      return null;
+    }
+
+    const platforms = await this.accountModule.GetPlatformAccounts();
+    const setupCompleted = platforms.length > 0;
+
+    const { paymentCount, volumeCents, connectedCount } =
+      await this.AggregateSevenDayMetrics();
+
+    const nodeMajor = parseInt(process.versions.node.split('.')[0], 10) || 0;
+
+    return {
+      instance_id: config.instance_id,
+      zoneless_version: GetZonelessVersion(),
+      livemode: GetAppConfig().livemode,
+      single_tenant: IsSingleTenantMode(),
+      setup_completed: setupCompleted,
+      os: process.platform,
+      node_major: nodeMajor,
+      payment_count_7d: BucketPaymentCount(paymentCount),
+      usdc_volume_7d: BucketVolumeCents(volumeCents),
+      connected_accounts: BucketConnectedAccounts(connectedCount),
+    };
+  }
+
+  /**
+   * Build and POST a report if effectively enabled.
+   * Failures never throw to callers that fire-and-forget.
+   */
+  async SendReport(): Promise<boolean> {
+    if (this.sending) {
+      return false;
+    }
+    if (!(await this.IsEffectivelyEnabled())) {
+      return false;
+    }
+
+    this.sending = true;
+    try {
+      const report = await this.BuildReport();
+      if (!report) {
+        return false;
+      }
+
+      const url = TELEMETRY_URL;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
+
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(report),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          Logger.warn('Telemetry ingest rejected report', {
+            status: response.status,
+          });
+          return false;
+        }
+
+        await this.db.Update<TelemetryConfig>(CONFIG_COLLECTION, CONFIG_ID, {
+          last_sent_at: Now(),
+          updated: Now(),
+        });
+        return true;
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (err) {
+      Logger.warn('Telemetry send failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    } finally {
+      this.sending = false;
+    }
+  }
+
+  private async AggregateSevenDayMetrics(): Promise<{
+    paymentCount: number;
+    volumeCents: number;
+    connectedCount: number;
+  }> {
+    const end = Now();
+    const start = end - SEVEN_DAYS_SECONDS;
+
+    const volumeRows = await this.db.Aggregate<{
+      count: number;
+      gross: number;
+    }>('BalanceTransactions', [
+      {
+        $match: {
+          type: { $in: ['payment', 'charge'] },
+          created: { $gte: start, $lt: end },
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          count: { $sum: 1 },
+          gross: { $sum: '$amount' },
+        },
+      },
+    ]);
+
+    const paymentCount = volumeRows[0]?.count ?? 0;
+    const volumeCents = volumeRows[0]?.gross ?? 0;
+
+    const connectedRows = await this.db.Aggregate<{ count: number }>(
+      'Accounts',
+      [
+        {
+          $match: {
+            $expr: { $ne: ['$platform_account', '$id'] },
+          },
+        },
+        { $group: { _id: null, count: { $sum: 1 } } },
+      ]
+    );
+
+    const connectedCount = connectedRows[0]?.count ?? 0;
+
+    return { paymentCount, volumeCents, connectedCount };
+  }
+}
+
+let telemetryInstance: TelemetryModule | null = null;
+
+export function GetTelemetryModule(db: Database): TelemetryModule {
+  if (!telemetryInstance) {
+    telemetryInstance = new TelemetryModule(db);
+  }
+  return telemetryInstance;
+}

--- a/apps/api/src/modules/Telemetry.ts
+++ b/apps/api/src/modules/Telemetry.ts
@@ -32,7 +32,8 @@ const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
 
 /** Amounts in BalanceTransactions are Stripe-style cents. */
 const VOLUME_BUCKETS: { maxCents: number; bucket: TelemetryVolumeBucket }[] = [
-  { maxCents: 0, bucket: '0' },
+  { maxCents: 1_000, bucket: 'lt_10' }, // < $10
+  { maxCents: 10_000, bucket: 'lt_100' }, // < $100
   { maxCents: 100_000, bucket: 'lt_1k' }, // < $1,000
   { maxCents: 1_000_000, bucket: 'lt_10k' },
   { maxCents: 10_000_000, bucket: 'lt_100k' },
@@ -76,7 +77,6 @@ function BucketPaymentCount(count: number): TelemetryPaymentCountBucket {
 function BucketVolumeCents(cents: number): TelemetryVolumeBucket {
   if (cents <= 0) return '0';
   for (const { maxCents, bucket } of VOLUME_BUCKETS) {
-    if (maxCents === 0) continue;
     if (cents < maxCents) return bucket;
   }
   return 'gte_1m';
@@ -111,10 +111,11 @@ export class TelemetryModule {
     const available = IsTelemetryAvailable();
     const forcedOff = IsTelemetryForcedOff();
     const consented = !!config?.enabled;
+    const livemode = GetAppConfig().livemode;
     return {
       object: 'telemetry_status',
       available,
-      enabled: available && consented && !forcedOff,
+      enabled: available && consented && !forcedOff && livemode,
       consented,
       forced_off: forcedOff,
       instance_id: config?.instance_id ?? null,
@@ -174,6 +175,10 @@ export class TelemetryModule {
     if (IsTelemetryForcedOff()) {
       return false;
     }
+    // Test-mode instances never report (consent may still be stored).
+    if (!GetAppConfig().livemode) {
+      return false;
+    }
     const config = await this.GetConfig();
     return !!config?.enabled && !!config.instance_id;
   }
@@ -187,7 +192,7 @@ export class TelemetryModule {
     const platforms = await this.accountModule.GetPlatformAccounts();
     const setupCompleted = platforms.length > 0;
 
-    const { paymentCount, volumeCents, connectedCount } =
+    const { paymentCount, volumeCents, payoutVolumeCents, connectedCount } =
       await this.AggregateSevenDayMetrics();
 
     const nodeMajor = parseInt(process.versions.node.split('.')[0], 10) || 0;
@@ -202,6 +207,7 @@ export class TelemetryModule {
       node_major: nodeMajor,
       payment_count_7d: BucketPaymentCount(paymentCount),
       usdc_volume_7d: BucketVolumeCents(volumeCents),
+      usdc_payout_volume_7d: BucketVolumeCents(payoutVolumeCents),
       connected_accounts: BucketConnectedAccounts(connectedCount),
     };
   }
@@ -225,12 +231,11 @@ export class TelemetryModule {
         return false;
       }
 
-      const url = TELEMETRY_URL;
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
 
       try {
-        const response = await fetch(url, {
+        const response = await fetch(TELEMETRY_URL, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(report),
@@ -265,11 +270,14 @@ export class TelemetryModule {
   private async AggregateSevenDayMetrics(): Promise<{
     paymentCount: number;
     volumeCents: number;
+    payoutVolumeCents: number;
     connectedCount: number;
   }> {
     const end = Now();
     const start = end - SEVEN_DAYS_SECONDS;
 
+    // One BalanceTransaction per event — payment and charge are alternate types,
+    // not two rows for the same payment. Current writers use type: 'payment'.
     const volumeRows = await this.db.Aggregate<{
       count: number;
       gross: number;
@@ -292,6 +300,27 @@ export class TelemetryModule {
     const paymentCount = volumeRows[0]?.count ?? 0;
     const volumeCents = volumeRows[0]?.gross ?? 0;
 
+    // Payout BTs store amount as negative; bucket absolute outflow.
+    const payoutRows = await this.db.Aggregate<{ gross: number }>(
+      'BalanceTransactions',
+      [
+        {
+          $match: {
+            type: 'payout',
+            created: { $gte: start, $lt: end },
+          },
+        },
+        {
+          $group: {
+            _id: null,
+            gross: { $sum: { $abs: '$amount' } },
+          },
+        },
+      ]
+    );
+
+    const payoutVolumeCents = payoutRows[0]?.gross ?? 0;
+
     const connectedRows = await this.db.Aggregate<{ count: number }>(
       'Accounts',
       [
@@ -306,7 +335,7 @@ export class TelemetryModule {
 
     const connectedCount = connectedRows[0]?.count ?? 0;
 
-    return { paymentCount, volumeCents, connectedCount };
+    return { paymentCount, volumeCents, payoutVolumeCents, connectedCount };
   }
 }
 

--- a/apps/api/src/modules/TelemetryMonitor.ts
+++ b/apps/api/src/modules/TelemetryMonitor.ts
@@ -1,0 +1,93 @@
+/**
+ * @fileOverview Telemetry Monitor — daily anonymous usage heartbeats
+ *
+ * Always starts; SendReport no-ops when consent is off or ZONELESS_TELEMETRY=0.
+ *
+ * @module TelemetryMonitor
+ */
+
+import { Database } from './Database';
+import { GetTelemetryModule, IsTelemetryForcedOff } from './Telemetry';
+import { Logger } from '../utils/Logger';
+
+const TELEMETRY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export class TelemetryMonitor {
+  private readonly db: Database;
+  private intervalId: NodeJS.Timeout | null = null;
+  private isRunning = false;
+
+  constructor(db: Database) {
+    this.db = db;
+  }
+
+  static GetPollInterval(): number {
+    return TELEMETRY_INTERVAL_MS;
+  }
+
+  /** Skip starting when telemetry is force-disabled via env. */
+  static ShouldStart(): boolean {
+    return !IsTelemetryForcedOff();
+  }
+
+  Start(): void {
+    if (this.isRunning) {
+      Logger.warn('TelemetryMonitor is already running');
+      return;
+    }
+
+    if (!TelemetryMonitor.ShouldStart()) {
+      Logger.info('TelemetryMonitor skipped (ZONELESS_TELEMETRY=0)');
+      return;
+    }
+
+    this.isRunning = true;
+    Logger.info('TelemetryMonitor started', {
+      intervalMs: TELEMETRY_INTERVAL_MS,
+    });
+
+    // Delay first tick slightly so startup isn't blocked on network
+    setTimeout(() => {
+      this.Tick().catch((error) => {
+        Logger.warn('TelemetryMonitor initial tick failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }, 30_000);
+
+    this.intervalId = setInterval(() => {
+      this.Tick().catch((error) => {
+        Logger.warn('TelemetryMonitor tick failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }, TELEMETRY_INTERVAL_MS);
+  }
+
+  Stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    this.isRunning = false;
+    Logger.info('TelemetryMonitor stopped');
+  }
+
+  IsRunning(): boolean {
+    return this.isRunning;
+  }
+
+  private async Tick(): Promise<void> {
+    const telemetry = GetTelemetryModule(this.db);
+    await telemetry.SendReport();
+  }
+}
+
+let monitorInstance: TelemetryMonitor | null = null;
+
+export function GetTelemetryMonitor(db: Database): TelemetryMonitor {
+  if (!monitorInstance) {
+    monitorInstance = new TelemetryMonitor(db);
+  }
+  return monitorInstance;
+}

--- a/apps/api/src/modules/TelemetryMonitor.ts
+++ b/apps/api/src/modules/TelemetryMonitor.ts
@@ -1,33 +1,32 @@
 /**
  * @fileOverview Telemetry Monitor — daily anonymous usage heartbeats
  *
- * Always starts; SendReport no-ops when consent is off or ZONELESS_TELEMETRY=0.
+ * Starts only for self-host live mode. SendReport still no-ops when consent
+ * is off or ZONELESS_TELEMETRY=0.
  *
  * @module TelemetryMonitor
  */
 
 import { Database } from './Database';
+import { GetAppConfig } from './AppConfig';
 import { GetTelemetryModule, IsTelemetryForcedOff } from './Telemetry';
 import { Logger } from '../utils/Logger';
 
-const TELEMETRY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const TELEMETRY_INTERVAL_MS = 1000 * 60 * 60 * 24;
 
 export class TelemetryMonitor {
   private readonly db: Database;
   private intervalId: NodeJS.Timeout | null = null;
+  private startupTimeoutId: NodeJS.Timeout | null = null;
   private isRunning = false;
 
   constructor(db: Database) {
     this.db = db;
   }
 
-  static GetPollInterval(): number {
-    return TELEMETRY_INTERVAL_MS;
-  }
-
-  /** Skip starting when telemetry is force-disabled via env. */
+  /** Skip when force-disabled, operator mode, or test mode. */
   static ShouldStart(): boolean {
-    return !IsTelemetryForcedOff();
+    return !IsTelemetryForcedOff() && GetAppConfig().livemode;
   }
 
   Start(): void {
@@ -37,7 +36,7 @@ export class TelemetryMonitor {
     }
 
     if (!TelemetryMonitor.ShouldStart()) {
-      Logger.info('TelemetryMonitor skipped (ZONELESS_TELEMETRY=0)');
+      Logger.info('TelemetryMonitor skipped (disabled, operator, or test mode)');
       return;
     }
 
@@ -47,7 +46,8 @@ export class TelemetryMonitor {
     });
 
     // Delay first tick slightly so startup isn't blocked on network
-    setTimeout(() => {
+    this.startupTimeoutId = setTimeout(() => {
+      this.startupTimeoutId = null;
       this.Tick().catch((error) => {
         Logger.warn('TelemetryMonitor initial tick failed', {
           error: error instanceof Error ? error.message : String(error),
@@ -65,16 +65,16 @@ export class TelemetryMonitor {
   }
 
   Stop(): void {
+    if (this.startupTimeoutId) {
+      clearTimeout(this.startupTimeoutId);
+      this.startupTimeoutId = null;
+    }
     if (this.intervalId) {
       clearInterval(this.intervalId);
       this.intervalId = null;
     }
     this.isRunning = false;
     Logger.info('TelemetryMonitor stopped');
-  }
-
-  IsRunning(): boolean {
-    return this.isRunning;
   }
 
   private async Tick(): Promise<void> {

--- a/apps/api/src/modules/TelemetryMonitor.ts
+++ b/apps/api/src/modules/TelemetryMonitor.ts
@@ -36,7 +36,9 @@ export class TelemetryMonitor {
     }
 
     if (!TelemetryMonitor.ShouldStart()) {
-      Logger.info('TelemetryMonitor skipped (disabled, operator, or test mode)');
+      Logger.info(
+        'TelemetryMonitor skipped (disabled, operator, or test mode)'
+      );
       return;
     }
 

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -33,6 +33,7 @@ import invoiceItemsRouter from './invoiceItems.routes';
 import invoicesRouter from './invoices.routes';
 import reportingRouter from './reporting.routes';
 import billingRouter from './billing.routes';
+import telemetryRouter from './telemetry.routes';
 
 const router = express.Router();
 
@@ -87,4 +88,5 @@ router.use('/charges', chargesRouter);
 router.use('/invoiceitems', invoiceItemsRouter);
 router.use('/invoices', invoicesRouter);
 router.use('/reporting', reportingRouter);
+router.use('/telemetry', telemetryRouter);
 export default router;

--- a/apps/api/src/routes/telemetry.routes.ts
+++ b/apps/api/src/routes/telemetry.routes.ts
@@ -1,0 +1,53 @@
+/**
+ * Telemetry consent routes (platform-only).
+ * GET/POST /v1/telemetry
+ */
+
+import * as express from 'express';
+import { UpdateTelemetryRequest } from '@zoneless/shared-types';
+import { AsyncHandler } from '../utils/AsyncHandler';
+import { AppError } from '../utils/AppError';
+import { ERRORS } from '../utils/Errors';
+import { db } from '../modules/Database';
+import { GetTelemetryModule } from '../modules/Telemetry';
+import { RequirePlatform } from '../middleware/Authorization';
+
+const router = express.Router();
+const telemetry = GetTelemetryModule(db);
+
+/**
+ * GET /v1/telemetry
+ * Current consent + effective enabled state.
+ */
+router.get(
+  '/',
+  RequirePlatform(),
+  AsyncHandler(async (_req: express.Request, res: express.Response) => {
+    const status = await telemetry.GetStatus();
+    res.json(status);
+  })
+);
+
+/**
+ * POST /v1/telemetry
+ * Body: { enabled: boolean }
+ */
+router.post(
+  '/',
+  RequirePlatform(),
+  AsyncHandler(async (req: express.Request, res: express.Response) => {
+    const body = req.body as UpdateTelemetryRequest;
+    if (typeof body?.enabled !== 'boolean') {
+      throw new AppError(
+        'enabled must be a boolean',
+        ERRORS.VALIDATION_ERROR.status,
+        ERRORS.VALIDATION_ERROR.type
+      );
+    }
+
+    const status = await telemetry.SetEnabled(body.enabled);
+    res.json(status);
+  })
+);
+
+export default router;

--- a/apps/web/src/app/data/services/index.ts
+++ b/apps/web/src/app/data/services/index.ts
@@ -15,6 +15,7 @@ export * from './product.service';
 export * from './reporting.service';
 export * from './setup.service';
 export * from './subscription.service';
+export * from './telemetry.service';
 export * from './topup.service';
 export * from './transaction.service';
 export * from './webhook-endpoint.service';

--- a/apps/web/src/app/data/services/telemetry.service.ts
+++ b/apps/web/src/app/data/services/telemetry.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, inject, signal, WritableSignal } from '@angular/core';
+import { ApiService } from '../../core';
+import {
+  TelemetryStatus,
+  UpdateTelemetryRequest,
+} from '@zoneless/shared-types';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TelemetryService {
+  private readonly api = inject(ApiService);
+
+  status: WritableSignal<TelemetryStatus | null> = signal(null);
+  loading: WritableSignal<boolean> = signal(false);
+
+  Reset(): void {
+    this.status.set(null);
+    this.loading.set(false);
+  }
+
+  async GetStatus(): Promise<TelemetryStatus | null> {
+    this.loading.set(true);
+    try {
+      const status = await this.api.Call<TelemetryStatus>('GET', 'telemetry');
+      this.status.set(status);
+      return status;
+    } catch (error) {
+      console.error('Failed to get telemetry status:', error);
+      this.status.set(null);
+      return null;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+
+  async SetEnabled(enabled: boolean): Promise<TelemetryStatus> {
+    this.loading.set(true);
+    try {
+      const body: UpdateTelemetryRequest = { enabled };
+      const status = await this.api.Call<TelemetryStatus>(
+        'POST',
+        'telemetry',
+        body
+      );
+      this.status.set(status);
+      return status;
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/apps/web/src/app/features/account/settings/settings.component.html
+++ b/apps/web/src/app/features/account/settings/settings.component.html
@@ -41,6 +41,37 @@
 </div>
 }
 
+<!-- Anonymous usage (self-host platform only) -->
+@if ( authService.isPlatform() && telemetryService.status()?.available ) {
+<div class="view-section">
+  <div class="settings-section-title">Anonymous usage</div>
+  <label class="custom-checkbox field-check telemetry-opt-in">
+    <input
+      type="checkbox"
+      [checked]="!!telemetryService.status()?.consented"
+      [disabled]="!!telemetryService.status()?.forced_off || telemetrySaving()"
+      (change)="OnTelemetryToggle($any($event.target).checked)"
+    />
+    <span class="checkmark"></span>
+    <div>
+      Share anonymous usage statistics with Zoneless. Helps improve the
+      open-source project. No payment details, emails, or business data.
+      <a
+        href="https://zoneless.com/privacy"
+        target="_blank"
+        rel="noopener noreferrer"
+        >Learn more</a
+      >.
+    </div>
+  </label>
+  @if (telemetryService.status()?.forced_off) {
+  <p class="telemetry-forced-off">
+    Telemetry is disabled on this instance via environment configuration.
+  </p>
+  }
+</div>
+}
+
 <div class="view-section">
   <button
     type="button"

--- a/apps/web/src/app/features/account/settings/settings.component.scss
+++ b/apps/web/src/app/features/account/settings/settings.component.scss
@@ -1,3 +1,45 @@
 @use '../../../styles/base.scss' as *;
 @use '../../../styles/buttons.scss' as *;
 @use '../../../styles/account.scss' as *;
+@use '../../../styles/forms.scss' as *;
+
+.telemetry-opt-in {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-small;
+  margin-top: $spacing-small;
+  margin-bottom: 0;
+  cursor: pointer;
+
+  .checkmark {
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    min-width: 16px;
+    min-height: 16px;
+    margin-top: 2px;
+    box-sizing: border-box;
+  }
+
+  div {
+    flex: 1;
+    margin-left: 0;
+    font-size: $font-size;
+    line-height: 1.45;
+    color: $text-color;
+  }
+
+  a {
+    color: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    text-decoration: underline;
+  }
+}
+
+.telemetry-forced-off {
+  margin-top: $spacing-small;
+  font-size: $font-size-small;
+  color: rgba($text-color, 0.65);
+}

--- a/apps/web/src/app/features/account/settings/settings.component.ts
+++ b/apps/web/src/app/features/account/settings/settings.component.ts
@@ -21,6 +21,7 @@ import {
   WebhookEndpointService,
   TopupService,
   ConfigService,
+  TelemetryService,
 } from '../../../data';
 import {
   BusinessProfileFormComponent,
@@ -59,6 +60,7 @@ export class SettingsComponent implements OnInit {
   readonly apiKeyService = inject(ApiKeyService);
   readonly topupService = inject(TopupService);
   readonly configService = inject(ConfigService);
+  readonly telemetryService = inject(TelemetryService);
   readonly router = inject(Router);
   private readonly metaService = inject(MetaService);
 
@@ -78,8 +80,25 @@ export class SettingsComponent implements OnInit {
   editBusinessLoading: WritableSignal<boolean> = signal(false);
   editBusinessShowErrors: WritableSignal<boolean> = signal(false);
 
+  telemetrySaving: WritableSignal<boolean> = signal(false);
+
   ngOnInit(): void {
     this.metaService.SetMetaTitle('Settings');
+    if (this.authService.isPlatform()) {
+      this.telemetryService.GetStatus();
+    }
+  }
+
+  async OnTelemetryToggle(checked: boolean): Promise<void> {
+    this.telemetrySaving.set(true);
+    try {
+      await this.telemetryService.SetEnabled(checked);
+    } catch (error) {
+      console.error('Failed to update telemetry preference:', error);
+      await this.telemetryService.GetStatus();
+    } finally {
+      this.telemetrySaving.set(false);
+    }
   }
 
   // Edit Business Panel
@@ -220,6 +239,7 @@ export class SettingsComponent implements OnInit {
     this.webhookEndpointService.Reset();
     this.apiKeyService.Reset();
     this.topupService.Reset();
+    this.telemetryService.Reset();
     this.router.navigateByUrl('/');
   }
 }

--- a/apps/web/src/app/features/setup/setup.component.html
+++ b/apps/web/src/app/features/setup/setup.component.html
@@ -114,6 +114,25 @@
         [showErrors]="platformShowErrors()"
       ></app-business-profile-form>
 
+      <label class="custom-checkbox field-check telemetry-opt-in">
+        <input
+          type="checkbox"
+          [checked]="telemetryEnabled()"
+          (change)="telemetryEnabled.set($any($event.target).checked)"
+        />
+        <span class="checkmark"></span>
+        <div>
+          Share anonymous usage statistics with Zoneless. Helps improve the
+          open-source project. No payment details, emails, or business data.
+          <a
+            href="https://zoneless.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Learn more</a
+          >.
+        </div>
+      </label>
+
       @if(error()) {
       <div class="error-message">{{ error() }}</div>
       }

--- a/apps/web/src/app/features/setup/setup.component.scss
+++ b/apps/web/src/app/features/setup/setup.component.scss
@@ -234,6 +234,41 @@ img.feature-icon {
   margin-bottom: $spacing;
 }
 
+.telemetry-opt-in {
+  display: flex;
+  align-items: flex-start;
+  gap: $spacing-small;
+  margin-top: $spacing-small;
+  margin-bottom: $spacing-large;
+  cursor: pointer;
+
+  .checkmark {
+    flex: 0 0 16px;
+    width: 16px;
+    height: 16px;
+    min-width: 16px;
+    min-height: 16px;
+    margin-top: 2px;
+    box-sizing: border-box;
+  }
+
+  div {
+    flex: 1;
+    margin-left: 0;
+    font-size: $font-size;
+    line-height: 1.45;
+    color: $text-color;
+  }
+
+  a {
+    color: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    text-decoration: underline;
+  }
+}
+
 // Anchor variant of .action-button (operator-managed notice)
 .operator-login-link {
   text-decoration: none;

--- a/apps/web/src/app/features/setup/setup.component.ts
+++ b/apps/web/src/app/features/setup/setup.component.ts
@@ -60,6 +60,9 @@ export class SetupComponent implements OnInit {
   platformDetails: WritableSignal<BusinessProfileSetupData | null> =
     signal(null);
 
+  /** Anonymous usage telemetry opt-in (default off; self-host setup only) */
+  telemetryEnabled: WritableSignal<boolean> = signal(false);
+
   // Wallet options
   walletOption: WritableSignal<'generate' | 'import'> = signal('generate');
 
@@ -221,6 +224,7 @@ export class SetupComponent implements OnInit {
       const response = await this.setupService.CompleteSetup({
         ...platformDetails,
         solana_public_key: publicKey,
+        telemetry_enabled: this.telemetryEnabled(),
       });
 
       this.setupResult.set(response);

--- a/libs/shared-types/src/lib/Config.ts
+++ b/libs/shared-types/src/lib/Config.ts
@@ -100,6 +100,11 @@ export interface SetupRequest {
   country?: string;
   /** Solana wallet public key (required - generated in browser or existing wallet) */
   solana_public_key: string;
+  /**
+   * Opt into anonymous usage telemetry (default false).
+   * See TELEMETRY.md — never sends PII or exact payment amounts.
+   */
+  telemetry_enabled?: boolean;
 }
 
 /**

--- a/libs/shared-types/src/lib/Telemetry.ts
+++ b/libs/shared-types/src/lib/Telemetry.ts
@@ -1,0 +1,86 @@
+/**
+ * Anonymous usage telemetry types.
+ * Opt-in heartbeats from self-hosted instances — see TELEMETRY.md.
+ */
+
+/** Coarse payment-count buckets for the last 7 days */
+export type TelemetryPaymentCountBucket =
+  | '0'
+  | '1-10'
+  | '11-100'
+  | '101-1000'
+  | '1000+';
+
+/**
+ * Coarse settled USDC volume buckets for the last 7 days.
+ * Thresholds are in USD (amounts stored as Stripe-style cents).
+ */
+export type TelemetryVolumeBucket =
+  | '0'
+  | 'lt_1k'
+  | 'lt_10k'
+  | 'lt_100k'
+  | 'lt_1m'
+  | 'gte_1m';
+
+/** Coarse connected-account count buckets */
+export type TelemetryConnectedAccountsBucket =
+  | '0'
+  | '1'
+  | '2-10'
+  | '11-100'
+  | '100+';
+
+/**
+ * Payload POSTed to the first-party ingest endpoint.
+ * Whitelist only — never include PII, secrets, or exact amounts.
+ */
+export interface TelemetryReport {
+  instance_id: string;
+  zoneless_version: string;
+  livemode: boolean;
+  single_tenant: boolean;
+  setup_completed: boolean;
+  os: string;
+  node_major: number;
+  payment_count_7d: TelemetryPaymentCountBucket;
+  usdc_volume_7d: TelemetryVolumeBucket;
+  connected_accounts: TelemetryConnectedAccountsBucket;
+}
+
+/**
+ * Persisted consent + identity for this deployment.
+ * Stored in TelemetryConfigs with id `telemetry`.
+ */
+export interface TelemetryConfig {
+  id: 'telemetry';
+  object: 'telemetry_config';
+  /** Whether this instance has opted in */
+  enabled: boolean;
+  /** Random UUID assigned on first enable; null when never enabled */
+  instance_id: string | null;
+  /** Unix timestamp of last successful send, or null */
+  last_sent_at: number | null;
+  created: number;
+  updated: number;
+}
+
+/** Response from GET /v1/telemetry */
+export interface TelemetryStatus {
+  object: 'telemetry_status';
+  /** False on operator-managed instances (telemetry UI hidden) */
+  available: boolean;
+  /** Effective enabled state (available && consented && !forced_off) */
+  enabled: boolean;
+  /** Whether this instance has consented in the DB */
+  consented: boolean;
+  /** True when env kill switch or operator mode blocks sending */
+  forced_off: boolean;
+  instance_id: string | null;
+  last_sent_at: number | null;
+}
+
+/** Request body for POST /v1/telemetry */
+export interface UpdateTelemetryRequest {
+  enabled: boolean;
+}

--- a/libs/shared-types/src/lib/Telemetry.ts
+++ b/libs/shared-types/src/lib/Telemetry.ts
@@ -17,6 +17,8 @@ export type TelemetryPaymentCountBucket =
  */
 export type TelemetryVolumeBucket =
   | '0'
+  | 'lt_10'
+  | 'lt_100'
   | 'lt_1k'
   | 'lt_10k'
   | 'lt_100k'
@@ -44,7 +46,10 @@ export interface TelemetryReport {
   os: string;
   node_major: number;
   payment_count_7d: TelemetryPaymentCountBucket;
+  /** Settled payment/charge volume (last 7 days), coarse bucket */
   usdc_volume_7d: TelemetryVolumeBucket;
+  /** Absolute payout volume (last 7 days), coarse bucket */
+  usdc_payout_volume_7d: TelemetryVolumeBucket;
   connected_accounts: TelemetryConnectedAccountsBucket;
 }
 
@@ -70,7 +75,7 @@ export interface TelemetryStatus {
   object: 'telemetry_status';
   /** False on operator-managed instances (telemetry UI hidden) */
   available: boolean;
-  /** Effective enabled state (available && consented && !forced_off) */
+  /** Effective enabled state (available && consented && !forced_off && livemode) */
   enabled: boolean;
   /** Whether this instance has consented in the DB */
   consented: boolean;

--- a/libs/shared-types/src/lib/index.ts
+++ b/libs/shared-types/src/lib/index.ts
@@ -31,6 +31,7 @@ export * from './QueryParameters';
 export * from './Reporting';
 export * from './Subscription';
 export * from './SubscriptionItem';
+export * from './Telemetry';
 export * from './TopUp';
 export * from './Transfer';
 export * from './WebhookEndpoint';


### PR DESCRIPTION
## Description

Adds a lightweight telemetry opt-in module during setup / via the dashboard that reports anonymous usage stats.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
