### PR TITLE
fix: display of account status chips for connected accounts

### DIFF
--- a/apps/api/src/modules/Account.ts
+++ b/apps/api/src/modules/Account.ts
@@ -559,10 +559,18 @@ export class AccountModule {
           },
         };
       case 'in_review':
-        // pending_verification[0] exists ⇒ array is non-empty
-        // OR person verification is pending (handled client-side for chips;
-        // list filter focuses on soft-review pending_verification).
+        // Lite-review flags only. KYC-due / payouts-off accounts are Restricted
+        // even when pending_verification also lists the document.
         return {
+          payouts_enabled: true,
+          'requirements.disabled_reason': {
+            operator: QueryOperators['not-in'],
+            value: rejectedReasons,
+          },
+          'requirements.currently_due.0': {
+            operator: QueryOperators.exists,
+            value: false,
+          },
           'requirements.pending_verification.0': {
             operator: QueryOperators.exists,
             value: true,

--- a/apps/web/src/app/features/account/connected-accounts/util/connected-account-display.ts
+++ b/apps/web/src/app/features/account/connected-accounts/util/connected-account-display.ts
@@ -7,22 +7,17 @@ export function GetAccountStatus(account: Account): string {
     return 'rejected';
   }
 
-  // Document submitted / provider processing — Stripe "In review"
-  if (account.individual?.verification?.status === 'pending') {
-    return 'in_review';
-  }
-
   const currentlyDue = account.requirements?.currently_due ?? [];
-  if (currentlyDue.length > 0) {
+  if (currentlyDue.length > 0 || !account.payouts_enabled) {
     return 'restricted';
   }
 
-  // Soft lite-review signals (duplicates, country mismatch, etc.)
+  // Soft lite-review only — payouts still on, operator can dismiss or reject
   if ((account.requirements?.pending_verification?.length ?? 0) > 0) {
     return 'in_review';
   }
 
-  return account.payouts_enabled ? 'enabled' : 'restricted';
+  return 'enabled';
 }
 
 export function FormatPayoutSchedule(account: Account): string {


### PR DESCRIPTION
## Description

Connected account statuses now follow the following rules:

Rejected — rejected reason
Restricted — something currently_due, or payouts off (missing ID, paused, and so on)
In review — payouts still on, only lite-review flags (Dismiss review / Reject)
Enabled — payouts on, nothing to review

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
