### PR TITLE
fix: prevent arbitrary fee payer transaction signing

### DIFF
--- a/apps/api/src/__tests__/CheckoutPayment.spec.ts
+++ b/apps/api/src/__tests__/CheckoutPayment.spec.ts
@@ -106,7 +106,7 @@ describe('CheckoutPaymentModule', () => {
       | 'VerifyCheckoutPayment'
       | 'VerifySubscribeTransaction'
       | 'CollectSubscriptionPayment'
-      | 'CosignAndBroadcastCheckoutTransaction'
+      | 'ValidateAndBroadcastCheckoutTransaction'
       | 'FindExistingSubscriptionDelegation'
       | 'WaitForSubscriptionAuthority'
       | 'GetUSDCMintAddress'
@@ -174,8 +174,8 @@ describe('CheckoutPaymentModule', () => {
         signature: 'collect_sig',
         alreadyCollected: false,
       }),
-      CosignAndBroadcastCheckoutTransaction: jest.fn().mockResolvedValue({
-        signature: 'cosign_sig',
+      ValidateAndBroadcastCheckoutTransaction: jest.fn().mockResolvedValue({
+        signature: 'relay_sig',
       }),
       FindExistingSubscriptionDelegation: jest.fn().mockResolvedValue(null),
       WaitForSubscriptionAuthority: jest.fn().mockResolvedValue(undefined),
@@ -458,9 +458,8 @@ describe('CheckoutPaymentModule', () => {
         verified: true,
         payer_address: 'PayerWallet111',
         amount_cents: 1000,
-        failure_reason: null,
       });
-      mockSolana.CosignAndBroadcastCheckoutTransaction.mockResolvedValueOnce({
+      mockSolana.ValidateAndBroadcastCheckoutTransaction.mockResolvedValueOnce({
         signature: 'sig_abc',
       });
 
@@ -469,7 +468,7 @@ describe('CheckoutPaymentModule', () => {
       });
 
       expect(
-        mockSolana.CosignAndBroadcastCheckoutTransaction
+        mockSolana.ValidateAndBroadcastCheckoutTransaction
       ).toHaveBeenCalledWith('signed_tx_base64');
       expect(eventService.Emit.mock.calls.map((call) => call[0])).toEqual([
         'payment_intent.processing',

--- a/apps/api/src/__tests__/mocks/Solana.ts
+++ b/apps/api/src/__tests__/mocks/Solana.ts
@@ -62,11 +62,8 @@ export class Solana {
     alreadyCollected: false,
   });
   FindExistingSubscriptionDelegation = jest.fn().mockResolvedValue(null);
-  CosignAndBroadcastCheckoutTransaction = jest.fn().mockResolvedValue({
+  ValidateAndBroadcastCheckoutTransaction = jest.fn().mockResolvedValue({
     signature: 'checkout_sig',
-  });
-  CosignAndBroadcastSubscribeTransaction = jest.fn().mockResolvedValue({
-    signature: 'subscribe_sig',
   });
   BuildBatchPayoutTransaction = jest.fn().mockResolvedValue({
     unsigned_transaction: 'base64tx',

--- a/apps/api/src/modules/CheckoutPayment.ts
+++ b/apps/api/src/modules/CheckoutPayment.ts
@@ -388,7 +388,8 @@ export class CheckoutPaymentModule {
    * Subscription, and collects the first period (unless trialing).
    *
    * Fee-sponsored confirms may pass `signed_transaction` instead of
-   * `signature`: the API cosigns with TRANSACTION_FEE_PAYER_KEY and broadcasts.
+   * `signature`: the API validates the existing fee payer and customer
+   * signatures before broadcasting.
    *
    * For subscription first-time wallets, pass `subscription_step: 'init_authority'`
    * after the init tx; the session stays open so the client can prepare subscribe.
@@ -439,7 +440,7 @@ export class CheckoutPaymentModule {
     ) {
       try {
         const broadcast =
-          await this.solana.CosignAndBroadcastCheckoutTransaction(
+          await this.solana.ValidateAndBroadcastCheckoutTransaction(
             options.signed_transaction
           );
         resolvedSignature = broadcast.signature;

--- a/apps/api/src/modules/chains/Solana.spec.ts
+++ b/apps/api/src/modules/chains/Solana.spec.ts
@@ -1,0 +1,128 @@
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from '@solana/web3.js';
+import { ValidateSponsoredCheckoutTransaction } from './Solana';
+
+jest.mock('@solana/kit', () => ({}));
+jest.mock('@solana/kit-plugin-rpc', () => ({}));
+jest.mock('@solana/kit-plugin-signer', () => ({}));
+jest.mock('@solana-program/token', () => ({}));
+jest.mock('@solana/subscriptions', () => ({}));
+
+function BuildTransferTransaction(
+  feePayer: PublicKey,
+  sender: PublicKey,
+  recipient: PublicKey
+): Transaction {
+  return new Transaction({
+    feePayer,
+    recentBlockhash: Keypair.generate().publicKey.toBase58(),
+  }).add(
+    SystemProgram.transfer({
+      fromPubkey: sender,
+      toPubkey: recipient,
+      lamports: 1,
+    })
+  );
+}
+
+function SerializePartiallySignedTransaction(transaction: Transaction): string {
+  return transaction
+    .serialize({
+      requireAllSignatures: false,
+      verifySignatures: false,
+    })
+    .toString('base64');
+}
+
+describe('Solana sponsored checkout transactions', () => {
+  it('accepts the unchanged transaction signed by the sponsor and customer', () => {
+    const sponsor = Keypair.generate();
+    const customer = Keypair.generate();
+    const transaction = BuildTransferTransaction(
+      sponsor.publicKey,
+      customer.publicKey,
+      Keypair.generate().publicKey
+    );
+    transaction.partialSign(sponsor, customer);
+    const signedTransaction = transaction.serialize().toString('base64');
+
+    expect(
+      ValidateSponsoredCheckoutTransaction(signedTransaction, sponsor.publicKey)
+    ).toBe(signedTransaction);
+  });
+
+  it('rejects an arbitrary transfer from the sponsor wallet', () => {
+    const sponsor = Keypair.generate();
+    const transaction = BuildTransferTransaction(
+      sponsor.publicKey,
+      sponsor.publicKey,
+      Keypair.generate().publicKey
+    );
+
+    expect(() =>
+      ValidateSponsoredCheckoutTransaction(
+        SerializePartiallySignedTransaction(transaction),
+        sponsor.publicKey
+      )
+    ).toThrow('Sponsored checkout fee payer signature is missing');
+  });
+
+  it('rejects a transaction with a different fee payer', () => {
+    const sponsor = Keypair.generate();
+    const attacker = Keypair.generate();
+    const transaction = BuildTransferTransaction(
+      attacker.publicKey,
+      attacker.publicKey,
+      Keypair.generate().publicKey
+    );
+    transaction.sign(attacker);
+
+    expect(() =>
+      ValidateSponsoredCheckoutTransaction(
+        transaction.serialize().toString('base64'),
+        sponsor.publicKey
+      )
+    ).toThrow('Sponsored checkout fee payer does not match');
+  });
+
+  it('rejects a transaction missing the customer signature', () => {
+    const sponsor = Keypair.generate();
+    const customer = Keypair.generate();
+    const transaction = BuildTransferTransaction(
+      sponsor.publicKey,
+      customer.publicKey,
+      Keypair.generate().publicKey
+    );
+    transaction.partialSign(sponsor);
+
+    expect(() =>
+      ValidateSponsoredCheckoutTransaction(
+        SerializePartiallySignedTransaction(transaction),
+        sponsor.publicKey
+      )
+    ).toThrow('Sponsored checkout transaction signatures are invalid');
+  });
+
+  it('rejects transaction instructions changed after preparation', () => {
+    const sponsor = Keypair.generate();
+    const customer = Keypair.generate();
+    const transaction = BuildTransferTransaction(
+      sponsor.publicKey,
+      customer.publicKey,
+      Keypair.generate().publicKey
+    );
+    transaction.partialSign(sponsor, customer);
+    transaction.instructions[0].data[0] ^= 1;
+
+    expect(() =>
+      ValidateSponsoredCheckoutTransaction(
+        SerializePartiallySignedTransaction(transaction),
+        sponsor.publicKey
+      )
+    ).toThrow('Sponsored checkout transaction signatures are invalid');
+  });
+});

--- a/apps/api/src/modules/chains/Solana.ts
+++ b/apps/api/src/modules/chains/Solana.ts
@@ -69,6 +69,43 @@ const MEMO_PROGRAM_ID = new PublicKey(
   'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'
 );
 
+/**
+ * Validate a wallet-signed checkout transaction without granting the fee payer
+ * authority over client-provided instructions. The fee payer signature must
+ * already be present from transaction preparation and every required signature
+ * must remain valid.
+ */
+export function ValidateSponsoredCheckoutTransaction(
+  signedTransactionBase64: string,
+  expectedFeePayer: PublicKey
+): string {
+  let transaction: Transaction;
+  try {
+    transaction = Transaction.from(
+      Buffer.from(signedTransactionBase64, 'base64')
+    );
+  } catch {
+    throw new Error('Invalid sponsored checkout transaction');
+  }
+
+  if (!transaction.feePayer?.equals(expectedFeePayer)) {
+    throw new Error('Sponsored checkout fee payer does not match');
+  }
+
+  const feePayerSignature = transaction.signatures.find(({ publicKey }) =>
+    publicKey.equals(expectedFeePayer)
+  )?.signature;
+  if (!feePayerSignature) {
+    throw new Error('Sponsored checkout fee payer signature is missing');
+  }
+
+  if (!transaction.verifySignatures()) {
+    throw new Error('Sponsored checkout transaction signatures are invalid');
+  }
+
+  return transaction.serialize().toString('base64');
+}
+
 /** Result of verifying a checkout payment transaction on-chain */
 export interface CheckoutPaymentVerification {
   verified: boolean;
@@ -738,9 +775,7 @@ export class Solana {
     const merchant = new PublicKey(merchantWalletAddress);
     const usdcMint = new PublicKey(this.GetUSDCMintAddress());
     const rentPayer = feeSponsored
-      ? Keypair.fromSecretKey(
-          bs58.decode(this.RequireCheckoutFeePayerSecretKey())
-        ).publicKey
+      ? this.GetCheckoutFeePayerKeypair().publicKey
       : payer;
 
     const payerTokenAccount = await getAssociatedTokenAddress(usdcMint, payer);
@@ -812,9 +847,7 @@ export class Solana {
     const subscriberSigner = createNoopSigner(subscriberAddress);
 
     const rentPayerPubkey = feeSponsored
-      ? Keypair.fromSecretKey(
-          bs58.decode(this.RequireCheckoutFeePayerSecretKey())
-        ).publicKey
+      ? this.GetCheckoutFeePayerKeypair().publicKey
       : new PublicKey(subscriberWallet);
     const rentPayerSigner = createNoopSigner(
       address(rentPayerPubkey.toBase58())
@@ -895,9 +928,7 @@ export class Solana {
     const subscriberSigner = createNoopSigner(subscriberAddress);
 
     const rentPayerPubkey = feeSponsored
-      ? Keypair.fromSecretKey(
-          bs58.decode(this.RequireCheckoutFeePayerSecretKey())
-        ).publicKey
+      ? this.GetCheckoutFeePayerKeypair().publicKey
       : new PublicKey(subscriberWallet);
     const rentPayerSigner = createNoopSigner(
       address(rentPayerPubkey.toBase58())
@@ -1011,36 +1042,24 @@ export class Solana {
   }
 
   /**
-   * After the customer co-signs a fee-sponsored checkout tx, add the
-   * TRANSACTION_FEE_PAYER signature and broadcast on our RPC.
+   * Validate that the customer preserved the fee payer's preparation signature,
+   * then broadcast the fully signed transaction unchanged.
    */
-  async CosignAndBroadcastCheckoutTransaction(
+  async ValidateAndBroadcastCheckoutTransaction(
     signedByCustomerBase64: string
   ): Promise<{ signature: string }> {
-    const transaction = Transaction.from(
-      Buffer.from(signedByCustomerBase64, 'base64')
+    const signedTransaction = ValidateSponsoredCheckoutTransaction(
+      signedByCustomerBase64,
+      this.GetCheckoutFeePayerKeypair().publicKey
     );
-    const feePayerKeypair = Keypair.fromSecretKey(
-      bs58.decode(this.RequireCheckoutFeePayerSecretKey())
-    );
-    transaction.partialSign(feePayerKeypair);
 
-    const broadcast = await this.BroadcastSignedTransaction(
-      transaction.serialize().toString('base64')
-    );
+    const broadcast = await this.BroadcastSignedTransaction(signedTransaction);
     if (broadcast.status === 'failed') {
       throw new Error(
         broadcast.failure_message || 'Failed to broadcast checkout transaction'
       );
     }
     return { signature: broadcast.signature };
-  }
-
-  /** @deprecated Use CosignAndBroadcastCheckoutTransaction */
-  async CosignAndBroadcastSubscribeTransaction(
-    signedBySubscriberBase64: string
-  ): Promise<{ signature: string }> {
-    return this.CosignAndBroadcastCheckoutTransaction(signedBySubscriberBase64);
   }
 
   /**
@@ -1328,14 +1347,14 @@ export class Solana {
     );
   }
 
-  private RequireCheckoutFeePayerSecretKey(): string {
+  private GetCheckoutFeePayerKeypair(): Keypair {
     const secretKey = GetCheckoutFeePayerSecretKey();
     if (!secretKey) {
       throw new Error(
         'TRANSACTION_FEE_PAYER_KEY is required for fee sponsorship'
       );
     }
-    return secretKey;
+    return Keypair.fromSecretKey(bs58.decode(secretKey));
   }
 
   private ToWeb3Instruction(instruction: Instruction): TransactionInstruction {
@@ -1371,10 +1390,7 @@ export class Solana {
     // Pre-sign with the fee payer so wallet simulation sees a funded payer
     // and does not warn about the subscriber's empty SOL balance.
     if (options?.feeSponsored) {
-      const feePayerKeypair = Keypair.fromSecretKey(
-        bs58.decode(this.RequireCheckoutFeePayerSecretKey())
-      );
-      transaction.partialSign(feePayerKeypair);
+      transaction.partialSign(this.GetCheckoutFeePayerKeypair());
     }
 
     const fee = await this.WithRetry(() =>

--- a/apps/web/src/app/data/services/checkout-session.service.ts
+++ b/apps/web/src/app/data/services/checkout-session.service.ts
@@ -171,7 +171,7 @@ export class CheckoutSessionService {
 
   /**
    * Confirm a checkout transaction. Fee-sponsored flows pass
-   * `signed_transaction` for the API to cosign and broadcast; buyer-pays
+   * `signed_transaction` for the API to validate and broadcast; buyer-pays
    * flows pass `signature` after the wallet has already sent the tx.
    */
   async ConfirmPayment(


### PR DESCRIPTION
## Description

Validates existing sponsor and customer signatures before broadcasting, preventing the API from signing arbitrary client-provided transactions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
