### PR TITLE
feat: preload dashboard routes to make initial clicks more responsive

### DIFF
--- a/apps/web/src/app/app.config.ts
+++ b/apps/web/src/app/app.config.ts
@@ -2,8 +2,13 @@ import {
   ApplicationConfig,
   provideZonelessChangeDetection,
 } from '@angular/core';
-import { provideRouter, withInMemoryScrolling } from '@angular/router';
+import {
+  provideRouter,
+  withInMemoryScrolling,
+  withPreloading,
+} from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
+import { DashboardPreloadingStrategy } from './core';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -13,7 +18,9 @@ export const appConfig: ApplicationConfig = {
       withInMemoryScrolling({
         scrollPositionRestoration: 'enabled',
         anchorScrolling: 'enabled',
-      })
+      }),
+      // Warm dashboard side-menu chunks only — not checkout/onboard/etc.
+      withPreloading(DashboardPreloadingStrategy)
     ),
     provideHttpClient(),
     provideZonelessChangeDetection(),

--- a/apps/web/src/app/app.routes.ts
+++ b/apps/web/src/app/app.routes.ts
@@ -17,6 +17,7 @@ export const routes: Routes = [
   },
   {
     path: 'setup',
+    data: { preload: false },
     loadComponent: () =>
       import('./features/setup/setup.component').then(
         (mod) => mod.SetupComponent
@@ -24,6 +25,7 @@ export const routes: Routes = [
   },
   {
     path: 'onboard',
+    data: { preload: false },
     loadComponent: () =>
       import('./features/onboard/onboard.component').then(
         (mod) => mod.OnboardComponent
@@ -31,6 +33,7 @@ export const routes: Routes = [
   },
   {
     path: 'login',
+    data: { preload: false },
     loadComponent: () =>
       import('./features/login/login.component').then(
         (mod) => mod.LoginComponent
@@ -38,6 +41,7 @@ export const routes: Routes = [
   },
   {
     path: 'platform-login',
+    data: { preload: false },
     loadComponent: () =>
       import('./features/platform-login/platform-login.component').then(
         (mod) => mod.PlatformLoginComponent
@@ -45,6 +49,7 @@ export const routes: Routes = [
   },
   {
     path: 'session-expired',
+    data: { preload: false },
     loadComponent: () =>
       import('./features/session-expired/session-expired.component').then(
         (mod) => mod.SessionExpiredComponent
@@ -52,6 +57,7 @@ export const routes: Routes = [
   },
   {
     path: 'c/:checkoutSessionId',
+    data: { preload: false },
     loadComponent: () =>
       import('./features/checkout/checkout.component').then(
         (m) => m.CheckoutComponent
@@ -59,6 +65,7 @@ export const routes: Routes = [
   },
   {
     path: 'b/:paymentLinkId',
+    data: { preload: false },
     loadComponent: () =>
       import('./features/payment-link/payment-link.component').then(
         (m) => m.PaymentLinkComponent
@@ -71,6 +78,7 @@ export const routes: Routes = [
   },
   {
     path: '**',
+    data: { preload: false },
     loadComponent: () =>
       import('./features/not-found/not-found.component').then(
         (m) => m.NotFoundComponent

--- a/apps/web/src/app/core/index.ts
+++ b/apps/web/src/app/core/index.ts
@@ -1,1 +1,2 @@
 export * from './services';
+export * from './routing/dashboard-preloading.strategy';

--- a/apps/web/src/app/core/routing/dashboard-preloading.strategy.ts
+++ b/apps/web/src/app/core/routing/dashboard-preloading.strategy.ts
@@ -1,0 +1,28 @@
+import { Injectable, inject } from '@angular/core';
+import { PreloadingStrategy, Route, Router } from '@angular/router';
+import { Observable, of } from 'rxjs';
+
+/**
+ * Background-loads dashboard route chunks after the user is in `/account`.
+ * Top-level non-dashboard routes should set `data: { preload: false }`.
+ */
+@Injectable({ providedIn: 'root' })
+export class DashboardPreloadingStrategy implements PreloadingStrategy {
+  private readonly router = inject(Router);
+
+  preload(
+    route: Route,
+    load: () => Observable<unknown>
+  ): Observable<unknown> {
+    if (route.data?.['preload'] === false) {
+      return of(null);
+    }
+
+    // Avoid warming dashboard (or anything else) during checkout/auth flows.
+    if (!this.router.url.startsWith('/account')) {
+      return of(null);
+    }
+
+    return load();
+  }
+}

--- a/apps/web/src/app/core/routing/dashboard-preloading.strategy.ts
+++ b/apps/web/src/app/core/routing/dashboard-preloading.strategy.ts
@@ -10,10 +10,7 @@ import { Observable, of } from 'rxjs';
 export class DashboardPreloadingStrategy implements PreloadingStrategy {
   private readonly router = inject(Router);
 
-  preload(
-    route: Route,
-    load: () => Observable<unknown>
-  ): Observable<unknown> {
+  preload(route: Route, load: () => Observable<unknown>): Observable<unknown> {
     if (route.data?.['preload'] === false) {
       return of(null);
     }


### PR DESCRIPTION
## Description

Preload dashboard routes via routing strategy. Before it felt slow / unresponsive on first load.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
