### PR TITLE
fix: test mobile number + extension picker

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoneless/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Provision and manage an agent-operated Zoneless store",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/web/src/app/shared/forms/person-form/person-form.component.ts
+++ b/apps/web/src/app/shared/forms/person-form/person-form.component.ts
@@ -122,7 +122,10 @@ export class PersonFormComponent implements OnInit, OnChanges {
       this.email.set(this.person.email || '');
 
       if (this.person.phone) {
-        this.ParseAndSetPhone(this.person.phone);
+        this.ParseAndSetPhone(
+          this.person.phone,
+          this.person.address?.country ?? undefined
+        );
       } else {
         this.phoneCountryCode.set('US');
         this.phoneNumber.set('');
@@ -176,10 +179,17 @@ export class PersonFormComponent implements OnInit, OnChanges {
     this.EmitFormChange();
   }
 
-  private ParseAndSetPhone(fullPhone: string): void {
-    const sortedCountries = [...ISO_CODES].sort(
-      (a, b) => b.dialCode.length - a.dialCode.length
-    );
+  private ParseAndSetPhone(
+    fullPhone: string,
+    preferredCountryCode?: string
+  ): void {
+    const sortedCountries = [...ISO_CODES].sort((a, b) => {
+      const dialCodeLengthDifference = b.dialCode.length - a.dialCode.length;
+      if (dialCodeLengthDifference !== 0) return dialCodeLengthDifference;
+      if (a.code === preferredCountryCode) return -1;
+      if (b.code === preferredCountryCode) return 1;
+      return 0;
+    });
     for (const country of sortedCountries) {
       if (fullPhone.startsWith(country.dialCode)) {
         this.phoneCountryCode.set(country.code);
@@ -609,7 +619,10 @@ export class PersonFormComponent implements OnInit, OnChanges {
     if (country) {
       this.phoneCountryCode.set(country.code);
     }
-    this.ParseAndSetPhone(TEST_PERSON_DATA.phone);
+    this.ParseAndSetPhone(
+      TEST_PERSON_DATA.phone,
+      TEST_PERSON_DATA.addressCountry
+    );
 
     this.ValidateAll();
     this.EmitFormChange();

--- a/apps/web/src/app/utils/constants/test-data.ts
+++ b/apps/web/src/app/utils/constants/test-data.ts
@@ -6,7 +6,7 @@ export const TEST_PERSON_DATA: PersonFormData = {
   firstName: 'Tom',
   lastName: 'Jones',
   email: 'tom.jones@example.com',
-  phone: '+1 5551234567',
+  phone: '+1 4155552671',
   dobDay: 1,
   dobMonth: 1,
   dobYear: 1990,


### PR DESCRIPTION
## Description

Test mobile number was not working because of new validation rules. Also selects extension based on the country.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
