### PR TITLE
feat: improve skill for wallet export human handoff

### DIFF
--- a/.agents/skills/zoneless-marketplace/SKILL.md
+++ b/.agents/skills/zoneless-marketplace/SKILL.md
@@ -13,9 +13,8 @@ the human explicitly asks for that additional work.
 
 - Never request, read, print, export, transmit, or commit an API key, wallet
   private key, seed phrase, or secret-manager value.
-- Never run `wallet backup` for the human. At handoff, tell the human to run it
-  themselves in an interactive terminal and place the result directly in their
-  deployment secret manager.
+- `wallet backup` is a human-run command. At handoff, tell the human to run it
+  in an interactive terminal and keep the resulting file somewhere private.
 - Work in the test profile. Do not create live-mode application data, fund a
   wallet, submit a transaction, broadcast a payout, or switch production
   traffic.
@@ -364,10 +363,13 @@ Report:
 - the exact live-mode promotion sequence, including the bound live profile
   name, `https://api.zoneless.com`, deployment secret changes, live webhook
   setup, wallet funding, and one supervised payout;
-- that the human must run
-  `npx @zoneless/cli@latest wallet backup --output <secure-path>` themselves,
-  place the backup's `secretKeyBase58` value directly in the production secret
-  manager as `SOLANA_SECRET_KEY`, and delete the temporary export securely;
+- that setup created a platform wallet and, before enabling live payouts, the
+  human should run
+  `npx @zoneless/cli@latest wallet backup --profile <live-profile> --output <private-path>`
+  in an interactive terminal and keep the resulting file somewhere private;
+  when the deployed payout worker needs wallet signing, they should use its
+  `secretKeyBase58` value as `SOLANA_SECRET_KEY` in the deployment secret
+  manager;
 - that the human must follow
   `https://zoneless.com/docs/fund-platform-wallet.md` to fund the platform
   wallet with enough USDC for seller payouts and a small amount of SOL for

--- a/.agents/skills/zoneless-payments/SKILL.md
+++ b/.agents/skills/zoneless-payments/SKILL.md
@@ -389,6 +389,11 @@ Report:
   collected automatically, so no further signing is required;
 - where the human must configure the live API key, live API URL, and live
   webhook secret;
+- that setup created a platform wallet for receiving USDC and, before accepting
+  live payments, the human should run
+  `npx @zoneless/cli@latest wallet backup --profile <live-profile> --output <private-path>`
+  in an interactive terminal and keep the resulting file somewhere private so
+  they can access the wallet later;
 - that the human must explicitly approve any live rollout.
 
 Do not claim the integration is production-ready until the human completes

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoneless/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Provision and manage an agent-operated Zoneless store",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description

Adds explicit instructions at the end of the payments skill for the user to run the wallet export command.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
