### PR TITLE
feat: configure webhooks during agent onboarding

### DIFF
--- a/.agents/skills/zoneless-payments/SKILL.md
+++ b/.agents/skills/zoneless-payments/SKILL.md
@@ -99,6 +99,47 @@ scripts and framework, then rerun once with `--target <relative-path>`.
 Pass that value directly to `@zoneless/node`; the SDK adds `/v1`. For raw HTTP
 requests, append `/v1` exactly once.
 
+## Configure test webhook delivery
+
+Determine the application's server-side webhook route and its public HTTPS URL.
+For a deployed test app, use its existing HTTPS origin. For localhost, explain
+that Zoneless cannot reach `localhost`; the human must run a tunnel such as
+`ngrok http <port>` or Cloudflare Tunnel and provide its public HTTPS URL. Do not
+silently install or leave a tunnel process running.
+
+Once the URL is known, create or update the bound test endpoint and sync its
+signing secret without displaying it:
+
+```bash
+npx @zoneless/cli@latest webhook sync \
+  --url "https://<public-host>/<server-webhook-route>" \
+  --preset subscriptions \
+  --json
+```
+
+Add `--target <relative-path>` when the server uses a non-default env file. The
+command subscribes to `checkout.session.completed`, `invoice.paid`,
+`invoice.payment_failed`, `customer.subscription.updated`, and
+`customer.subscription.deleted`; stores the one-time endpoint secret in the
+operating-system credential store; and writes `ZONELESS_WEBHOOK_SECRET` to the
+local env file without printing it. Restart the application after the command
+so it loads the new value.
+
+If CLI setup is unavailable, give the human these manual test-mode steps without
+asking them to reveal the secret:
+
+1. Open `https://dashboard-test.zoneless.com/account/developers`.
+2. Choose **Developers** in the side menu.
+3. In **Webhook Endpoints**, choose **Add endpoint**.
+4. Enter the public HTTPS endpoint URL.
+5. Select the five subscription events listed above.
+6. Choose **Create**, copy the one-time webhook secret directly into the
+   server's local environment as `ZONELESS_WEBHOOK_SECRET`, and restart the
+   server.
+
+Reserve `https://dashboard.zoneless.com/account/developers` for the explicit
+live handoff. Never configure a live endpoint while implementing in test mode.
+
 ## Use test mode, then hand off live promotion
 
 Implement and verify against `https://api-test.zoneless.com`. Keep the mode

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -100,6 +100,35 @@ Payment collection does not require a wallet key in the application, so omit
 a server process that must sign wallet operations, such as a self-hosted payout
 worker.
 
