### PR TITLE
fix: keep auth and global rate limits on separate counters

### DIFF
--- a/apps/api/src/middleware/RateLimiter.ts
+++ b/apps/api/src/middleware/RateLimiter.ts
@@ -14,6 +14,7 @@ interface RateLimitStore {
 }
 
 interface RateLimitOptions {
+  name: string;
   windowMs: number; // Time window in milliseconds
   maxRequests: number; // Max requests per window
   keyGenerator?: (req: Request) => string; // Custom key generator
@@ -22,7 +23,6 @@ interface RateLimitOptions {
 }
 
 const store: RateLimitStore = {};
-let limiterId = 0;
 
 // Clean up expired entries periodically
 setInterval(() => {
@@ -39,14 +39,14 @@ setInterval(() => {
  */
 export function RateLimiter(options: RateLimitOptions) {
   const {
+    name,
     windowMs,
     maxRequests,
     keyGenerator = (req: Request) => req.ip || 'unknown',
   } = options;
-  const id = ++limiterId;
 
   return (req: Request, res: Response, next: NextFunction) => {
-    const key = `${id}:${keyGenerator(req)}`;
+    const key = `${name}:${keyGenerator(req)}`;
     const now = Date.now();
 
     // Initialize or reset if window expired
@@ -90,24 +90,28 @@ export function RateLimiter(options: RateLimitOptions) {
 export const RateLimiters = {
   // Standard API rate limit: 5000 requests per 15 minutes
   standard: RateLimiter({
+    name: 'standard',
     windowMs: 15 * 60 * 1000,
     maxRequests: 5000,
   }),
 
   // Strict rate limit for sensitive operations: 100 requests per minute
   strict: RateLimiter({
+    name: 'strict',
     windowMs: 60 * 1000,
     maxRequests: 100,
   }),
 
   // Auth rate limit: 100 attempts per 15 minutes
   auth: RateLimiter({
+    name: 'auth',
     windowMs: 15 * 60 * 1000,
     maxRequests: 100,
   }),
 
   // Rate limit by API key instead of IP
   byApiKey: RateLimiter({
+    name: 'byApiKey',
     windowMs: 15 * 60 * 1000,
     maxRequests: 10000,
     keyGenerator: (req: Request) => {

--- a/apps/api/src/middleware/RateLimiter.ts
+++ b/apps/api/src/middleware/RateLimiter.ts
@@ -22,6 +22,7 @@ interface RateLimitOptions {
 }
 
 const store: RateLimitStore = {};
+let limiterId = 0;
 
 // Clean up expired entries periodically
 setInterval(() => {
@@ -42,9 +43,10 @@ export function RateLimiter(options: RateLimitOptions) {
     maxRequests,
     keyGenerator = (req: Request) => req.ip || 'unknown',
   } = options;
+  const id = ++limiterId;
 
   return (req: Request, res: Response, next: NextFunction) => {
-    const key = keyGenerator(req);
+    const key = `${id}:${keyGenerator(req)}`;
     const now = Date.now();
 
     // Initialize or reset if window expired


### PR DESCRIPTION
## Description

Regular api calls from connected accounts were eating up auth limits and hitting 429 errors.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
