### PR TITLE
feat: separate kyb flow and business type onboarding picker

### DIFF
--- a/apps/api/src/__tests__/IdentityVerificationSession.spec.ts
+++ b/apps/api/src/__tests__/IdentityVerificationSession.spec.ts
@@ -14,6 +14,11 @@ import {
   IdentityVerificationSession,
   Person,
 } from '@zoneless/shared-types';
+import {
+  IsBusinessAccount,
+  ResolvedIdentityProvider,
+  SelectIdentityWorkflow,
+} from '../modules/identity/ResolveIdentityProvider';
 import { IDENTITY_REQUIREMENT_FIELDS } from '@zoneless/shared-schemas';
 import {
   CreateMockDatabase,
@@ -71,6 +76,69 @@ describe('IdentitySettingsCrypto', () => {
     expect(redacted.settings?.identity?.didit?.api_key_set).toBe(true);
     expect(redacted.settings?.identity?.didit?.webhook_secret_set).toBe(true);
     expect(redacted.settings?.identity?.didit?.workflow_id).toBe('wf_123');
+    expect(encrypted?.didit?.kyb_workflow_id).toBeUndefined();
+  });
+
+  it('persists kyb_workflow_id without encrypting it', () => {
+    const encrypted = EncryptIdentitySettings({
+      provider: 'didit',
+      didit: {
+        api_key: 'didit_live_key',
+        workflow_id: 'wf_kyc',
+        kyb_workflow_id: 'wf_kyb',
+        webhook_secret: 'whsec_abc',
+      },
+    });
+
+    expect(encrypted?.didit?.workflow_id).toBe('wf_kyc');
+    expect(encrypted?.didit?.kyb_workflow_id).toBe('wf_kyb');
+  });
+});
+
+describe('SelectIdentityWorkflow', () => {
+  function BuildResolved(
+    kybWorkflowId: string | null = 'wf_kyb'
+  ): ResolvedIdentityProvider {
+    return {
+      provider: {} as never,
+      apiKey: 'key',
+      workflowId: 'wf_kyc',
+      kybWorkflowId,
+      webhookSecret: null,
+    };
+  }
+
+  it('uses the KYC workflow for individuals', () => {
+    expect(
+      SelectIdentityWorkflow(BuildResolved(), {
+        business_type: 'individual',
+      } as Account)
+    ).toEqual({ workflowId: 'wf_kyc', isKyb: false });
+  });
+
+  it('uses the KYB workflow for companies when configured', () => {
+    expect(
+      SelectIdentityWorkflow(BuildResolved(), {
+        business_type: 'company',
+      } as Account)
+    ).toEqual({ workflowId: 'wf_kyb', isKyb: true });
+  });
+
+  it('falls back to the KYC workflow when kyb_workflow_id is unset', () => {
+    expect(
+      SelectIdentityWorkflow(BuildResolved(null), {
+        business_type: 'company',
+      } as Account)
+    ).toEqual({ workflowId: 'wf_kyc', isKyb: false });
+  });
+
+  it('treats non_profit and government_entity as business accounts', () => {
+    expect(IsBusinessAccount({ business_type: 'non_profit' })).toBe(true);
+    expect(IsBusinessAccount({ business_type: 'government_entity' })).toBe(
+      true
+    );
+    expect(IsBusinessAccount({ business_type: 'individual' })).toBe(false);
+    expect(IsBusinessAccount(null)).toBe(false);
   });
 });
 
@@ -359,6 +427,71 @@ describe('IdentityVerificationSessionModule', () => {
         }),
       })
     );
