### PR TITLE
feat: search connect accounts from platform dashboard

### DIFF
--- a/apps/api/src/__tests__/Account.spec.ts
+++ b/apps/api/src/__tests__/Account.spec.ts
@@ -407,4 +407,82 @@ describe('AccountModule', () => {
       });
     });
   });
+
+  describe('SearchAccounts', () => {
+    it('should return an empty list for a blank query', async () => {
+      const result = await accountModule.SearchAccounts(
+        'acct_z_platform',
+        '  '
+      );
+
+      expect(result).toEqual({
+        object: 'list',
+        data: [],
+        has_more: false,
+        url: '/v1/accounts/search',
+      });
+      expect(mockDb.Aggregate).not.toHaveBeenCalled();
+    });
+
+    it('should search accounts and persons then return matching accounts', async () => {
+      const matched = {
+        id: 'acct_z_connected',
+        created: 1700000000,
+        email: 'kurniawan.anto7@gmail.com',
+        platform_account: 'acct_z_platform',
+      } as Account;
+
+      mockDb.Aggregate = jest
+        .fn()
+        .mockResolvedValueOnce([{ id: 'acct_z_connected' }])
+        .mockResolvedValueOnce([{ account: 'acct_z_connected' }]);
+      mockDb.Get = jest.fn().mockResolvedValue(matched);
+
+      const result = await accountModule.SearchAccounts(
+        'acct_z_platform',
+        'kurniawan.anto7@gmail.com'
+      );
+
+      expect(mockDb.Aggregate).toHaveBeenCalledTimes(2);
+      expect(mockDb.Aggregate).toHaveBeenNthCalledWith(
+        1,
+        'Accounts',
+        expect.any(Array)
+      );
+      expect(mockDb.Aggregate).toHaveBeenNthCalledWith(
+        2,
+        'Persons',
+        expect.any(Array)
+      );
+      expect(result.data).toEqual([matched]);
+      expect(result.has_more).toBe(false);
+      expect(result.url).toBe('/v1/accounts/search');
+    });
+
+    it('should skip person search when account matches already fill the limit', async () => {
+      mockDb.Aggregate = jest
+        .fn()
+        .mockResolvedValueOnce([{ id: 'acct_z_1' }, { id: 'acct_z_2' }]);
+      mockDb.Get = jest
+        .fn()
+        .mockResolvedValueOnce({
+          id: 'acct_z_1',
+          created: 2,
+        } as Account)
+        .mockResolvedValueOnce({
+          id: 'acct_z_2',
+          created: 1,
+        } as Account);
+
+      const result = await accountModule.SearchAccounts(
+        'acct_z_platform',
+        'anto',
+        { limit: 1 }
+      );
+
+      expect(mockDb.Aggregate).toHaveBeenCalledTimes(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.has_more).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/modules/Account.ts
+++ b/apps/api/src/modules/Account.ts
@@ -414,6 +414,114 @@ export class AccountModule {
     });
   }
 
+  /**
+   * Search connected accounts by email, name, or account id.
+   * Zoneless extension — not part of Stripe's Accounts API.
+   *
+   * Matches account email / business name / display name / id, plus person
+   * email / first name / last name / full name under the same platform.
+   */
+  async SearchAccounts(
+    platformAccountId: string,
+    query: string,
+    options: { limit?: number } = {}
+  ): Promise<ListResult<AccountType>> {
+    const url = '/v1/accounts/search';
+    const limit = Math.min(Math.max(options.limit ?? 10, 1), 100);
+    const trimmed = query.trim();
+
+    if (!trimmed) {
+      return { object: 'list', data: [], has_more: false, url };
+    }
+
+    const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = { $regex: escaped, $options: 'i' };
+    const accountIds = new Set<string>();
+
+    const accountHits = await this.db.Aggregate<{ id: string }>('Accounts', [
+      {
+        $match: {
+          platform_account: platformAccountId,
+          id: { $ne: platformAccountId },
+          $or: [
+            { id: regex },
+            { email: regex },
+            { 'business_profile.name': regex },
+            { 'settings.dashboard.display_name': regex },
+          ],
+        },
+      },
+      { $project: { id: 1 } },
+      { $limit: limit + 1 },
+    ]);
+
+    for (const hit of accountHits) {
+      if (hit.id) accountIds.add(hit.id);
+    }
+
+    if (accountIds.size <= limit) {
+      const personHits = await this.db.Aggregate<{ account: string }>(
+        'Persons',
+        [
+          {
+            $match: {
+              platform_account: platformAccountId,
+              $or: [
+                { email: regex },
+                { first_name: regex },
+                { last_name: regex },
+                {
+                  $expr: {
+                    $regexMatch: {
+                      input: {
+                        $trim: {
+                          input: {
+                            $concat: [
+                              { $ifNull: ['$first_name', ''] },
+                              ' ',
+                              { $ifNull: ['$last_name', ''] },
+                            ],
+                          },
+                        },
+                      },
+                      regex: escaped,
+                      options: 'i',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          { $project: { account: 1 } },
+          { $limit: limit + 1 },
+        ]
+      );
+
+      for (const hit of personHits) {
+        if (hit.account && hit.account !== platformAccountId) {
+          accountIds.add(hit.account);
+        }
+      }
+    }
+
+    const orderedIds = [...accountIds];
+    const hasMore = orderedIds.length > limit;
+    const pageIds = orderedIds.slice(0, limit);
+
+    const accounts = (
+      await Promise.all(pageIds.map((id) => this.GetAccount(id)))
+    ).filter((account): account is AccountType => account !== null);
+
+    accounts.sort((a, b) => b.created - a.created);
+
+    return {
+      object: 'list',
+      data: accounts,
+      has_more: hasMore,
+      url,
+    };
+  }
+
   private BuildStatusFilters(
     status?: ConnectedAccountStatusFilter
   ): Record<string, unknown | FilterCondition> {

--- a/apps/api/src/modules/Database.ts
+++ b/apps/api/src/modules/Database.ts
@@ -388,7 +388,8 @@ export class Database {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async Aggregate<T>(collection: string, pipeline: any[]): Promise<T[]> {
     const model = this.GetModel(collection);
-    return model.aggregate(pipeline).exec();
+    const docs = await model.aggregate(pipeline).exec();
+    return docs.map((doc) => this.StripMongoFields(doc as T));
   }
 
   /**

--- a/apps/api/src/routes/accounts.routes.ts
+++ b/apps/api/src/routes/accounts.routes.ts
@@ -258,6 +258,40 @@ router.get(
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
+// GET /v1/accounts/search - Search connected accounts
+// Zoneless extension for the platform dashboard search bar
+// ─────────────────────────────────────────────────────────────────────────────
+router.get(
+  '/search',
+  RequirePlatform(),
+  AsyncHandler(async (req: express.Request, res: express.Response) => {
+    const platformAccountId = req.user.account;
+    const query = ((req.query.query as string | undefined) ?? '').trim();
+    const limit = req.query.limit
+      ? parseInt(req.query.limit as string, 10)
+      : 10;
+
+    Logger.info('Searching accounts', {
+      platformAccountId,
+      query,
+      limit,
+    });
+
+    const result = await accountModule.SearchAccounts(
+      platformAccountId,
+      query,
+      { limit }
+    );
+
+    result.data = await Promise.all(
+      result.data.map((account) => PopulateAccountResources(account, false))
+    );
+
+    res.json(result);
+  })
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // GET /v1/accounts/:id - Retrieve a specific account
 // @see https://docs.stripe.com/api/accounts/retrieve
 // ─────────────────────────────────────────────────────────────────────────────

--- a/apps/web/src/app/data/services/account.service.ts
+++ b/apps/web/src/app/data/services/account.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal, WritableSignal, inject } from '@angular/core';
 import { ApiService } from '../../core/services/api.service';
-import { Account, LoginLink } from '@zoneless/shared-types';
+import { Account, ListResponse, LoginLink } from '@zoneless/shared-types';
 import {
   CreateAccountInput,
   FormatPayoutVolumeThresholdCents,
@@ -151,6 +151,19 @@ export class AccountService {
   }
 
   /**
+   * Search connected accounts by email, name, or account id.
+   */
+  async SearchConnectedAccounts(
+    query: string,
+    limit = 8
+  ): Promise<ListResponse<Account>> {
+    return this.api.Call<ListResponse<Account>>('GET', 'accounts/search', {
+      query,
+      limit: String(limit),
+    });
+  }
+
+  /**
    * Create a login link for a connected account and open their dashboard in a new tab.
    */
   async CreateLoginLink(accountId: string): Promise<LoginLink> {
@@ -179,6 +192,23 @@ export class AccountService {
     }
 
     return account.email ?? individual?.email ?? account.id;
+  }
+
+  /**
+   * Secondary label shown in search results.
+   * Prefers the field that matches the query (email, then id), else email/id.
+   */
+  GetConnectedAccountSearchMatch(account: Account, query = ''): string {
+    const email =
+      account.email?.trim() || account.individual?.email?.trim() || '';
+    const normalizedQuery = query.trim().toLowerCase();
+
+    if (normalizedQuery) {
+      if (email.toLowerCase().includes(normalizedQuery)) return email;
+      if (account.id.toLowerCase().includes(normalizedQuery)) return account.id;
+    }
+
+    return email || account.id;
   }
 
   /**

--- a/apps/web/src/app/features/account/components/events-list/events-list.component.ts
+++ b/apps/web/src/app/features/account/components/events-list/events-list.component.ts
@@ -1,8 +1,10 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  OnChanges,
   OnInit,
   Input,
+  SimpleChanges,
   signal,
   WritableSignal,
 } from '@angular/core';
@@ -21,7 +23,7 @@ import { Event } from '@zoneless/shared-types';
   styleUrl: './events-list.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class EventsListComponent implements OnInit {
+export class EventsListComponent implements OnInit, OnChanges {
   @Input() itemId = '';
 
   eventColumns: WritableSignal<PaginatedListColumn[]> = signal([]);
@@ -29,6 +31,12 @@ export class EventsListComponent implements OnInit {
 
   ngOnInit(): void {
     this.InitEventList(this.itemId);
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['itemId'] && !changes['itemId'].firstChange) {
+      this.InitEventList(this.itemId);
+    }
   }
 
   InitEventList(itemId: string): void {

--- a/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.ts
+++ b/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.ts
@@ -352,6 +352,7 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
   }
 
   private sub?: Subscription;
+  private actionsSub?: Subscription;
 
   @ViewChild('overviewTransfers')
   overviewTransfersList?: PaginatedListComponent<any>;
@@ -363,11 +364,14 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
   paymentsPayoutsList?: PaginatedListComponent<any>;
 
   async ngOnInit(): Promise<void> {
-    const id = this.route.snapshot.paramMap.get('accountId');
-    if (!id) return;
-    await this.LoadAccount(id);
-    this.metaService.SetMetaTitle(this.displayName());
-    this.sub = this.actions.events$.subscribe((event) => {
+    this.sub = this.route.paramMap.subscribe((params) => {
+      const id = params.get('accountId');
+      if (!id) return;
+      void this.OnAccountIdChange(id);
+    });
+    this.actionsSub = this.actions.events$.subscribe((event) => {
+      const id = this.account()?.id;
+      if (!id) return;
       if (
         (event.type === 'funds_added' ||
           event.type === 'funds_pulled' ||
@@ -385,7 +389,23 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.sub?.unsubscribe();
+    this.actionsSub?.unsubscribe();
     clearTimeout(this.idCopiedTimer);
+  }
+
+  private async OnAccountIdChange(id: string): Promise<void> {
+    if (this.account()?.id === id) return;
+
+    this.account.set(null);
+    this.activeTab.set('overview');
+    this.detailPanel.set('main');
+    this.moneyMovementTab.set('payouts');
+    this.paymentsTab.set('transfers');
+    this.idCopied.set(false);
+    clearTimeout(this.idCopiedTimer);
+
+    await this.LoadAccount(id);
+    this.metaService.SetMetaTitle(this.displayName());
   }
 
   private async LoadAccount(id: string): Promise<void> {

--- a/apps/web/src/app/features/account/shells/full-shell/dashboard-search/dashboard-search.component.html
+++ b/apps/web/src/app/features/account/shells/full-shell/dashboard-search/dashboard-search.component.html
@@ -1,0 +1,59 @@
+<div class="dashboard-search" [class.is-open]="open()">
+  <div class="search-field">
+    <img
+      class="search-icon"
+      src="assets/icons/search.svg"
+      alt=""
+      aria-hidden="true"
+    />
+    <input
+      type="search"
+      placeholder="Search"
+      aria-label="Search"
+      autocomplete="off"
+      [ngModel]="query()"
+      (ngModelChange)="OnQueryChange($event)"
+      (focus)="OnFocus()"
+      (keydown)="OnKeyDown($event)"
+    />
+  </div>
+
+  @if (open()) {
+  <div class="search-dropdown" role="listbox" aria-label="Search results">
+    <div class="search-section">
+      <div class="search-section-header">Connected accounts</div>
+
+      @if (loading() && results().length === 0) {
+      <div class="search-empty">Searching…</div>
+      } @else if (results().length === 0) {
+      <div class="search-empty">No connected accounts found</div>
+      } @else {
+      <div class="search-results">
+        @for (account of results(); track account.id; let i = $index) {
+        <a
+          class="search-result"
+          role="option"
+          [attr.aria-selected]="activeIndex() === i"
+          [class.is-active]="activeIndex() === i"
+          [routerLink]="['/account/connected-accounts', account.id]"
+          (click)="OnResultClick()"
+          (mouseenter)="activeIndex.set(i)"
+        >
+          <span
+            class="search-result-name"
+            [class.search-match]="MatchesQuery(GetDisplayName(account))"
+            >{{ GetDisplayName(account) }}</span
+          >
+          <span
+            class="search-result-match-value"
+            [class.search-match]="MatchesQuery(GetMatchValue(account))"
+            >{{ GetMatchValue(account) }}</span
+          >
+        </a>
+        }
+      </div>
+      }
+    </div>
+  </div>
+  }
+</div>

--- a/apps/web/src/app/features/account/shells/full-shell/dashboard-search/dashboard-search.component.scss
+++ b/apps/web/src/app/features/account/shells/full-shell/dashboard-search/dashboard-search.component.scss
@@ -1,0 +1,158 @@
+@use '../../../../../styles/base.scss' as *;
+
+:host {
+  display: block;
+  flex: 1;
+  max-width: 420px;
+  min-width: 0;
+}
+
+.dashboard-search {
+  position: relative;
+  width: 100%;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: $spacing-small;
+  width: 100%;
+  height: 36px;
+  padding: 0 $spacing;
+  background-color: $mid-background-color;
+  border: 1px solid transparent;
+  border-radius: $border-radius-small;
+  box-sizing: border-box;
+  transition: background-color $transition-fast, border-color $transition-fast,
+    box-shadow $transition-fast;
+}
+
+.dashboard-search.is-open .search-field {
+  background-color: $background-color;
+  border-color: $darkest-background-color;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  box-shadow: 0 8px 24px rgba(30, 41, 59, 0.12),
+    0 2px 6px rgba(30, 41, 59, 0.08);
+}
+
+.search-icon {
+  width: 14px;
+  height: 14px;
+  opacity: $dimmed-extra;
+  flex-shrink: 0;
+}
+
+.search-field input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: $text-font;
+  font-size: $font-size;
+  color: $text-color;
+  min-width: 0;
+}
+
+.search-field input::placeholder {
+  color: $text-color;
+  opacity: $dimmed-extra;
+}
+
+.search-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  width: 100%;
+  background-color: $background-color;
+  border: 1px solid $darkest-background-color;
+  border-top: none;
+  border-radius: 0 0 $border-radius-small $border-radius-small;
+  box-shadow: 0 8px 24px rgba(30, 41, 59, 0.12),
+    0 2px 6px rgba(30, 41, 59, 0.08);
+  padding: $spacing-small 0 $spacing-extra-small;
+  animation: searchDropdownFadeIn $transition-fast ease-out;
+  box-sizing: border-box;
+}
+
+.search-section-header {
+  padding: $spacing-extra-small $spacing $spacing-small;
+  font-size: $font-size-small;
+  font-weight: 600;
+  color: $text-color;
+  opacity: $dimmed;
+}
+
+.search-results {
+  display: flex;
+  flex-direction: column;
+}
+
+.search-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing;
+  padding: $spacing-small $spacing;
+  color: $text-color !important;
+  font-size: $font-size;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color $transition-fast;
+
+  &:hover,
+  &.is-active {
+    background-color: $dark-background-color;
+  }
+}
+
+.search-result-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: $text-color;
+  font-weight: $text-weight;
+}
+
+.search-result-match-value {
+  flex-shrink: 0;
+  max-width: 55%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: $text-color;
+  font-size: $font-size;
+}
+
+.search-match {
+  background-color: rgba(0, 85, 255, 0.12);
+  border-radius: 2px;
+  padding: 1px 4px;
+}
+
+.search-empty {
+  padding: $spacing-small $spacing $spacing;
+  font-size: $font-size-small;
+  color: $text-color;
+  opacity: $dimmed;
+}
+
+@keyframes searchDropdownFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media only screen and (max-width: 1000px) {
+  :host {
+    max-width: none;
+  }
+}

--- a/apps/web/src/app/features/account/shells/full-shell/dashboard-search/dashboard-search.component.ts
+++ b/apps/web/src/app/features/account/shells/full-shell/dashboard-search/dashboard-search.component.ts
@@ -1,0 +1,171 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  inject,
+  signal,
+  WritableSignal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import type { Account } from '@zoneless/shared-types';
+import { AccountService } from '../../../../../data';
+
+@Component({
+  selector: 'app-dashboard-search',
+  imports: [FormsModule, RouterLink],
+  templateUrl: './dashboard-search.component.html',
+  styleUrl: './dashboard-search.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DashboardSearchComponent implements OnDestroy {
+  private readonly accountService = inject(AccountService);
+  private readonly router = inject(Router);
+  private readonly host = inject(ElementRef<HTMLElement>);
+
+  query: WritableSignal<string> = signal('');
+  results: WritableSignal<Account[]> = signal([]);
+  open: WritableSignal<boolean> = signal(false);
+  loading: WritableSignal<boolean> = signal(false);
+  activeIndex: WritableSignal<number> = signal(-1);
+
+  private searchTimer: ReturnType<typeof setTimeout> | null = null;
+  private searchRequestId = 0;
+
+  ngOnDestroy(): void {
+    this.ClearSearchTimer();
+  }
+
+  OnFocus(): void {
+    if (this.query().trim()) {
+      this.open.set(true);
+    }
+  }
+
+  OnQueryChange(value: string): void {
+    this.query.set(value);
+    this.activeIndex.set(-1);
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      this.ClearSearchTimer();
+      this.results.set([]);
+      this.open.set(false);
+      this.loading.set(false);
+      return;
+    }
+
+    this.open.set(true);
+    this.loading.set(true);
+    this.ClearSearchTimer();
+    this.searchTimer = setTimeout(() => {
+      void this.RunSearch(trimmed);
+    }, 200);
+  }
+
+  OnKeyDown(event: KeyboardEvent): void {
+    if (!this.open()) return;
+
+    const results = this.results();
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (results.length === 0) return;
+      this.activeIndex.update((index) =>
+        index < results.length - 1 ? index + 1 : 0
+      );
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (results.length === 0) return;
+      this.activeIndex.update((index) =>
+        index <= 0 ? results.length - 1 : index - 1
+      );
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      const index = this.activeIndex();
+      const account = index >= 0 ? results[index] : results[0];
+      if (account) {
+        event.preventDefault();
+        this.SelectAccount(account);
+      }
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.Close();
+    }
+  }
+
+  SelectAccount(account: Account): void {
+    this.OnResultClick();
+    void this.router.navigate(['/account/connected-accounts', account.id]);
+  }
+
+  OnResultClick(): void {
+    this.query.set('');
+    this.results.set([]);
+    this.Close();
+  }
+
+  GetDisplayName(account: Account): string {
+    return this.accountService.GetConnectedAccountDisplayName(account);
+  }
+
+  GetMatchValue(account: Account): string {
+    return this.accountService.GetConnectedAccountSearchMatch(
+      account,
+      this.query()
+    );
+  }
+
+  MatchesQuery(value: string): boolean {
+    const query = this.query().trim().toLowerCase();
+    if (!query) return false;
+    return value.toLowerCase().includes(query);
+  }
+
+  @HostListener('document:click', ['$event'])
+  OnDocumentClick(event: MouseEvent): void {
+    if (!this.open()) return;
+    if (!this.host.nativeElement.contains(event.target as Node)) {
+      this.Close();
+    }
+  }
+
+  private async RunSearch(query: string): Promise<void> {
+    const requestId = ++this.searchRequestId;
+    try {
+      const response = await this.accountService.SearchConnectedAccounts(query);
+      if (requestId !== this.searchRequestId) return;
+      this.results.set(response.data);
+      this.open.set(true);
+    } catch (error) {
+      if (requestId !== this.searchRequestId) return;
+      console.error('Failed to search connected accounts:', error);
+      this.results.set([]);
+    } finally {
+      if (requestId === this.searchRequestId) {
+        this.loading.set(false);
+      }
+    }
+  }
+
+  private Close(): void {
+    this.open.set(false);
+    this.activeIndex.set(-1);
+  }
+
+  private ClearSearchTimer(): void {
+    if (this.searchTimer) {
+      clearTimeout(this.searchTimer);
+      this.searchTimer = null;
+    }
+  }
+}

--- a/apps/web/src/app/features/account/shells/full-shell/full-shell.component.html
+++ b/apps/web/src/app/features/account/shells/full-shell/full-shell.component.html
@@ -12,20 +12,7 @@
 
     <div class="shell-main">
       <header class="full-top-bar">
-        <div class="search-field">
-          <img
-            class="search-icon"
-            src="assets/icons/search.svg"
-            alt=""
-            aria-hidden="true"
-          />
-          <input
-            type="search"
-            placeholder="Search"
-            aria-label="Search"
-            disabled
-          />
-        </div>
+        <app-dashboard-search></app-dashboard-search>
 
         <div class="top-bar-actions">
           <a

--- a/apps/web/src/app/features/account/shells/full-shell/full-shell.component.scss
+++ b/apps/web/src/app/features/account/shells/full-shell/full-shell.component.scss
@@ -15,47 +15,6 @@
   box-sizing: border-box;
 }
 
-.search-field {
-  display: flex;
-  align-items: center;
-  gap: $spacing-small;
-  flex: 1;
-  max-width: 420px;
-  height: 36px;
-  padding: 0 $spacing;
-  background-color: $mid-background-color;
-  border: none;
-  border-radius: $border-radius-small;
-}
-
-.search-icon {
-  width: 14px;
-  height: 14px;
-  opacity: $dimmed-extra;
-  flex-shrink: 0;
-}
-
-.search-field input {
-  flex: 1;
-  border: none;
-  outline: none;
-  background: transparent;
-  font-family: $text-font;
-  font-size: $font-size;
-  color: $text-color;
-  min-width: 0;
-}
-
-.search-field input::placeholder {
-  color: $text-color;
-  opacity: $dimmed-extra;
-}
-
-.search-field input:disabled {
-  cursor: default;
-  opacity: $dimmed;
-}
-
 .top-bar-actions {
   display: flex;
   align-items: center;
@@ -85,9 +44,5 @@
 @media only screen and (max-width: 1000px) {
   .full-top-bar {
     padding: $spacing-small $spacing;
-  }
-
-  .search-field {
-    max-width: none;
   }
 }

--- a/apps/web/src/app/features/account/shells/full-shell/full-shell.component.ts
+++ b/apps/web/src/app/features/account/shells/full-shell/full-shell.component.ts
@@ -1,10 +1,11 @@
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { SideMenuComponent, SideMenuGroup } from '../../../../shared';
+import { DashboardSearchComponent } from './dashboard-search/dashboard-search.component';
 
 @Component({
   selector: 'app-full-shell',
-  imports: [SideMenuComponent, RouterLink],
+  imports: [SideMenuComponent, RouterLink, DashboardSearchComponent],
   templateUrl: './full-shell.component.html',
   styleUrl: './full-shell.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Description

Finally a non-disabled search bar! You can use the search bar to query connect accounts via id, name or email.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