+Create or update a test webhook endpoint and sync its one-time signing secret
+without printing it:
+
+```bash
+npx @zoneless/cli@latest webhook sync \
+  --url "https://YOUR-PUBLIC-HOST/api/webhooks/zoneless" \
+  --preset subscriptions \
+  --json
+```
+
+The subscription preset listens for `checkout.session.completed`,
+`invoice.paid`, `invoice.payment_failed`, `customer.subscription.updated`, and
+`customer.subscription.deleted`. The command stores the endpoint secret in the
+operating-system credential store, writes `ZONELESS_WEBHOOK_SECRET` with the API
+credentials in the selected local env file, and reports that the application
+must restart. Rerunning it updates the managed endpoint URL and events without
+changing its secret. Use `--events <event,...>` instead of the preset for a
+custom list.
+
+The URL must be publicly reachable over HTTPS. For local development, start an
+ngrok or Cloudflare Tunnel separately and pass its URL to the command.
+
+To configure an endpoint manually, use the Developers page in the
+[test dashboard](https://dashboard-test.zoneless.com/account/developers) or,
+for an explicit production rollout, the
+[live dashboard](https://dashboard.zoneless.com/account/developers). In
+**Webhook Endpoints**, choose **Add endpoint**, enter the URL, select the events,
+and choose **Create**. The signing secret is displayed once.
+
 Add `--interval` to sell the product as a recurring USDC subscription instead of
 a one-time purchase. The payment link then opens a subscription checkout, where
 the customer approves the plan once and Zoneless collects each following cycle

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoneless/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Provision and manage an agent-operated Zoneless store",
   "license": "Apache-2.0",
   "repository": {

--- a/apps/cli/src/app/Arguments.ts
+++ b/apps/cli/src/app/Arguments.ts
@@ -5,6 +5,8 @@ import {
   type ParsedCommand,
   type RecurringInterval,
   type StoreInitCommand,
+  subscriptionWebhookEvents,
+  type WebhookSyncCommand,
 } from './Types';
 
 const storeValueOptions = new Set([
@@ -27,6 +29,13 @@ const reconnectValueOptions = new Set([
 ]);
 const envSyncValueOptions = new Set(['--profile', '--target']);
 const envSyncBooleanOptions = new Set(['--include-wallet', '--json']);
+const webhookSyncValueOptions = new Set([
+  '--events',
+  '--preset',
+  '--profile',
+  '--target',
+  '--url',
+]);
 const installSkillValueOptions = new Set(['--skill']);
 const walletBackupValueOptions = new Set(['--output', '--profile']);
 const setupValueOptions = new Set([
@@ -135,6 +144,10 @@ export function ParseArguments(argumentsList: string[]): ParsedCommand {
       profile: ReadOptionalOption(commandArguments, '--profile'),
       target: ReadOptionalOption(commandArguments, '--target'),
     };
+  }
+
+  if (argumentsList[0] === 'webhook' && argumentsList[1] === 'sync') {
+    return ParseWebhookSync(argumentsList.slice(2));
   }
 
   if (argumentsList[0] === 'wallet' && argumentsList[1] === 'backup') {
@@ -252,6 +265,62 @@ function ParseStoreInit(argumentsList: string[]): StoreInitCommand {
     profile: ReadOptionalOption(argumentsList, '--profile'),
     trialDays,
   };
+}
+
+function ParseWebhookSync(argumentsList: string[]): WebhookSyncCommand {
+  ValidateOptions(
+    argumentsList,
+    webhookSyncValueOptions,
+    jsonBooleanOptions,
+    'webhook sync'
+  );
+
+  const rawUrl = ReadRequiredOption(argumentsList, '--url');
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    throw InvalidInput('--url must be a valid public HTTPS URL.');
+  }
+  if (parsedUrl.protocol !== 'https:') {
+    throw InvalidInput('--url must use HTTPS so Zoneless can deliver events.');
+  }
+
+  const presetValue = ReadOptionalOption(argumentsList, '--preset');
+  const eventsValue = ReadOptionalOption(argumentsList, '--events');
+  if (presetValue !== undefined && eventsValue !== undefined) {
+    throw InvalidInput('Use either --preset or --events, not both.');
+  }
+  if (presetValue !== undefined && presetValue !== 'subscriptions') {
+    throw InvalidInput('--preset must be subscriptions.');
+  }
+  const events =
+    eventsValue !== undefined
+      ? ParseWebhookEvents(eventsValue)
+      : [...subscriptionWebhookEvents];
+
+  return {
+    events,
+    json: argumentsList.includes('--json'),
+    name: 'webhook-sync',
+    preset: eventsValue !== undefined ? null : 'subscriptions',
+    profile: ReadOptionalOption(argumentsList, '--profile'),
+    target: ReadOptionalOption(argumentsList, '--target'),
+    url: parsedUrl.toString(),
+  };
+}
+
+function ParseWebhookEvents(value: string): string[] {
+  const events = [...new Set(value.split(',').map((event) => event.trim()))];
+  if (
+    events.length === 0 ||
+    events.some((event) => !/^[a-z0-9_.]+$/.test(event))
+  ) {
+    throw InvalidInput(
+      '--events must be a comma-separated list of Zoneless event types.'
+    );
+  }
+  return events;
 }
 
 function ValidateStoreOptions(argumentsList: string[]): void {

--- a/apps/cli/src/app/Cli.spec.ts
+++ b/apps/cli/src/app/Cli.spec.ts
@@ -194,6 +194,54 @@ describe('Zoneless CLI', () => {
     });
   });
 
+  it('parses subscription and custom webhook sync events', () => {
+    expect(
+      ParseArguments([
+        'webhook',
+        'sync',
+        '--url',
+        'https://example.ngrok.app/api/webhooks/zoneless',
+        '--preset',
+        'subscriptions',
+        '--target',
+        '.env',
+        '--json',
+      ])
+    ).toMatchObject({
+      events: [
+        'checkout.session.completed',
+        'invoice.paid',
+        'invoice.payment_failed',
+        'customer.subscription.updated',
+        'customer.subscription.deleted',
+      ],
+      name: 'webhook-sync',
+      preset: 'subscriptions',
+      target: '.env',
+    });
+    expect(
+      ParseArguments([
+        'webhook',
+        'sync',
+        '--url',
+        'https://example.com/webhook',
+        '--events',
+        'invoice.paid, customer.subscription.deleted,invoice.paid',
+      ])
+    ).toMatchObject({
+      events: ['invoice.paid', 'customer.subscription.deleted'],
+      preset: null,
+    });
+    expect(() =>
+      ParseArguments([
+        'webhook',
+        'sync',
+        '--url',
+        'http://localhost:4242/webhook',
+      ])
+    ).toThrow(/must use HTTPS/);
+  });
+
   it('returns the selected installed skill path as JSON', async () => {
     const projectDirectory = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), 'zoneless-cli-'))

--- a/apps/cli/src/app/Cli.ts
+++ b/apps/cli/src/app/Cli.ts
@@ -15,6 +15,7 @@ import { ProjectStore, type LocatedProjectBinding } from './ProjectStore';
 import { KeyringSecretStore, type SecretStore } from './SecretStore';
 import { InstallAgentSkill } from './SkillInstaller';
 import { BackupWallet } from './Wallet';
+import { SyncWebhook } from './WebhookSync';
 import {
   exitCodes,
   type CliIo,
@@ -30,6 +31,7 @@ Usage:
   zoneless auth status [--profile <name>] [--json]
   zoneless auth reconnect [--profile <name>] [--json]
   zoneless env sync [--target <path>] [--include-wallet] [--json]
+  zoneless webhook sync --url <https-url> [--preset subscriptions] [--target <path>] [--json]
   zoneless wallet backup --output <path> [--profile <name>]
   zoneless doctor [--profile <name>] [--json]
   zoneless store init --name <name> --amount <integer> [options]
@@ -49,6 +51,9 @@ Options:
   --idempotency-key <key>    Reuse the same operation keys on retry
   --profile <name>           Use a stored live or test profile
   --target <path>            Environment file relative to the project
+  --url <https-url>          Public webhook endpoint URL
+  --preset subscriptions     Subscribe to the standard billing events
+  --events <event,...>       Subscribe to a custom comma-separated event list
   --include-wallet           Also sync SOLANA_SECRET_KEY
   --json                     Emit machine-readable JSON
 
@@ -369,6 +374,44 @@ export async function RunCli(
       WriteResult(command.json, result, io);
       return exitCodes.success;
     }
+    if (command.name === 'webhook-sync') {
+      if (!locatedProject) {
+        throw InvalidInput(
+          'Webhook sync requires a bound Zoneless project. Run "zoneless agent setup" first.'
+        );
+      }
+      const profileName =
+        (await ResolveProfileName(
+          command.profile,
+          environment,
+          locatedProject
+        )) ?? (await profileStore.GetProfile()).profileName;
+      await VerifyProfileCredentials(
+        profileName,
+        profileStore,
+        fetchRequest,
+        secretValues
+      );
+      const credentials = await profileStore.GetCredentials(profileName);
+      secretValues.push(credentials.apiKey);
+      const result = await SyncWebhook(
+        new ZonelessClient(
+          credentials.profile.apiUrl,
+          credentials.apiKey,
+          fetchRequest
+        ),
+        {
+          command,
+          profileName,
+          profileStore,
+          projectDirectory: locatedProject.rootDirectory,
+          secretStore,
+          workspaceId: locatedProject.binding.workspaceId,
+        }
+      );
+      WriteResult(command.json, result, io);
+      return exitCodes.success;
+    }
     if (command.name === 'wallet-backup') {
       const profileName = await ResolveProfileName(
         command.profile,
@@ -614,6 +657,19 @@ function FormatHumanResult(result: object): string {
     return [
       `Synced ${written} to ${resultRecord['target']}.`,
       `Profile: ${resultRecord['profile']} (${resultRecord['mode']})`,
+      '',
+    ].join('\n');
+  }
+  if (resultRecord['object'] === 'webhook_sync') {
+    return [
+      `${resultRecord['created'] ? 'Created' : 'Updated'} webhook endpoint ${
+        resultRecord['endpoint_id']
+      }.`,
+      `URL: ${resultRecord['url']}`,
+      `Events: ${(resultRecord['enabled_events'] as string[]).join(', ')}`,
+      `Synced ZONELESS_WEBHOOK_SECRET to ${resultRecord['target']}.`,
+      'Restart the application so it loads the updated environment.',
+      `Dashboard: ${resultRecord['dashboard_url']}`,
       '',
     ].join('\n');
   }

--- a/apps/cli/src/app/Client.ts
+++ b/apps/cli/src/app/Client.ts
@@ -4,6 +4,8 @@ import type {
   PriceResponse,
   ProductResponse,
   PublicConfig,
+  WebhookEndpointListResponse,
+  WebhookEndpointResponse,
 } from './Types';
 
 export type FetchLike = (
@@ -67,6 +69,34 @@ export class ZonelessClient {
       body,
       idempotencyKey,
     });
+  }
+
+  ListWebhookEndpoints(): Promise<WebhookEndpointListResponse> {
+    return this.Request<WebhookEndpointListResponse>(
+      'GET',
+      '/webhook_endpoints?limit=100'
+    );
+  }
+
+  CreateWebhookEndpoint(
+    body: Record<string, unknown>,
+    idempotencyKey: string
+  ): Promise<WebhookEndpointResponse> {
+    return this.Request<WebhookEndpointResponse>('POST', '/webhook_endpoints', {
+      body,
+      idempotencyKey,
+    });
+  }
+
+  UpdateWebhookEndpoint(
+    id: string,
+    body: Record<string, unknown>
+  ): Promise<WebhookEndpointResponse> {
+    return this.Request<WebhookEndpointResponse>(
+      'POST',
+      `/webhook_endpoints/${encodeURIComponent(id)}`,
+      { body }
+    );
   }
 
   private async Request<T>(

--- a/apps/cli/src/app/EnvSync.ts
+++ b/apps/cli/src/app/EnvSync.ts
@@ -12,6 +12,7 @@ export interface EnvSyncOptions {
   profileName: string;
   projectDirectory: string;
   target?: string;
+  webhookSecret?: string;
 }
 
 export interface EnvSyncResult {
@@ -38,6 +39,10 @@ export async function SyncEnvironment(
     ZONELESS_API_KEY: credentials.apiKey,
     ZONELESS_API_URL: credentials.profile.apiUrl.replace(/\/v1\/?$/, ''),
   };
+
+  if (options.webhookSecret) {
+    values['ZONELESS_WEBHOOK_SECRET'] = options.webhookSecret;
+  }
 
   if (options.includeWallet) {
     const secretKeyBase64 = await secretStore.Get(

--- a/apps/cli/src/app/SecretStore.ts
+++ b/apps/cli/src/app/SecretStore.ts
@@ -52,3 +52,10 @@ export function GetApiKeyAccount(profileName: string): string {
 export function GetWalletAccount(walletPublicKey: string): string {
   return `wallet:${walletPublicKey}:secret-key`;
 }
+
+export function GetWebhookSecretAccount(
+  profileName: string,
+  endpointId: string
+): string {
+  return `profile:${profileName}:webhook:${endpointId}:secret`;
+}

--- a/apps/cli/src/app/Types.ts
+++ b/apps/cli/src/app/Types.ts
@@ -112,6 +112,24 @@ export interface EnvSyncCommand {
   target?: string;
 }
 
+export const subscriptionWebhookEvents = [
+  'checkout.session.completed',
+  'invoice.paid',
+  'invoice.payment_failed',
+  'customer.subscription.updated',
+  'customer.subscription.deleted',
+] as const;
+
+export interface WebhookSyncCommand {
+  events: string[];
+  json: boolean;
+  name: 'webhook-sync';
+  preset: 'subscriptions' | null;
+  profile?: string;
+  target?: string;
+  url: string;
+}
+
 export interface WalletBackupCommand {
   name: 'wallet-backup';
   outputPath: string;
@@ -126,6 +144,7 @@ export type ParsedCommand =
   | AuthStatusCommand
   | AuthReconnectCommand
   | EnvSyncCommand
+  | WebhookSyncCommand
   | WalletBackupCommand
   | HelpCommand;
 
@@ -146,6 +165,21 @@ export interface PriceResponse {
 export interface PaymentLinkResponse {
   id: string;
   url: string;
+}
+
+export interface WebhookEndpointResponse {
+  description?: string | null;
+  enabled_events: string[];
+  id: string;
+  metadata?: Record<string, string>;
+  secret?: string | null;
+  status?: string;
+  url: string;
+}
+
+export interface WebhookEndpointListResponse {
+  data: WebhookEndpointResponse[];
+  has_more: boolean;
 }
 
 export interface PartialResources {

--- a/apps/cli/src/app/WebhookSync.spec.ts
+++ b/apps/cli/src/app/WebhookSync.spec.ts
@@ -1,0 +1,218 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { ProfileStore, type AgentProfile } from './ProfileStore';
+import { GetWebhookSecretAccount, type SecretStore } from './SecretStore';
+import type { WebhookEndpointResponse, WebhookSyncCommand } from './Types';
+import { SyncWebhook, type WebhookClient } from './WebhookSync';
+
+class MemorySecretStore implements SecretStore {
+  private readonly values = new Map<string, string>();
+
+  async Delete(account: string): Promise<void> {
+    this.values.delete(account);
+  }
+
+  async Get(account: string): Promise<string | null> {
+    return this.values.get(account) ?? null;
+  }
+
+  async Set(account: string, value: string): Promise<void> {
+    this.values.set(account, value);
+  }
+}
+
+class FakeWebhookClient implements WebhookClient {
+  readonly created: Record<string, unknown>[] = [];
+  readonly updated: Array<{ body: Record<string, unknown>; id: string }> = [];
+
+  constructor(readonly endpoints: WebhookEndpointResponse[] = []) {}
+
+  async CreateWebhookEndpoint(
+    body: Record<string, unknown>
+  ): Promise<WebhookEndpointResponse> {
+    this.created.push(body);
+    const endpoint: WebhookEndpointResponse = {
+      enabled_events: body['enabled_events'] as string[],
+      id: 'we_z_created',
+      metadata: body['metadata'] as Record<string, string>,
+      secret: 'whsec_z_created',
+      status: 'enabled',
+      url: body['url'] as string,
+    };
+    this.endpoints.push(endpoint);
+    return endpoint;
+  }
+
+  async ListWebhookEndpoints() {
+    return { data: this.endpoints, has_more: false };
+  }
+
+  async UpdateWebhookEndpoint(
+    id: string,
+    body: Record<string, unknown>
+  ): Promise<WebhookEndpointResponse> {
+    this.updated.push({ body, id });
+    const endpoint = this.endpoints.find((candidate) => candidate.id === id)!;
+    Object.assign(endpoint, {
+      enabled_events: body['enabled_events'],
+      metadata: body['metadata'],
+      status: 'enabled',
+      url: body['url'],
+    });
+    return endpoint;
+  }
+}
+
+interface Fixture {
+  command: WebhookSyncCommand;
+  profileStore: ProfileStore;
+  projectDirectory: string;
+  rootDirectory: string;
+  secretStore: MemorySecretStore;
+}
+
+async function CreateFixture(): Promise<Fixture> {
+  const rootDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'zoneless-webhook-sync-')
+  );
+  const projectDirectory = path.join(rootDirectory, 'project');
+  await fs.mkdir(projectDirectory);
+  const secretStore = new MemorySecretStore();
+  const profileStore = new ProfileStore(
+    { XDG_CONFIG_HOME: path.join(rootDirectory, 'config') },
+    secretStore
+  );
+  const profile: AgentProfile = {
+    apiKeyPrefix: 'sk_test_z_',
+    apiUrl: 'https://api-test.zoneless.com/v1',
+    mode: 'test',
+    platformId: 'acct_test',
+    platformName: 'Test Platform',
+    walletPublicKey: 'wallet_test',
+    workspaceId: 'workspace_test',
+  };
+  await profileStore.SaveProfiles(
+    { 'test-platform-test': profile },
+    { 'test-platform-test': 'sk_test_z_fixture' },
+    'test-platform-test'
+  );
+
+  return {
+    command: {
+      events: ['checkout.session.completed', 'invoice.paid'],
+      json: true,
+      name: 'webhook-sync',
+      preset: null,
+      profile: 'test-platform-test',
+      target: '.env',
+      url: 'https://example.ngrok.app/api/webhooks/zoneless',
+    },
+    profileStore,
+    projectDirectory,
+    rootDirectory,
+    secretStore,
+  };
+}
+
+describe('Webhook sync', () => {
+  it('creates an endpoint and privately syncs its one-time secret', async () => {
+    const fixture = await CreateFixture();
+    try {
+      const client = new FakeWebhookClient();
+      const result = await SyncWebhook(client, {
+        ...fixture,
+        profileName: 'test-platform-test',
+        workspaceId: 'workspace_test',
+      });
+
+      expect(result).toMatchObject({
+        created: true,
+        endpoint_id: 'we_z_created',
+        mode: 'test',
+        restart_required: true,
+      });
+      expect(JSON.stringify(result)).not.toContain('whsec_z_created');
+      expect(
+        await fixture.secretStore.Get(
+          GetWebhookSecretAccount('test-platform-test', 'we_z_created')
+        )
+      ).toBe('whsec_z_created');
+      const environment = await fs.readFile(
+        path.join(fixture.projectDirectory, '.env'),
+        'utf8'
+      );
+      expect(environment).toContain('ZONELESS_WEBHOOK_SECRET=whsec_z_created');
+      expect(environment).toContain(
+        'ZONELESS_API_URL=https://api-test.zoneless.com'
+      );
+    } finally {
+      await fs.rm(fixture.rootDirectory, { force: true, recursive: true });
+    }
+  });
+
+  it('updates the managed endpoint and reuses its stored secret', async () => {
+    const fixture = await CreateFixture();
+    try {
+      const endpoint: WebhookEndpointResponse = {
+        enabled_events: ['checkout.session.completed'],
+        id: 'we_z_existing',
+        metadata: {
+          zoneless_cli_managed: 'webhook_sync',
+          zoneless_workspace_id: 'workspace_test',
+        },
+        status: 'enabled',
+        url: 'https://old.example/webhook',
+      };
+      const client = new FakeWebhookClient([endpoint]);
+      await fixture.secretStore.Set(
+        GetWebhookSecretAccount('test-platform-test', endpoint.id),
+        'whsec_z_existing'
+      );
+
+      const result = await SyncWebhook(client, {
+        ...fixture,
+        profileName: 'test-platform-test',
+        workspaceId: 'workspace_test',
+      });
+
+      expect(result.created).toBe(false);
+      expect(client.created).toHaveLength(0);
+      expect(client.updated).toHaveLength(1);
+      expect(result.url).toBe(fixture.command.url);
+      const environment = await fs.readFile(
+        path.join(fixture.projectDirectory, '.env'),
+        'utf8'
+      );
+      expect(environment).toContain('ZONELESS_WEBHOOK_SECRET=whsec_z_existing');
+    } finally {
+      await fs.rm(fixture.rootDirectory, { force: true, recursive: true });
+    }
+  });
+
+  it('does not duplicate a dashboard endpoint with the same URL', async () => {
+    const fixture = await CreateFixture();
+    try {
+      const client = new FakeWebhookClient([
+        {
+          enabled_events: ['checkout.session.completed'],
+          id: 'we_z_dashboard',
+          metadata: {},
+          status: 'enabled',
+          url: fixture.command.url,
+        },
+      ]);
+
+      await expect(
+        SyncWebhook(client, {
+          ...fixture,
+          profileName: 'test-platform-test',
+          workspaceId: 'workspace_test',
+        })
+      ).rejects.toThrow(/not managed by the CLI/);
+      expect(client.created).toHaveLength(0);
+    } finally {
+      await fs.rm(fixture.rootDirectory, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/cli/src/app/WebhookSync.ts
+++ b/apps/cli/src/app/WebhookSync.ts
@@ -1,0 +1,192 @@
+import { createHash } from 'node:crypto';
+import { SyncEnvironment } from './EnvSync';
+import { ApiError, InvalidInput } from './Errors';
+import type { ProfileStore } from './ProfileStore';
+import { GetWebhookSecretAccount, type SecretStore } from './SecretStore';
+import type {
+  WebhookEndpointListResponse,
+  WebhookEndpointResponse,
+  WebhookSyncCommand,
+} from './Types';
+
+const managedMetadataKey = 'zoneless_cli_managed';
+const managedMetadataValue = 'webhook_sync';
+const workspaceMetadataKey = 'zoneless_workspace_id';
+
+export interface WebhookClient {
+  CreateWebhookEndpoint(
+    body: Record<string, unknown>,
+    idempotencyKey: string
+  ): Promise<WebhookEndpointResponse>;
+  ListWebhookEndpoints(): Promise<WebhookEndpointListResponse>;
+  UpdateWebhookEndpoint(
+    id: string,
+    body: Record<string, unknown>
+  ): Promise<WebhookEndpointResponse>;
+}
+
+export interface WebhookSyncOptions {
+  command: WebhookSyncCommand;
+  profileName: string;
+  profileStore: ProfileStore;
+  projectDirectory: string;
+  secretStore: SecretStore;
+  workspaceId: string;
+}
+
+export interface WebhookSyncResult {
+  created: boolean;
+  dashboard_url: string;
+  enabled_events: string[];
+  endpoint_id: string;
+  mode: 'live' | 'test';
+  object: 'webhook_sync';
+  ok: true;
+  profile: string;
+  restart_required: true;
+  target: string;
+  url: string;
+  written: string[];
+}
+
+export async function SyncWebhook(
+  client: WebhookClient,
+  options: WebhookSyncOptions
+): Promise<WebhookSyncResult> {
+  const { command, profileName, workspaceId } = options;
+  const endpoints = await client.ListWebhookEndpoints();
+  const managedEndpoints = endpoints.data.filter((endpoint) =>
+    IsManagedEndpoint(endpoint, workspaceId)
+  );
+  if (managedEndpoints.length > 1) {
+    throw InvalidInput(
+      'Multiple CLI-managed webhook endpoints were found for this project. Remove the duplicates in the Zoneless dashboard, then retry.'
+    );
+  }
+
+  let endpoint = managedEndpoints[0];
+  let created = false;
+  let webhookSecret: string | null = null;
+
+  if (endpoint) {
+    webhookSecret = await options.secretStore.Get(
+      GetWebhookSecretAccount(profileName, endpoint.id)
+    );
+    if (!webhookSecret) {
+      throw InvalidInput(
+        `The signing secret for webhook endpoint "${endpoint.id}" is not available locally. Delete that CLI-managed endpoint in the Zoneless dashboard and rerun webhook sync, or configure ZONELESS_WEBHOOK_SECRET manually.`
+      );
+    }
+
+    if (
+      endpoint.url !== command.url ||
+      !SameEvents(endpoint.enabled_events, command.events) ||
+      endpoint.status !== 'enabled'
+    ) {
+      endpoint = await client.UpdateWebhookEndpoint(endpoint.id, {
+        disabled: false,
+        enabled_events: command.events,
+        metadata: {
+          ...(endpoint.metadata ?? {}),
+          ...ManagedMetadata(workspaceId),
+        },
+        url: command.url,
+      });
+    }
+  } else {
+    const existingAtUrl = endpoints.data.find(
+      (candidate) => candidate.url === command.url
+    );
+    if (existingAtUrl) {
+      throw InvalidInput(
+        `Webhook endpoint "${existingAtUrl.id}" already uses this URL, but its one-time signing secret is not managed by the CLI. Use its secret manually or delete it in the Zoneless dashboard before running webhook sync.`
+      );
+    }
+
+    const body = {
+      description: 'Managed by Zoneless CLI for subscription billing',
+      enabled_events: command.events,
+      metadata: ManagedMetadata(workspaceId),
+      url: command.url,
+    };
+    endpoint = await client.CreateWebhookEndpoint(
+      body,
+      CreateIdempotencyKey(workspaceId, command.url, command.events)
+    );
+    webhookSecret = endpoint.secret ?? null;
+    if (!webhookSecret) {
+      throw new ApiError(
+        'Zoneless created the webhook endpoint without returning its signing secret.',
+        0
+      );
+    }
+    await options.secretStore.Set(
+      GetWebhookSecretAccount(profileName, endpoint.id),
+      webhookSecret
+    );
+    created = true;
+  }
+
+  const environment = await SyncEnvironment(
+    {
+      includeWallet: false,
+      profileName,
+      projectDirectory: options.projectDirectory,
+      target: command.target,
+      webhookSecret,
+    },
+    options.profileStore,
+    options.secretStore
+  );
+
+  return {
+    created,
+    dashboard_url:
+      environment.mode === 'live'
+        ? 'https://dashboard.zoneless.com/account/developers'
+        : 'https://dashboard-test.zoneless.com/account/developers',
+    enabled_events: command.events,
+    endpoint_id: endpoint.id,
+    mode: environment.mode,
+    object: 'webhook_sync',
+    ok: true,
+    profile: profileName,
+    restart_required: true,
+    target: environment.target,
+    url: endpoint.url,
+    written: environment.written,
+  };
+}
+
+function IsManagedEndpoint(
+  endpoint: WebhookEndpointResponse,
+  workspaceId: string
+): boolean {
+  return (
+    endpoint.metadata?.[managedMetadataKey] === managedMetadataValue &&
+    endpoint.metadata?.[workspaceMetadataKey] === workspaceId
+  );
+}
+
+function ManagedMetadata(workspaceId: string): Record<string, string> {
+  return {
+    [managedMetadataKey]: managedMetadataValue,
+    [workspaceMetadataKey]: workspaceId,
+  };
+}
+
+function SameEvents(left: string[], right: string[]): boolean {
+  return [...left].sort().join('\n') === [...right].sort().join('\n');
+}
+
+function CreateIdempotencyKey(
+  workspaceId: string,
+  url: string,
+  events: string[]
+): string {
+  const digest = createHash('sha256')
+    .update(JSON.stringify({ events: [...events].sort(), url, workspaceId }))
+    .digest('hex')
+    .slice(0, 32);
+  return `webhook-sync:${digest}`;
+}


### PR DESCRIPTION
## Description

During usdc subscription agentic onboarding a lot of manual stuff had to occur with setting up webhook secrets etc. Now this should be possible via the cli.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