+    const createBody = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body
+    );
+    expect(createBody.workflow_id).toBe('wf_test');
+    expect(createBody.expected_details).toBeUndefined();
+  });
+
+  it('uses the KYB workflow and expected_details for company accounts', async () => {
+    const platform = storedAccounts.get(platformId)!;
+    platform.settings = {
+      identity: EncryptIdentitySettings({
+        provider: 'didit',
+        didit: {
+          api_key: 'didit_key',
+          workflow_id: 'wf_test',
+          kyb_workflow_id: 'wf_kyb',
+          webhook_secret: 'whsec_test',
+        },
+      }),
+    };
+    storedAccounts.set(platformId, platform);
+
+    const connected = storedAccounts.get(connectedId)!;
+    connected.business_type = 'company';
+    connected.business_profile = {
+      name: "Ben's Business",
+      mcc: null,
+      product_description: null,
+      support_email: null,
+      support_phone: null,
+      support_url: null,
+      url: null,
+    };
+    storedAccounts.set(connectedId, connected);
+
+    await sessionModule.Create(platformId, {
+      type: 'document',
+      related_account: connectedId,
+    });
+
+    const createBody = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body
+    );
+    expect(createBody.workflow_id).toBe('wf_kyb');
+    expect(createBody.expected_details).toEqual({
+      company_name: "Ben's Business",
+      registry_country: 'US',
+    });
+  });
+
+  it('falls back to the KYC workflow for companies without kyb_workflow_id', async () => {
+    const connected = storedAccounts.get(connectedId)!;
+    connected.business_type = 'company';
+    storedAccounts.set(connectedId, connected);
+
+    await sessionModule.Create(platformId, {
+      type: 'document',
+      related_account: connectedId,
+    });
+
+    const createBody = JSON.parse(
+      (global.fetch as jest.Mock).mock.calls[0][1].body
+    );
+    expect(createBody.workflow_id).toBe('wf_test');
+    expect(createBody.expected_details).toBeUndefined();
   });
 
   it('cancels a session and sets person back to unverified', async () => {
@@ -941,6 +1074,7 @@ describe('AccountModule identity settings merge', () => {
           didit: {
             api_key: 'plain_key',
             workflow_id: 'wf_1',
+            kyb_workflow_id: 'wf_kyb_1',
             webhook_secret: 'plain_secret',
           },
           rules: { payout_volume_threshold_cents: 1000 },
@@ -950,6 +1084,7 @@ describe('AccountModule identity settings merge', () => {
 
     expect(updated.settings?.identity?.didit?.api_key).not.toBe('plain_key');
     expect(updated.settings?.identity?.didit?.workflow_id).toBe('wf_1');
+    expect(updated.settings?.identity?.didit?.kyb_workflow_id).toBe('wf_kyb_1');
     expect(
       DecryptIdentitySecret(updated.settings?.identity?.didit?.api_key)
     ).toBe('plain_key');

--- a/apps/api/src/modules/IdentityVerificationSession.ts
+++ b/apps/api/src/modules/IdentityVerificationSession.ts
@@ -15,7 +15,10 @@ import { AccountModule } from './Account';
 import { PersonModule } from './Person';
 import { IdentityLiteModule } from './identity/IdentityLite';
 import { GetAppConfig } from './AppConfig';
-import { ResolveIdentityProvider } from './identity/ResolveIdentityProvider';
+import {
+  ResolveIdentityProvider,
+  SelectIdentityWorkflow,
+} from './identity/ResolveIdentityProvider';
 import { DecryptIdentitySecret } from './identity/IdentitySettingsCrypto';
 import { GenerateId } from '../utils/IdGenerator';
 import { Now } from '../utils/Timestamp';
@@ -95,17 +98,24 @@ export class IdentityVerificationSessionModule {
     );
 
     const resolved = ResolveIdentityProvider(platformAccount);
+    const selected = SelectIdentityWorkflow(resolved, relatedAccount);
     const sessionId = GenerateId('vs_z');
 
     const providerSession = await resolved.provider.CreateSession(
       resolved.apiKey,
       {
-        workflowId: resolved.workflowId,
+        workflowId: selected.workflowId,
         vendorData: sessionId,
         callbackUrl: validated.return_url,
         email: validated.provided_details?.email,
         phone: validated.provided_details?.phone,
         metadata: validated.metadata,
+        expectedDetails: selected.isKyb
+          ? {
+              company_name: relatedAccount.business_profile?.name ?? undefined,
+              registry_country: relatedAccount.country || undefined,
+            }
+          : undefined,
       }
     );
 

--- a/apps/api/src/modules/identity/DiditProvider.ts
+++ b/apps/api/src/modules/identity/DiditProvider.ts
@@ -51,6 +51,11 @@ export class DiditProvider implements IdentityVerificationProvider {
       body.metadata = input.metadata;
     }
 
+    const expectedDetails = CompactExpectedDetails(input.expectedDetails);
+    if (expectedDetails) {
+      body.expected_details = expectedDetails;
+    }
+
     const response = await fetch(`${DIDIT_API_BASE}/session/`, {
       method: 'POST',
       headers: {
@@ -272,6 +277,18 @@ function ShortenFloats(obj: unknown): unknown {
     return obj;
   }
   return obj;
+}
+
+function CompactExpectedDetails(
+  details: ProviderCreateSessionInput['expectedDetails']
+): Record<string, string> | null {
+  if (!details) return null;
+  const compacted: Record<string, string> = {};
+  const companyName = details.company_name?.trim();
+  const registryCountry = details.registry_country?.trim();
+  if (companyName) compacted.company_name = companyName;
+  if (registryCountry) compacted.registry_country = registryCountry;
+  return Object.keys(compacted).length > 0 ? compacted : null;
 }
 
 export const diditProvider = new DiditProvider();

--- a/apps/api/src/modules/identity/IdentityVerificationProvider.ts
+++ b/apps/api/src/modules/identity/IdentityVerificationProvider.ts
@@ -12,6 +12,11 @@ import {
   IdentityVerificationSessionType,
 } from '@zoneless/shared-types';
 
+export interface ProviderExpectedDetails {
+  company_name?: string;
+  registry_country?: string;
+}
+
 export interface ProviderCreateSessionInput {
   /** Provider workflow / flow ID */
   workflowId: string;
@@ -23,6 +28,8 @@ export interface ProviderCreateSessionInput {
   email?: string | null;
   phone?: string | null;
   metadata?: Record<string, string>;
+  /** Prefill for KYB company registry search */
+  expectedDetails?: ProviderExpectedDetails;
 }
 
 export interface ProviderSession {

--- a/apps/api/src/modules/identity/ResolveIdentityProvider.ts
+++ b/apps/api/src/modules/identity/ResolveIdentityProvider.ts
@@ -4,7 +4,10 @@
  * @module ResolveIdentityProvider
  */
 
-import { Account as AccountType } from '@zoneless/shared-types';
+import {
+  Account as AccountType,
+  AccountBusinessType,
+} from '@zoneless/shared-types';
 import { AppError } from '../../utils/AppError';
 import { DecryptIdentitySecret } from './IdentitySettingsCrypto';
 import { diditProvider } from './DiditProvider';
@@ -13,8 +16,16 @@ import { IdentityVerificationProvider } from './IdentityVerificationProvider';
 export interface ResolvedIdentityProvider {
   provider: IdentityVerificationProvider;
   apiKey: string;
+  /** Individual / KYC workflow */
   workflowId: string;
+  /** Company / KYB workflow when configured */
+  kybWorkflowId: string | null;
   webhookSecret: string | null;
+}
+
+export interface SelectedIdentityWorkflow {
+  workflowId: string;
+  isKyb: boolean;
 }
 
 /**
@@ -37,6 +48,7 @@ export function ResolveIdentityProvider(
 
   const apiKey = DecryptIdentitySecret(identity?.didit?.api_key);
   const workflowId = identity?.didit?.workflow_id?.trim() || null;
+  const kybWorkflowId = identity?.didit?.kyb_workflow_id?.trim() || null;
   const webhookSecret = DecryptIdentitySecret(identity?.didit?.webhook_secret);
 
   if (!apiKey || !workflowId) {
@@ -51,8 +63,35 @@ export function ResolveIdentityProvider(
     provider: diditProvider,
     apiKey,
     workflowId,
+    kybWorkflowId,
     webhookSecret,
   };
+}
+
+/**
+ * True when the account represents a legal entity rather than a person.
+ */
+export function IsBusinessAccount(
+  account: { business_type?: AccountBusinessType | null } | null | undefined
+): boolean {
+  const type = account?.business_type;
+  return (
+    type === 'company' || type === 'non_profit' || type === 'government_entity'
+  );
+}
+
+/**
+ * Choose the Didit workflow for a connected account.
+ * Business accounts use kyb_workflow_id when set; otherwise KYC workflow_id.
+ */
+export function SelectIdentityWorkflow(
+  resolved: ResolvedIdentityProvider,
+  connectedAccount: AccountType
+): SelectedIdentityWorkflow {
+  if (IsBusinessAccount(connectedAccount) && resolved.kybWorkflowId) {
+    return { workflowId: resolved.kybWorkflowId, isKyb: true };
+  }
+  return { workflowId: resolved.workflowId, isKyb: false };
 }
 
 /**

--- a/apps/web/src/app/data/services/account.service.ts
+++ b/apps/web/src/app/data/services/account.service.ts
@@ -7,6 +7,7 @@ import {
   UpdateAccountInput,
 } from '@zoneless/shared-schemas';
 import { SettingsCardRow } from '../../shared';
+import { FormatBusinessType, IsBusinessAccount } from '../../utils';
 
 @Injectable({
   providedIn: 'root',
@@ -223,6 +224,42 @@ export class AccountService {
   }
 
   /**
+   * Display title for the connected-account type card.
+   */
+  GetAccountTypeTitle(account: Account | null): string {
+    if (!account) return 'Account type';
+    if (IsBusinessAccount(account)) {
+      return (
+        account.business_profile?.name?.trim() ||
+        FormatBusinessType(account.business_type)
+      );
+    }
+    return 'Individual';
+  }
+
+  GetAccountTypeCardRows(account: Account | null): SettingsCardRow[] {
+    if (!account) return [];
+
+    const rows: SettingsCardRow[] = [
+      {
+        label: 'Type',
+        value: FormatBusinessType(account.business_type),
+        type: 'text',
+      },
+    ];
+
+    if (IsBusinessAccount(account)) {
+      rows.push({
+        label: 'Legal business name',
+        value: account.business_profile?.name?.trim() || '—',
+        type: 'text',
+      });
+    }
+
+    return rows;
+  }
+
+  /**
    * Display title for the Business details settings card.
    */
   GetBusinessDetailsTitle(account: Account | null): string {
@@ -284,8 +321,13 @@ export class AccountService {
         type: 'text',
       },
       {
-        label: 'Workflow ID',
+        label: 'KYC workflow ID',
         value: providerSettings?.workflow_id?.trim() || '—',
+        type: 'text',
+      },
+      {
+        label: 'KYB workflow ID',
+        value: providerSettings?.kyb_workflow_id?.trim() || '—',
         type: 'text',
       },
       {

--- a/apps/web/src/app/features/account/components/connected-account-detail/connected-account-detail.component.ts
+++ b/apps/web/src/app/features/account/components/connected-account-detail/connected-account-detail.component.ts
@@ -12,7 +12,7 @@ import { Account, Person } from '@zoneless/shared-types';
 import { StatusChipComponent } from '../../../../shared';
 import { AccountService } from '../../../../data/services/account.service';
 import { PersonService } from '../../../../data/services/person.service';
-import { GetCountryName } from '../../../../utils';
+import { FormatBusinessType, GetCountryName } from '../../../../utils';
 import { GetAccountStatus } from '../../connected-accounts/util/connected-account-display';
 
 @Component({
@@ -80,10 +80,7 @@ export class ConnectedAccountDetailComponent {
 
   GetBusinessType(): string | null {
     if (!this.account.business_type) return null;
-    return this.account.business_type
-      .split('_')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+    return FormatBusinessType(this.account.business_type);
   }
 
   GetChargesEnabled(): boolean {

--- a/apps/web/src/app/features/account/connected-accounts/services/connected-account-actions.service.ts
+++ b/apps/web/src/app/features/account/connected-accounts/services/connected-account-actions.service.ts
@@ -28,7 +28,7 @@ import {
   TransferService,
 } from '../../../../data';
 import { SolanaWalletService } from '../../../../core';
-import { GetCountryName } from '../../../../utils';
+import { FormatBusinessType, GetCountryName } from '../../../../utils';
 
 export type CreateConnectedAccountStep = 'summary' | 'edit-details' | 'success';
 
@@ -288,16 +288,7 @@ export class ConnectedAccountActionsService {
   }
 
   GetBusinessTypeLabel(type: BusinessType = this.businessType()): string {
-    switch (type) {
-      case 'individual':
-        return 'Individual';
-      case 'company':
-        return 'Company';
-      case 'non_profit':
-        return 'Non-profit';
-      case 'government_entity':
-        return 'Government entity';
-    }
+    return FormatBusinessType(type);
   }
 
   GetCapabilitiesLabel(): string {

--- a/apps/web/src/app/features/account/settings/settings.component.html
+++ b/apps/web/src/app/features/account/settings/settings.component.html
@@ -120,8 +120,18 @@
 </div>
 }
 
-<!-- Personal Details Card (connected accounts only) -->
+<!-- Account type + personal details (connected accounts only) -->
 @if (!authService.isPlatform()) {
+<div class="view-section">
+  <div class="settings-section-title">Account type</div>
+  <app-settings-card
+    [title]="accountService.GetAccountTypeTitle(accountService.account())"
+    [rows]="accountService.GetAccountTypeCardRows(accountService.account())"
+    [showEditButton]="true"
+    (editClicked)="OnEditAccountTypeClick()"
+  ></app-settings-card>
+</div>
+
 <div class="view-section">
   <div class="settings-section-title">Personal details</div>
   <app-settings-card
@@ -227,8 +237,26 @@
 </app-slide-panel>
 }
 
-<!-- Edit Person Slide Panel -->
+<!-- Edit Account Type + Person Slide Panels -->
 @if (!authService.isPlatform()) {
+<app-slide-panel
+  [isOpen]="editAccountTypePanelOpen()"
+  title="Edit account type"
+  [loading]="editAccountTypeLoading()"
+  submitLabel="Save"
+  [submitDisabled]="false"
+  (closed)="OnEditAccountTypePanelClosed()"
+  (submitted)="OnEditAccountTypeSubmit()"
+>
+  <app-account-type-form
+    #editAccountTypeForm
+    mode="edit"
+    [account]="accountService.account()"
+    [isOpen]="editAccountTypePanelOpen()"
+    [showErrors]="editAccountTypeShowErrors()"
+  ></app-account-type-form>
+</app-slide-panel>
+
 <app-slide-panel
   [isOpen]="editPersonPanelOpen()"
   title="Edit personal details"

--- a/apps/web/src/app/features/account/settings/settings.component.ts
+++ b/apps/web/src/app/features/account/settings/settings.component.ts
@@ -26,6 +26,7 @@ import {
   TelemetryService,
 } from '../../../data';
 import {
+  AccountTypeFormComponent,
   BusinessProfileFormComponent,
   ExternalWalletFormComponent,
   IdentitySettingsFormComponent,
@@ -48,6 +49,7 @@ import {
   selector: 'app-settings',
   imports: [
     SlidePanelComponent,
+    AccountTypeFormComponent,
     PersonFormComponent,
     ExternalWalletFormComponent,
     BusinessProfileFormComponent,
@@ -65,6 +67,8 @@ export class SettingsComponent implements OnInit {
   editBusinessForm!: BusinessProfileFormComponent;
   @ViewChild('editIdentityForm')
   editIdentityForm!: IdentitySettingsFormComponent;
+  @ViewChild('editAccountTypeForm')
+  editAccountTypeForm!: AccountTypeFormComponent;
 
   readonly personService = inject(PersonService);
   readonly externalWalletService = inject(ExternalWalletService);
@@ -102,6 +106,11 @@ export class SettingsComponent implements OnInit {
   editIdentityPanelOpen: WritableSignal<boolean> = signal(false);
   editIdentityLoading: WritableSignal<boolean> = signal(false);
   editIdentityShowErrors: WritableSignal<boolean> = signal(false);
+
+  // Edit account type panel (connected accounts)
+  editAccountTypePanelOpen: WritableSignal<boolean> = signal(false);
+  editAccountTypeLoading: WritableSignal<boolean> = signal(false);
+  editAccountTypeShowErrors: WritableSignal<boolean> = signal(false);
 
   telemetrySaving: WritableSignal<boolean> = signal(false);
 
@@ -304,6 +313,44 @@ export class SettingsComponent implements OnInit {
       console.error('Failed to update identity settings:', error);
     } finally {
       this.editIdentityLoading.set(false);
+    }
+  }
+
+  OnEditAccountTypeClick(): void {
+    this.editAccountTypeShowErrors.set(false);
+    this.editAccountTypePanelOpen.set(true);
+  }
+
+  OnEditAccountTypePanelClosed(): void {
+    this.editAccountTypePanelOpen.set(false);
+    this.editAccountTypeShowErrors.set(false);
+  }
+
+  async OnEditAccountTypeSubmit(): Promise<void> {
+    if (!this.editAccountTypeForm) return;
+
+    this.editAccountTypeShowErrors.set(true);
+
+    if (!this.editAccountTypeForm.ValidateAll()) {
+      return;
+    }
+
+    const account = this.GetAccount();
+    if (!account) return;
+
+    this.editAccountTypeLoading.set(true);
+
+    try {
+      await this.accountService.UpdateAccount(
+        account.id,
+        this.editAccountTypeForm.GetUpdateData()
+      );
+      this.editAccountTypePanelOpen.set(false);
+      this.editAccountTypeShowErrors.set(false);
+    } catch (error) {
+      console.error('Failed to update account type:', error);
+    } finally {
+      this.editAccountTypeLoading.set(false);
     }
   }
 

--- a/apps/web/src/app/features/onboard/onboard.component.html
+++ b/apps/web/src/app/features/onboard/onboard.component.html
@@ -85,7 +85,15 @@
             [showErrors]="showPersonErrors()"
             (formChange)="OnPersonFormChange()"
             (validationChange)="OnPersonValidationChange($event)"
-          ></app-person-form>
+          >
+            <app-account-type-form
+              #onboardAccountTypeForm
+              mode="onboard"
+              [account]="accountService.account()"
+              [showErrors]="showPersonErrors()"
+              (validationChange)="OnAccountTypeValidationChange($event)"
+            ></app-account-type-form>
+          </app-person-form>
 
           <div class="form-navigation">
             @if(apiError()){
@@ -144,9 +152,32 @@
           <p>Take a moment to review your information.</p>
 
           <div class="review-cards">
+            <!-- Account Type Card -->
+            <div class="review-section">
+              <div class="review-section-title">Account type</div>
+              <app-settings-card
+                [title]="
+                  accountService.GetAccountTypeTitle(accountService.account())
+                "
+                [rows]="
+                  accountService.GetAccountTypeCardRows(
+                    accountService.account()
+                  )
+                "
+                [showEditButton]="true"
+                (editClicked)="OnEditAccountTypeClick()"
+              ></app-settings-card>
+            </div>
+
             <!-- Personal Details Card -->
             <div class="review-section">
-              <div class="review-section-title">Personal details</div>
+              <div class="review-section-title">
+                {{
+                  ShowBusinessDetails()
+                    ? 'Account representative'
+                    : 'Personal details'
+                }}
+              </div>
               <app-settings-card
                 [title]="personService.GetFullName(personService.person())"
                 [rows]="
@@ -249,6 +280,25 @@
       </div>
     </div>
   </div>
+
+  <!-- Edit Account Type Slide Panel -->
+  <app-slide-panel
+    [isOpen]="editAccountTypePanelOpen()"
+    title="Edit account type"
+    [loading]="editAccountTypeLoading()"
+    submitLabel="Save"
+    [submitDisabled]="false"
+    (closed)="OnEditAccountTypePanelClosed()"
+    (submitted)="OnEditAccountTypeSubmit()"
+  >
+    <app-account-type-form
+      #editAccountTypeForm
+      mode="edit"
+      [account]="accountService.account()"
+      [isOpen]="editAccountTypePanelOpen()"
+      [showErrors]="editAccountTypeShowErrors()"
+    ></app-account-type-form>
+  </app-slide-panel>
 
   <!-- Edit Person Slide Panel -->
   <app-slide-panel

--- a/apps/web/src/app/features/onboard/onboard.component.ts
+++ b/apps/web/src/app/features/onboard/onboard.component.ts
@@ -20,6 +20,7 @@ import {
 import {
   PageLoaderComponent,
   LoaderComponent,
+  AccountTypeFormComponent,
   PersonFormComponent,
   ExternalWalletFormComponent,
   SettingsCardComponent,
@@ -27,6 +28,7 @@ import {
   PlatformLogoComponent,
 } from '../../shared';
 import { GetFormBlockingIdentityRequirements } from '@zoneless/shared-schemas';
+import { IsBusinessAccount } from '../../utils';
 
 enum OnboardStep {
   PERSON = 1,
@@ -43,6 +45,7 @@ enum OnboardStep {
   imports: [
     PageLoaderComponent,
     LoaderComponent,
+    AccountTypeFormComponent,
     PersonFormComponent,
     ExternalWalletFormComponent,
     SettingsCardComponent,
@@ -54,7 +57,7 @@ enum OnboardStep {
 export class OnboardComponent implements OnInit {
   private readonly meta = inject(MetaService);
   private readonly router = inject(Router);
-  private readonly accountService = inject(AccountService);
+  readonly accountService = inject(AccountService);
   private readonly accountLinkService = inject(AccountLinkService);
   readonly personService = inject(PersonService);
   readonly externalWalletService = inject(ExternalWalletService);
@@ -63,8 +66,12 @@ export class OnboardComponent implements OnInit {
   @ViewChild(PersonFormComponent) personForm!: PersonFormComponent;
   @ViewChild(ExternalWalletFormComponent)
   walletForm!: ExternalWalletFormComponent;
+  @ViewChild('onboardAccountTypeForm')
+  accountTypeForm!: AccountTypeFormComponent;
   @ViewChild('editPersonForm') editPersonForm!: PersonFormComponent;
   @ViewChild('editWalletForm') editWalletForm!: ExternalWalletFormComponent;
+  @ViewChild('editAccountTypeForm')
+  editAccountTypeForm!: AccountTypeFormComponent;
 
   readonly STEPS = OnboardStep;
 
@@ -80,6 +87,7 @@ export class OnboardComponent implements OnInit {
   showWalletErrors: WritableSignal<boolean> = signal(false);
 
   personFormValid: WritableSignal<boolean> = signal(false);
+  accountTypeFormValid: WritableSignal<boolean> = signal(true);
   walletFormValid: WritableSignal<boolean> = signal(false);
 
   // Edit panel state
@@ -90,6 +98,10 @@ export class OnboardComponent implements OnInit {
   editWalletPanelOpen: WritableSignal<boolean> = signal(false);
   editWalletLoading: WritableSignal<boolean> = signal(false);
   editWalletShowErrors: WritableSignal<boolean> = signal(false);
+
+  editAccountTypePanelOpen: WritableSignal<boolean> = signal(false);
+  editAccountTypeLoading: WritableSignal<boolean> = signal(false);
+  editAccountTypeShowErrors: WritableSignal<boolean> = signal(false);
 
   private tokenExchanged = false;
   private initRetries = 0;
@@ -188,6 +200,14 @@ export class OnboardComponent implements OnInit {
     this.personFormValid.set(isValid);
   }
 
+  OnAccountTypeValidationChange(isValid: boolean): void {
+    this.accountTypeFormValid.set(isValid);
+  }
+
+  ShowBusinessDetails(): boolean {
+    return IsBusinessAccount(this.accountService.account());
+  }
+
   OnWalletValidationChange(isValid: boolean): void {
     this.walletFormValid.set(isValid);
   }
@@ -216,7 +236,7 @@ export class OnboardComponent implements OnInit {
   IsStepValid(step: number): boolean {
     switch (step) {
       case OnboardStep.PERSON:
-        return this.personFormValid();
+        return this.personFormValid() && this.accountTypeFormValid();
       case OnboardStep.WALLET:
         return this.walletFormValid();
       case OnboardStep.FINISH:
@@ -264,9 +284,19 @@ export class OnboardComponent implements OnInit {
       const account = this.accountService.account();
       const person = this.personService.person();
 
-      if (!account || !person || !this.personForm) {
+      if (!account || !person || !this.personForm || !this.accountTypeForm) {
         throw new Error('Account or person not found');
       }
+
+      if (!this.accountTypeForm.ValidateAll()) {
+        this.showPersonErrors.set(true);
+        throw new Error('Please complete your account type details');
+      }
+
+      await this.accountService.UpdateAccount(
+        account.id,
+        this.accountTypeForm.GetUpdateData()
+      );
 
       const updateData = this.personForm.GetUpdateData();
       const updated = await this.personService.UpdatePerson(
@@ -391,6 +421,44 @@ export class OnboardComponent implements OnInit {
       console.error('Failed to update person:', error);
     } finally {
       this.editPersonLoading.set(false);
+    }
+  }
+
+  OnEditAccountTypeClick(): void {
+    this.editAccountTypeShowErrors.set(false);
+    this.editAccountTypePanelOpen.set(true);
+  }
+
+  OnEditAccountTypePanelClosed(): void {
+    this.editAccountTypePanelOpen.set(false);
+    this.editAccountTypeShowErrors.set(false);
+  }
+
+  async OnEditAccountTypeSubmit(): Promise<void> {
+    if (!this.editAccountTypeForm) return;
+
+    this.editAccountTypeShowErrors.set(true);
+
+    if (!this.editAccountTypeForm.ValidateAll()) {
+      return;
+    }
+
+    const account = this.accountService.account();
+    if (!account) return;
+
+    this.editAccountTypeLoading.set(true);
+
+    try {
+      await this.accountService.UpdateAccount(
+        account.id,
+        this.editAccountTypeForm.GetUpdateData()
+      );
+      this.editAccountTypePanelOpen.set(false);
+      this.editAccountTypeShowErrors.set(false);
+    } catch (error) {
+      console.error('Failed to update account type:', error);
+    } finally {
+      this.editAccountTypeLoading.set(false);
     }
   }
 

--- a/apps/web/src/app/shared/forms/account-type-form/account-type-form.component.html
+++ b/apps/web/src/app/shared/forms/account-type-form/account-type-form.component.html
@@ -1,0 +1,44 @@
+<div class="account-type-form">
+  <div class="field-group">
+    <div class="field-title">Account type</div>
+    <p class="field-help">
+      Choose whether you are signing up as an individual or a registered
+      business.
+    </p>
+    <div class="field">
+      <select
+        [ngModel]="accountType()"
+        (ngModelChange)="OnAccountTypeChange($event)"
+        name="account-type"
+      >
+        <option value="individual">Individual</option>
+        <option value="company">Company</option>
+      </select>
+    </div>
+  </div>
+
+  @if (IsBusiness()) {
+  <div class="field-group">
+    <div class="field-title">Legal business name</div>
+    <p class="field-help">
+      Enter the name exactly as it appears on government or tax records.
+    </p>
+    <div class="field">
+      <input
+        [ngModel]="businessName()"
+        (ngModelChange)="OnBusinessNameChange($event)"
+        class="field-value"
+        type="text"
+        placeholder="Acme Inc."
+        name="legal-business-name"
+        autocomplete="organization"
+        [maxlength]="NAME_MAX_LENGTH"
+        [class.field-error]="showErrors && businessNameError()"
+      />
+      @if (showErrors && businessNameError()) {
+      <div class="error">{{ businessNameError() }}</div>
+      }
+    </div>
+  </div>
+  }
+</div>

--- a/apps/web/src/app/shared/forms/account-type-form/account-type-form.component.scss
+++ b/apps/web/src/app/shared/forms/account-type-form/account-type-form.component.scss
@@ -1,0 +1,17 @@
+@use '../../../styles/base.scss' as *;
+@use '../../../styles/forms.scss' as *;
+
+.account-type-form {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing;
+  margin-bottom: $spacing;
+}
+
+.field-group {
+  margin-bottom: $spacing-small;
+}
+
+select {
+  width: 100%;
+}

--- a/apps/web/src/app/shared/forms/account-type-form/account-type-form.component.ts
+++ b/apps/web/src/app/shared/forms/account-type-form/account-type-form.component.ts
@@ -1,0 +1,153 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  signal,
+  WritableSignal,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Account, AccountBusinessType } from '@zoneless/shared-types';
+import { UpdateAccountInput } from '@zoneless/shared-schemas';
+import {
+  IsBusinessAccount,
+  NAME_MAX_LENGTH,
+  NAME_MIN_LENGTH,
+} from '../../../utils';
+
+export type AccountTypeFormMode = 'onboard' | 'edit';
+
+export interface AccountTypeFormData {
+  businessType: AccountBusinessType;
+  businessName: string;
+}
+
+type AccountTypeChoice = 'individual' | 'company';
+
+@Component({
+  selector: 'app-account-type-form',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './account-type-form.component.html',
+  styleUrls: ['./account-type-form.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AccountTypeFormComponent implements OnInit, OnChanges {
+  readonly NAME_MAX_LENGTH = NAME_MAX_LENGTH;
+
+  @Input() mode: AccountTypeFormMode = 'onboard';
+  @Input() account: Account | null = null;
+  @Input() showErrors = false;
+  @Input() isOpen = false;
+
+  @Output() formChange = new EventEmitter<AccountTypeFormData>();
+  @Output() validationChange = new EventEmitter<boolean>();
+
+  accountType: WritableSignal<AccountTypeChoice> = signal('individual');
+  businessName: WritableSignal<string> = signal('');
+  businessNameError: WritableSignal<string> = signal('');
+
+  ngOnInit(): void {
+    this.InitializeForm();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['isOpen'] && this.isOpen) {
+      this.InitializeForm();
+    }
+    if (changes['account'] && !this.isOpen) {
+      this.InitializeForm();
+    }
+  }
+
+  InitializeForm(): void {
+    this.accountType.set(
+      IsBusinessAccount(this.account) ? 'company' : 'individual'
+    );
+    this.businessName.set(this.account?.business_profile?.name?.trim() || '');
+    this.businessNameError.set('');
+    this.EmitFormChange();
+  }
+
+  OnAccountTypeChange(value: string): void {
+    this.accountType.set(value === 'company' ? 'company' : 'individual');
+    this.ValidateBusinessName();
+    this.EmitFormChange();
+  }
+
+  OnBusinessNameChange(value: string): void {
+    this.businessName.set(value);
+    this.ValidateBusinessName();
+    this.EmitFormChange();
+  }
+
+  IsBusiness(): boolean {
+    return this.accountType() === 'company';
+  }
+
+  ValidateAll(): boolean {
+    this.ValidateBusinessName();
+    const valid = this.IsValid();
+    this.validationChange.emit(valid);
+    return valid;
+  }
+
+  IsValid(): boolean {
+    if (!this.IsBusiness()) return true;
+    return !!this.businessName().trim() && !this.businessNameError();
+  }
+
+  GetFormData(): AccountTypeFormData {
+    return {
+      businessType: this.ResolveBusinessType(),
+      businessName: this.businessName().trim(),
+    };
+  }
+
+  GetUpdateData(): UpdateAccountInput {
+    const isBusiness = this.IsBusiness();
+    return {
+      business_type: this.ResolveBusinessType(),
+      business_profile: {
+        name: isBusiness ? this.businessName().trim() : null,
+      },
+    };
+  }
+
+  private ResolveBusinessType(): AccountBusinessType {
+    if (!this.IsBusiness()) return 'individual';
+    const existing = this.account?.business_type;
+    if (existing === 'non_profit' || existing === 'government_entity') {
+      return existing;
+    }
+    return 'company';
+  }
+
+  private ValidateBusinessName(): void {
+    if (!this.IsBusiness()) {
+      this.businessNameError.set('');
+      return;
+    }
+    const name = this.businessName().trim();
+    if (!name) {
+      this.businessNameError.set('Legal business name is required');
+      return;
+    }
+    if (name.length < NAME_MIN_LENGTH) {
+      this.businessNameError.set(
+        `Business name must be at least ${NAME_MIN_LENGTH} characters`
+      );
+      return;
+    }
+    this.businessNameError.set('');
+  }
+
+  private EmitFormChange(): void {
+    this.formChange.emit(this.GetFormData());
+    this.validationChange.emit(this.IsValid());
+  }
+}

--- a/apps/web/src/app/shared/forms/identity-settings-form/identity-settings-form.component.html
+++ b/apps/web/src/app/shared/forms/identity-settings-form/identity-settings-form.component.html
@@ -34,9 +34,10 @@
   </div>
 
   <div class="field">
-    <div class="field-title">Workflow ID</div>
+    <div class="field-title">KYC workflow ID</div>
     <p class="field-help">
-      The published Didit workflow used for KYC verification sessions.
+      The published Didit workflow used for individual KYC verification
+      sessions.
     </p>
     <input
       [ngModel]="workflowId()"
@@ -51,6 +52,25 @@
     @if (showErrors && workflowIdError()) {
     <div class="error">{{ workflowIdError() }}</div>
     }
+  </div>
+
+  <div class="field">
+    <div class="field-title">
+      KYB workflow ID <span class="field-optional">Optional</span>
+    </div>
+    <p class="field-help">
+      The published Didit workflow used for company verification sessions. When
+      unset, business accounts use the KYC workflow.
+    </p>
+    <input
+      [ngModel]="kybWorkflowId()"
+      (ngModelChange)="OnKybWorkflowIdChange($event)"
+      class="field-value"
+      type="text"
+      placeholder="550e8400-e29b-41d4-a716-446655440000"
+      name="didit-kyb-workflow-id"
+      autocomplete="off"
+    />
   </div>
 
   <div class="field">

--- a/apps/web/src/app/shared/forms/identity-settings-form/identity-settings-form.component.ts
+++ b/apps/web/src/app/shared/forms/identity-settings-form/identity-settings-form.component.ts
@@ -20,6 +20,7 @@ import { GetDiditWebhookUrl } from './didit-webhook-url';
 export interface IdentitySettingsFormData {
   apiKey: string;
   workflowId: string;
+  kybWorkflowId: string;
   webhookSecret: string;
   /** Dollars string for the default payout volume threshold */
   payoutVolumeThreshold: string;
@@ -61,6 +62,8 @@ export class IdentitySettingsFormComponent implements OnInit, OnChanges {
   workflowId: WritableSignal<string> = signal('');
   workflowIdError: WritableSignal<string> = signal('');
 
+  kybWorkflowId: WritableSignal<string> = signal('');
+
   webhookSecret: WritableSignal<string> = signal('');
   webhookSecretError: WritableSignal<string> = signal('');
   webhookSecretConfigured: WritableSignal<boolean> = signal(false);
@@ -96,6 +99,7 @@ export class IdentitySettingsFormComponent implements OnInit, OnChanges {
     this.apiKeyConfigured.set(!!providerSettings?.api_key_set);
     this.webhookSecretConfigured.set(!!providerSettings?.webhook_secret_set);
     this.workflowId.set(providerSettings?.workflow_id?.trim() || '');
+    this.kybWorkflowId.set(providerSettings?.kyb_workflow_id?.trim() || '');
 
     const cents = rules?.payout_volume_threshold_cents;
     this.payoutVolumeThreshold.set(
@@ -135,6 +139,11 @@ export class IdentitySettingsFormComponent implements OnInit, OnChanges {
     this.workflowId.set(value);
     this.ValidateWorkflowId();
     this.ValidateThresholdRequiresProvider();
+    this.EmitFormChange();
+  }
+
+  OnKybWorkflowIdChange(value: string): void {
+    this.kybWorkflowId.set(value);
     this.EmitFormChange();
   }
 
@@ -226,6 +235,7 @@ export class IdentitySettingsFormComponent implements OnInit, OnChanges {
     return {
       apiKey: this.apiKey(),
       workflowId: this.workflowId(),
+      kybWorkflowId: this.kybWorkflowId(),
       webhookSecret: this.webhookSecret(),
       payoutVolumeThreshold: this.payoutVolumeThreshold(),
       countryThresholds: this.countryThresholds(),
@@ -240,9 +250,11 @@ export class IdentitySettingsFormComponent implements OnInit, OnChanges {
     const providerCredentials: {
       api_key?: string;
       workflow_id: string | null;
+      kyb_workflow_id: string | null;
       webhook_secret?: string;
     } = {
       workflow_id: this.workflowId().trim() || null,
+      kyb_workflow_id: this.kybWorkflowId().trim() || null,
     };
 
     const apiKey = this.apiKey().trim();

--- a/apps/web/src/app/shared/forms/index.ts
+++ b/apps/web/src/app/shared/forms/index.ts
@@ -1,3 +1,4 @@
+export * from './account-type-form/account-type-form.component';
 export * from './person-form/person-form.component';
 export * from './external-wallet-form/external-wallet-form.component';
 export * from './business-profile-form/business-profile-form.component';

--- a/apps/web/src/app/shared/forms/person-form/person-form.component.html
+++ b/apps/web/src/app/shared/forms/person-form/person-form.component.html
@@ -21,6 +21,9 @@
   </p>
   }
 
+  <!-- Content slot for account type form during onboarding -->
+  <ng-content></ng-content>
+
   <!-- Legal Name -->
   <div class="field-group">
     <div class="field-title">Your legal name</div>

--- a/apps/web/src/app/styles/forms.scss
+++ b/apps/web/src/app/styles/forms.scss
@@ -142,7 +142,10 @@ select {
   cursor: pointer;
   border-radius: $border-radius-small;
   font-family: $text-font;
-  height: 33px; /*Forces to same height as an input*/
+  box-sizing: border-box;
+  min-height: 36px;
+  height: auto;
+  line-height: 1.3;
 }
 
 option {

--- a/apps/web/src/app/utils/account-type.ts
+++ b/apps/web/src/app/utils/account-type.ts
@@ -1,0 +1,34 @@
+import { Account, AccountBusinessType } from '@zoneless/shared-types';
+
+/**
+ * True when the account represents a legal entity rather than a person.
+ */
+export function IsBusinessAccount(
+  account:
+    | Account
+    | { business_type?: AccountBusinessType | null }
+    | null
+    | undefined
+): boolean {
+  const type = account?.business_type;
+  return (
+    type === 'company' || type === 'non_profit' || type === 'government_entity'
+  );
+}
+
+const BUSINESS_TYPE_LABELS: Record<AccountBusinessType, string> = {
+  individual: 'Individual',
+  company: 'Company',
+  non_profit: 'Non-profit',
+  government_entity: 'Government entity',
+};
+
+/**
+ * Human-readable label for Account.business_type.
+ */
+export function FormatBusinessType(
+  businessType: AccountBusinessType | null | undefined
+): string {
+  if (!businessType) return BUSINESS_TYPE_LABELS.individual;
+  return BUSINESS_TYPE_LABELS[businessType];
+}

--- a/apps/web/src/app/utils/index.ts
+++ b/apps/web/src/app/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './account-type';
 export * from './constants';
 export * from './validation';

--- a/libs/shared-schemas/src/lib/AccountSchema.ts
+++ b/libs/shared-schemas/src/lib/AccountSchema.ts
@@ -103,6 +103,7 @@ const IdentityDiditSettingsSchema = z
   .object({
     api_key: z.string().min(1).max(512).nullable(),
     workflow_id: z.string().min(1).max(255).nullable(),
+    kyb_workflow_id: z.string().min(1).max(255).nullable(),
     webhook_secret: z.string().min(1).max(512).nullable(),
   })
   .partial();

--- a/libs/shared-types/src/lib/Account.ts
+++ b/libs/shared-types/src/lib/Account.ts
@@ -437,8 +437,14 @@ export interface AccountIdentityDiditSettings {
    */
   api_key?: string | null;
 
-  /** Didit workflow ID used when creating verification sessions */
+  /** Didit KYC workflow ID used for individual verification sessions */
   workflow_id?: string | null;
+
+  /**
+   * Didit KYB workflow ID used for company / non-profit / government accounts.
+   * When unset, business accounts fall back to workflow_id.
+   */
+  kyb_workflow_id?: string | null;
 
   /**
    * Didit webhook destination shared secret.


### PR DESCRIPTION
## Description

During onboarding, a connect account can choose between individual or business. The platform can optionally paste in a KYB workflow ID from Didit via their dashboard to run checks against the business (or if left empty, regular KYC checks will run against the individual).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
