### PR TITLE
fix: checkout wallet flow on android

### DIFF
--- a/apps/web/src/app/core/services/wallet.service.spec.ts
+++ b/apps/web/src/app/core/services/wallet.service.spec.ts
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 
 import { Keypair, SystemProgram, Transaction } from '@solana/web3.js';
+import type { Wallet } from '@wallet-standard/base';
 import bs58 from 'bs58';
 import { SolanaWalletService } from './wallet.service';
 
@@ -23,6 +24,21 @@ describe('SolanaWalletService local key signing', () => {
     await expect(service.GetSecretKeyAddress('not a key')).rejects.toThrow(
       'Invalid base58 Solana private key'
     );
+  });
+
+  it('identifies Mobile Wallet Adapter errors through wrapped causes', () => {
+    service.wallet.set({
+      name: 'Mobile Wallet Adapter',
+    } as Wallet);
+    const walletError = Object.assign(new Error('Wallet unavailable'), {
+      code: 'ERROR_WALLET_NOT_FOUND',
+    });
+
+    expect(
+      service.IsMobileWalletNotFoundError(
+        new Error('Could not connect', { cause: walletError })
+      )
+    ).toBe(true);
   });
 
   it('signs a payout transaction with the matching private key', async () => {

--- a/apps/web/src/app/core/services/wallet.service.ts
+++ b/apps/web/src/app/core/services/wallet.service.ts
@@ -10,6 +10,8 @@ type DisconnectFeature = {
   disconnect: () => Promise<void>;
 };
 
+const MOBILE_WALLET_ADAPTER_NAME = 'Mobile Wallet Adapter';
+
 @Injectable({ providedIn: 'root' })
 export class SolanaWalletService {
   private readonly walletStore = getWallets();
@@ -23,7 +25,13 @@ export class SolanaWalletService {
     this.wallet.set(discoveredWallet);
 
     this.walletStore.on('register', (nextWallet) => {
-      if (!this.wallet()) this.wallet.set(nextWallet);
+      const selectedWallet = this.wallet();
+      if (
+        !selectedWallet ||
+        selectedWallet.name === MOBILE_WALLET_ADAPTER_NAME
+      ) {
+        this.wallet.set(nextWallet);
+      }
     });
   }
 
@@ -52,6 +60,35 @@ export class SolanaWalletService {
 
   HasWallet(): boolean {
     return this.wallet() !== null;
+  }
+
+  IsMobileWalletAdapter(): boolean {
+    return this.wallet()?.name === MOBILE_WALLET_ADAPTER_NAME;
+  }
+
+  IsMobileWalletNotFoundError(error: unknown): boolean {
+    if (!this.IsMobileWalletAdapter()) return false;
+
+    let currentError: unknown = error;
+    for (let depth = 0; depth < 4; depth += 1) {
+      if (!currentError || typeof currentError !== 'object') return false;
+      const errorWithCause = currentError as {
+        code?: unknown;
+        message?: unknown;
+        cause?: unknown;
+      };
+      if (errorWithCause.code === 'ERROR_WALLET_NOT_FOUND') return true;
+      if (
+        typeof errorWithCause.message === 'string' &&
+        /can't find a wallet|no installed wallet|wallet not found|supports the mobile wallet protocol/i.test(
+          errorWithCause.message
+        )
+      ) {
+        return true;
+      }
+      currentError = errorWithCause.cause;
+    }
+    return false;
   }
 
   GetAddress(): string {

--- a/apps/web/src/app/features/checkout/checkout.component.spec.ts
+++ b/apps/web/src/app/features/checkout/checkout.component.spec.ts
@@ -1,14 +1,55 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+import { CheckoutSession } from '@zoneless/shared-types';
 
 import { MetaService, SolanaWalletService } from '../../core';
-import { CheckoutSessionService } from '../../data/services/checkout-session.service';
+import {
+  CheckoutPaymentTransaction,
+  CheckoutSessionService,
+} from '../../data/services/checkout-session.service';
 import { CheckoutComponent } from './checkout.component';
 
 describe('CheckoutComponent mobile wallet handoff', () => {
   const walletService = {
     HasWallet: jest.fn(),
+    IsMobileWalletAdapter: jest.fn(),
+    IsMobileWalletNotFoundError: jest.fn(),
+    GetAddress: jest.fn(),
+    Connect: jest.fn(),
+    SignAndSendUnsignedTransaction: jest.fn(),
+    SignUnsignedTransaction: jest.fn(),
+    BytesToBase64: jest.fn(),
   };
+  const checkoutSessionService = {
+    PreparePayment: jest.fn(),
+    ConfirmPayment: jest.fn(),
+  };
+  const checkoutSession = {
+    id: 'cs_test',
+    url_slug: 'test-session',
+    mode: 'payment',
+    status: 'open',
+    livemode: false,
+    amount_total: 100,
+    amount_subtotal: 100,
+    currency: 'usdc',
+    line_items: [],
+  } as unknown as CheckoutSession;
+  const preparedPayment = {
+    object: 'checkout.payment_transaction',
+    checkout_session: 'cs_test',
+    amount_total: 100,
+    currency: 'usdc',
+    merchant_wallet_address: 'merchant',
+    unsigned_transaction: 'dGVzdA==',
+    estimated_fee_lamports: 5000,
+    blockhash: 'blockhash',
+    last_valid_block_height: 100,
+  } satisfies CheckoutPaymentTransaction;
+  const completedSession = {
+    ...checkoutSession,
+    status: 'complete',
+  } as CheckoutSession;
   let component: CheckoutComponent;
 
   beforeEach(() => {
@@ -18,17 +59,29 @@ describe('CheckoutComponent mobile wallet handoff', () => {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: { get: () => null } } },
         },
-        { provide: CheckoutSessionService, useValue: {} },
+        { provide: CheckoutSessionService, useValue: checkoutSessionService },
         { provide: MetaService, useValue: {} },
         { provide: SolanaWalletService, useValue: walletService },
       ],
     });
     component = TestBed.runInInjectionContext(() => new CheckoutComponent());
+    component.checkoutSession.set(checkoutSession);
+    component.email = 'payer@example.com';
+    walletService.HasWallet.mockReturnValue(true);
+    walletService.IsMobileWalletAdapter.mockReturnValue(false);
+    walletService.IsMobileWalletNotFoundError.mockReturnValue(false);
+    walletService.GetAddress.mockReturnValue('');
+    walletService.Connect.mockResolvedValue(undefined);
+    walletService.SignAndSendUnsignedTransaction.mockResolvedValue(
+      new Uint8Array([1, 2, 3])
+    );
+    checkoutSessionService.PreparePayment.mockResolvedValue(preparedPayment);
+    checkoutSessionService.ConfirmPayment.mockResolvedValue(completedSession);
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
-    walletService.HasWallet.mockReset();
+    jest.clearAllMocks();
   });
 
   it('requests a wallet-browser handoff on mobile without a wallet', () => {
@@ -56,5 +109,46 @@ describe('CheckoutComponent mobile wallet handoff', () => {
     walletService.HasWallet.mockReturnValue(false);
 
     expect(component.NeedsMobileWalletHandoff()).toBe(false);
+  });
+
+  it('separates MWA connection and signing into explicit user actions', async () => {
+    walletService.IsMobileWalletAdapter.mockReturnValue(true);
+    walletService.Connect.mockImplementation(async () => {
+      walletService.GetAddress.mockReturnValue('payer-wallet');
+    });
+
+    await component.Pay();
+
+    expect(walletService.Connect).toHaveBeenCalledTimes(1);
+    expect(checkoutSessionService.PreparePayment).toHaveBeenCalledTimes(1);
+    expect(walletService.SignAndSendUnsignedTransaction).not.toHaveBeenCalled();
+    expect(component.paymentPhase()).toBe('ready_to_sign');
+    expect(component.SubmitLabel()).toBe('Confirm payment');
+
+    await component.Pay();
+
+    expect(walletService.SignAndSendUnsignedTransaction).toHaveBeenCalledWith(
+      preparedPayment.unsigned_transaction,
+      'solana:devnet'
+    );
+    expect(checkoutSessionService.ConfirmPayment).toHaveBeenCalledTimes(1);
+    expect(component.paymentPhase()).toBe('complete');
+  });
+
+  it('shows wallet-browser choices when MWA cannot find a wallet', async () => {
+    jest
+      .spyOn(navigator, 'userAgent', 'get')
+      .mockReturnValue('Mozilla/5.0 (Linux; Android 16) Chrome/140 Mobile');
+    walletService.IsMobileWalletAdapter.mockReturnValue(true);
+    walletService.IsMobileWalletNotFoundError.mockReturnValue(true);
+    walletService.Connect.mockRejectedValue({
+      code: 'ERROR_WALLET_NOT_FOUND',
+    });
+
+    await component.Pay();
+
+    expect(component.mobileWalletHandoffRequested()).toBe(true);
+    expect(component.NeedsMobileWalletHandoff()).toBe(true);
+    expect(component.paymentError()).toBeNull();
   });
 });

--- a/apps/web/src/app/features/checkout/checkout.component.ts
+++ b/apps/web/src/app/features/checkout/checkout.component.ts
@@ -11,7 +11,10 @@ import { ActivatedRoute } from '@angular/router';
 import bs58 from 'bs58';
 
 import { MetaService, SolanaWalletService } from '../../core';
-import { CheckoutSessionService } from '../../data/services/checkout-session.service';
+import {
+  CheckoutPaymentTransaction,
+  CheckoutSessionService,
+} from '../../data/services/checkout-session.service';
 import { LoaderComponent, PageLoaderComponent } from '../../shared';
 import { ISO_CODES } from '../../utils';
 import {
@@ -44,7 +47,14 @@ import {
   MobileWalletOption,
 } from './util/mobile-wallet';
 
-type PaymentPhase = 'idle' | 'awaiting_wallet' | 'processing' | 'complete';
+type PaymentPhase =
+  | 'idle'
+  | 'connecting'
+  | 'preparing'
+  | 'ready_to_sign'
+  | 'awaiting_wallet'
+  | 'processing'
+  | 'complete';
 
 type AddressFormValue = {
   name: string;
@@ -63,6 +73,18 @@ type PreparedAddress = {
   state?: string;
   postal_code?: string;
   country?: string;
+};
+
+type CustomerDetailsPayload = {
+  email?: string;
+  name?: string;
+  business_name?: string;
+  phone?: string;
+  address?: PreparedAddress;
+  shipping_address?: PreparedAddress & { name?: string };
+  tax_id?: string;
+  custom_fields?: { key: string; value: string }[];
+  terms_of_service_accepted?: boolean;
 };
 
 function EmptyAddressForm(): AddressFormValue {
@@ -103,9 +125,14 @@ export class CheckoutComponent implements OnInit {
   loading: WritableSignal<boolean> = signal(true);
   paymentPhase: WritableSignal<PaymentPhase> = signal('idle');
   paymentError: WritableSignal<string | null> = signal(null);
+  mobileWalletHandoffRequested: WritableSignal<boolean> = signal(false);
   confirmationExpanded: WritableSignal<boolean> = signal(false);
   billingAddressExpanded: WritableSignal<boolean> = signal(false);
   shippingAddressExpanded: WritableSignal<boolean> = signal(false);
+  private readonly preparedPayment: WritableSignal<CheckoutPaymentTransaction | null> =
+    signal(null);
+  private preparedCustomerDetailsKey = '';
+  private mobileInitAuthorityDone = false;
 
   readonly countryOptions = [...ISO_CODES].sort((a, b) =>
     a.country.localeCompare(b.country)
@@ -251,7 +278,12 @@ export class CheckoutComponent implements OnInit {
 
   IsBusy(): boolean {
     const phase = this.paymentPhase();
-    return phase === 'awaiting_wallet' || phase === 'processing';
+    return (
+      phase === 'connecting' ||
+      phase === 'preparing' ||
+      phase === 'awaiting_wallet' ||
+      phase === 'processing'
+    );
   }
 
   IsComplete(): boolean {
@@ -262,7 +294,8 @@ export class CheckoutComponent implements OnInit {
     if (typeof navigator === 'undefined') return false;
     return (
       IsMobileBrowser(navigator.userAgent, navigator.maxTouchPoints) &&
-      !this.solanaWalletService.HasWallet()
+      (!this.solanaWalletService.HasWallet() ||
+        this.mobileWalletHandoffRequested())
     );
   }
 
@@ -276,7 +309,13 @@ export class CheckoutComponent implements OnInit {
 
   async Pay(): Promise<void> {
     const session = this.checkoutSession();
-    if (!session || this.paymentPhase() !== 'idle') return;
+    if (!session) return;
+
+    if (this.paymentPhase() === 'ready_to_sign') {
+      await this.ConfirmMobileWalletPayment(session);
+      return;
+    }
+    if (this.paymentPhase() !== 'idle') return;
 
     const validationError = this.ValidateCollectedDetails();
     if (validationError) {
@@ -284,9 +323,15 @@ export class CheckoutComponent implements OnInit {
       return;
     }
 
-    this.paymentPhase.set('awaiting_wallet');
     this.paymentError.set(null);
+    this.mobileWalletHandoffRequested.set(false);
 
+    if (this.solanaWalletService.IsMobileWalletAdapter()) {
+      await this.BeginMobileWalletPayment(session);
+      return;
+    }
+
+    this.paymentPhase.set('awaiting_wallet');
     try {
       if (!this.solanaWalletService.GetAddress()) {
         await this.solanaWalletService.Connect();
@@ -297,13 +342,126 @@ export class CheckoutComponent implements OnInit {
       }
 
       const completedSession = await this.PayWithWallet(session, payerWallet);
-
-      this.checkoutSession.set(completedSession);
-      this.paymentPhase.set('complete');
-      this.HandleAfterCompletion(completedSession);
+      this.CompletePayment(completedSession);
     } catch (error) {
-      this.paymentError.set(this.ErrorMessage(error));
-      this.paymentPhase.set('idle');
+      this.HandlePaymentError(error, 'idle');
+    }
+  }
+
+  private async BeginMobileWalletPayment(
+    session: CheckoutSession
+  ): Promise<void> {
+    try {
+      if (!this.solanaWalletService.GetAddress()) {
+        this.paymentPhase.set('connecting');
+        await this.solanaWalletService.Connect();
+      }
+      const payerWallet = this.solanaWalletService.GetAddress();
+      if (!payerWallet) {
+        throw new Error('Connect a wallet to pay');
+      }
+      await this.PrepareMobileWalletPayment(session, payerWallet);
+    } catch (error) {
+      this.HandlePaymentError(error, 'idle');
+    }
+  }
+
+  private async PrepareMobileWalletPayment(
+    session: CheckoutSession,
+    payerWallet: string
+  ): Promise<void> {
+    this.paymentPhase.set('preparing');
+    const customerDetails = this.BuildCustomerDetailsPayload();
+    const prepared = await this.PreparePayment(
+      session,
+      payerWallet,
+      customerDetails
+    );
+
+    const completedSession = await this.ConfirmAlreadySubscribed(
+      session,
+      prepared
+    );
+    if (completedSession) {
+      this.CompletePayment(completedSession);
+      return;
+    }
+
+    if (
+      prepared.subscription_step === 'init_authority' &&
+      this.mobileInitAuthorityDone
+    ) {
+      throw new Error(
+        'Subscription authority init did not land. Please try again.'
+      );
+    }
+
+    this.preparedPayment.set(prepared);
+    this.preparedCustomerDetailsKey = JSON.stringify(customerDetails);
+    this.paymentPhase.set('ready_to_sign');
+  }
+
+  private async ConfirmMobileWalletPayment(
+    session: CheckoutSession
+  ): Promise<void> {
+    const prepared = this.preparedPayment();
+    const payerWallet = this.solanaWalletService.GetAddress();
+    if (!prepared || !payerWallet) {
+      this.ResetPreparedPayment();
+      return;
+    }
+
+    const validationError = this.ValidateCollectedDetails();
+    if (validationError) {
+      this.paymentError.set(validationError);
+      this.ResetPreparedPayment();
+      return;
+    }
+
+    const customerDetailsKey = JSON.stringify(
+      this.BuildCustomerDetailsPayload()
+    );
+    if (customerDetailsKey !== this.preparedCustomerDetailsKey) {
+      try {
+        await this.PrepareMobileWalletPayment(session, payerWallet);
+      } catch (error) {
+        this.HandlePaymentError(error, 'idle');
+      }
+      return;
+    }
+
+    const chain = session.livemode ? 'solana:mainnet' : 'solana:devnet';
+    this.paymentPhase.set('awaiting_wallet');
+    this.paymentError.set(null);
+
+    try {
+      const completedSession = await this.SignAndConfirmPrepared(
+        session,
+        prepared,
+        chain
+      );
+      this.preparedPayment.set(null);
+
+      if (prepared.subscription_step === 'init_authority') {
+        this.mobileInitAuthorityDone = true;
+        await this.PrepareMobileWalletPayment(session, payerWallet);
+        return;
+      }
+
+      this.CompletePayment(completedSession);
+    } catch (error) {
+      if (this.IsRetryableBroadcastError(error)) {
+        try {
+          await this.PrepareMobileWalletPayment(session, payerWallet);
+          this.paymentError.set(
+            'The payment approval expired. Confirm the refreshed payment.'
+          );
+        } catch (prepareError) {
+          this.HandlePaymentError(prepareError, 'idle');
+        }
+        return;
+      }
+      this.HandlePaymentError(error, 'ready_to_sign');
     }
   }
 
@@ -429,19 +587,17 @@ export class CheckoutComponent implements OnInit {
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
         this.paymentPhase.set('awaiting_wallet');
-        const prepared = await this.checkoutSessionService.PreparePayment(
-          session.url_slug,
+        const prepared = await this.PreparePayment(
+          session,
           payerWallet,
           this.BuildCustomerDetailsPayload()
         );
 
-        if (prepared.already_subscribed) {
-          this.paymentPhase.set('processing');
-          return this.checkoutSessionService.ConfirmPayment(session.url_slug, {
-            already_subscribed: true,
-            subscription_delegation_pda: prepared.subscription_delegation_pda,
-          });
-        }
+        const completedSession = await this.ConfirmAlreadySubscribed(
+          session,
+          prepared
+        );
+        if (completedSession) return completedSession;
 
         if (prepared.subscription_step === 'init_authority') {
           if (initAuthorityDone) {
@@ -457,10 +613,7 @@ export class CheckoutComponent implements OnInit {
         return await this.SignAndConfirmPrepared(session, prepared, chain);
       } catch (error) {
         lastError = error;
-        if (
-          this.IsSubscription() &&
-          this.IsRetryableSubscribeBroadcastError(error)
-        ) {
+        if (this.IsRetryableBroadcastError(error)) {
           continue;
         }
         throw error;
@@ -469,17 +622,31 @@ export class CheckoutComponent implements OnInit {
     throw lastError;
   }
 
-  private BuildCustomerDetailsPayload(): {
-    email?: string;
-    name?: string;
-    business_name?: string;
-    phone?: string;
-    address?: PreparedAddress;
-    shipping_address?: PreparedAddress & { name?: string };
-    tax_id?: string;
-    custom_fields?: { key: string; value: string }[];
-    terms_of_service_accepted?: boolean;
-  } {
+  private PreparePayment(
+    session: CheckoutSession,
+    payerWallet: string,
+    customerDetails: CustomerDetailsPayload
+  ): Promise<CheckoutPaymentTransaction> {
+    return this.checkoutSessionService.PreparePayment(
+      session.url_slug,
+      payerWallet,
+      customerDetails
+    );
+  }
+
+  private ConfirmAlreadySubscribed(
+    session: CheckoutSession,
+    prepared: CheckoutPaymentTransaction
+  ): Promise<CheckoutSession | null> {
+    if (!prepared.already_subscribed) return Promise.resolve(null);
+    this.paymentPhase.set('processing');
+    return this.checkoutSessionService.ConfirmPayment(session.url_slug, {
+      already_subscribed: true,
+      subscription_delegation_pda: prepared.subscription_delegation_pda,
+    });
+  }
+
+  private BuildCustomerDetailsPayload(): CustomerDetailsPayload {
     const options = this.CollectionOptions();
     const customFields = this.CustomFields()
       .map((field) => ({
@@ -619,7 +786,7 @@ export class CheckoutComponent implements OnInit {
     });
   }
 
-  private IsRetryableSubscribeBroadcastError(error: unknown): boolean {
+  private IsRetryableBroadcastError(error: unknown): boolean {
     const message =
       error instanceof Error
         ? error.message
@@ -629,6 +796,34 @@ export class CheckoutComponent implements OnInit {
     return /blockhash not found|expired|already been processed|not found on-chain|may not be confirmed yet/i.test(
       message
     );
+  }
+
+  private CompletePayment(completedSession: CheckoutSession): void {
+    this.preparedPayment.set(null);
+    this.preparedCustomerDetailsKey = '';
+    this.checkoutSession.set(completedSession);
+    this.paymentPhase.set('complete');
+    this.HandleAfterCompletion(completedSession);
+  }
+
+  private HandlePaymentError(
+    error: unknown,
+    fallbackPhase: PaymentPhase
+  ): void {
+    if (this.solanaWalletService.IsMobileWalletNotFoundError(error)) {
+      this.mobileWalletHandoffRequested.set(true);
+      this.paymentError.set(null);
+      this.ResetPreparedPayment();
+      return;
+    }
+    this.paymentError.set(this.ErrorMessage(error));
+    this.paymentPhase.set(fallbackPhase);
+  }
+
+  private ResetPreparedPayment(): void {
+    this.preparedPayment.set(null);
+    this.preparedCustomerDetailsKey = '';
+    this.paymentPhase.set('idle');
   }
 
   private HandleAfterCompletion(session: CheckoutSession): void {
@@ -673,6 +868,9 @@ export class CheckoutComponent implements OnInit {
   }
 
   SubmitLabel(): string {
+    if (this.paymentPhase() === 'ready_to_sign') {
+      return this.IsSubscription() ? 'Confirm subscription' : 'Confirm payment';
+    }
     return GetCheckoutSubmitLabel(
       this.checkoutSession()?.submit_type,
       this.IsSubscription()
@@ -680,9 +878,16 @@ export class CheckoutComponent implements OnInit {
   }
 
   BusyLabel(): string {
-    return this.paymentPhase() === 'awaiting_wallet'
-      ? 'Confirm in wallet'
-      : 'Processing';
+    switch (this.paymentPhase()) {
+      case 'connecting':
+        return 'Connect in wallet';
+      case 'preparing':
+        return 'Preparing payment';
+      case 'awaiting_wallet':
+        return 'Confirm in wallet';
+      default:
+        return 'Processing';
+    }
   }
 
   SummaryHeading(): string {
@@ -699,6 +904,9 @@ export class CheckoutComponent implements OnInit {
 
   MethodHelpText(): string {
     const amount = this.FormatAmount(this.checkoutSession()?.amount_total);
+    if (this.paymentPhase() === 'ready_to_sign') {
+      return `Your ${amount} USDC transaction is ready. Confirm to open your wallet.`;
+    }
     if (this.IsSubscription()) {
       const cadence = this.RecurringIntervalLabel();
       return cadence

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -5,10 +5,12 @@ import { AppComponent } from './app/app.component';
 async function RegisterMobileWalletAdapter(): Promise<void> {
   if (!/Android/i.test(navigator.userAgent)) return;
 
+  const { getWallets } = await import('@wallet-standard/app');
+  if (getWallets().get().length > 0) return;
+
   const {
     createDefaultAuthorizationCache,
     createDefaultChainSelector,
-    createDefaultWalletNotFoundHandler,
     registerMwa,
   } = await import('@solana-mobile/wallet-standard-mobile');
 
@@ -21,7 +23,7 @@ async function RegisterMobileWalletAdapter(): Promise<void> {
     authorizationCache: createDefaultAuthorizationCache(),
     chains: ['solana:devnet', 'solana:mainnet'],
     chainSelector: createDefaultChainSelector(),
-    onWalletNotFound: createDefaultWalletNotFoundHandler(),
+    onWalletNotFound: () => Promise.resolve(),
   });
 }
 


### PR DESCRIPTION
## Description

Fixes checkout flow on android by splitting steps into confirm and pay. Bug with re-opening the android app twice.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
