### PR TITLE
feat: display verification id on connect account page

### DIFF
--- a/apps/web/src/app/data/services/identity.service.ts
+++ b/apps/web/src/app/data/services/identity.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, inject } from '@angular/core';
 import { ApiService } from '../../core/services/api.service';
-import type { IdentityVerificationSession } from '@zoneless/shared-types';
+import type {
+  IdentityVerificationSession,
+  ListResponse,
+} from '@zoneless/shared-types';
 import type { CreateIdentityVerificationSessionInput } from '@zoneless/shared-schemas';
 
 @Injectable({
@@ -20,6 +23,29 @@ export class IdentityService {
       'POST',
       'identity/verification_sessions',
       data
+    );
+  }
+
+  /**
+   * List VerificationSessions for the platform, newest first.
+   */
+  async ListVerificationSessions(
+    params: {
+      relatedAccount?: string;
+      limit?: number;
+    } = {}
+  ): Promise<ListResponse<IdentityVerificationSession>> {
+    const query: Record<string, string> = {};
+    if (params.relatedAccount) {
+      query['related_account'] = params.relatedAccount;
+    }
+    if (params.limit !== undefined) {
+      query['limit'] = String(params.limit);
+    }
+    return this.api.Call<ListResponse<IdentityVerificationSession>>(
+      'GET',
+      'identity/verification_sessions',
+      query
     );
   }
 }

--- a/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.html
+++ b/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.html
@@ -408,6 +408,11 @@
           }
         </ul>
       </div>
+      } @if (diditSessionId(); as sessionId) {
+      <div class="mb">
+        <div class="bolded mb-small">Didit session</div>
+        <div><app-copy-text [text]="sessionId"></app-copy-text></div>
+      </div>
       } @if ( !GetIdentityStatusLabel() && GetCurrentlyDue().length === 0 &&
       GetPendingVerification().length === 0 && GetRequirementErrors().length ===
       0 ) {

--- a/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.ts
+++ b/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.ts
@@ -23,6 +23,7 @@ import {
   AccountService,
   BalanceService,
   ExternalWalletService,
+  IdentityService,
   PersonService,
 } from '../../../../../data';
 import { MetaService } from '../../../../../core';
@@ -84,6 +85,7 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
   private readonly accountService = inject(AccountService);
   private readonly balanceService = inject(BalanceService);
   private readonly externalWalletService = inject(ExternalWalletService);
+  private readonly identityService = inject(IdentityService);
   private readonly personService = inject(PersonService);
   private readonly metaService = inject(MetaService);
   readonly actions = inject(ConnectedAccountActionsService);
@@ -106,6 +108,7 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
   availableBalance: WritableSignal<number> = signal(0);
   pendingBalance: WritableSignal<number> = signal(0);
   externalWallets: WritableSignal<ExternalWallet[]> = signal([]);
+  diditSessionId: WritableSignal<string | null> = signal(null);
   idCopied: WritableSignal<boolean> = signal(false);
   private idCopiedTimer?: ReturnType<typeof setTimeout>;
 
@@ -407,6 +410,7 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
     if (this.account()?.id === id) return;
 
     this.account.set(null);
+    this.diditSessionId.set(null);
     this.activeTab.set('overview');
     this.detailPanel.set('main');
     this.moneyMovementTab.set('payouts');
@@ -427,6 +431,7 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
       await Promise.all([
         this.RefreshBalance(id),
         this.LoadWallets(id, account),
+        this.LoadLatestVerificationSession(id),
       ]);
     } finally {
       this.loading.set(false);
@@ -462,6 +467,22 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
       this.actions.externalWallets.set(wallets);
     } catch {
       this.externalWallets.set([]);
+    }
+  }
+
+  private async LoadLatestVerificationSession(
+    accountId: string
+  ): Promise<void> {
+    try {
+      const result = await this.identityService.ListVerificationSessions({
+        relatedAccount: accountId,
+        limit: 1,
+      });
+      this.diditSessionId.set(
+        result.data[0]?.provider_session_id?.trim() || null
+      );
+    } catch {
+      this.diditSessionId.set(null);
     }
   }
 


### PR DESCRIPTION
## Description

Adds an easy way to copy the Didit verification id from the platform dashboard, so make the connection between Zoneless connected account and Didit verification session.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
