### PR TITLE
feat: view multiple vericiation sessions + re-verify block on reject

### DIFF
--- a/apps/web/src/app/data/services/identity.service.ts
+++ b/apps/web/src/app/data/services/identity.service.ts
@@ -33,6 +33,7 @@ export class IdentityService {
     params: {
       relatedAccount?: string;
       limit?: number;
+      startingAfter?: string;
     } = {}
   ): Promise<ListResponse<IdentityVerificationSession>> {
     const query: Record<string, string> = {};
@@ -41,6 +42,9 @@ export class IdentityService {
     }
     if (params.limit !== undefined) {
       query['limit'] = String(params.limit);
+    }
+    if (params.startingAfter) {
+      query['starting_after'] = params.startingAfter;
     }
     return this.api.Call<ListResponse<IdentityVerificationSession>>(
       'GET',

--- a/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.html
+++ b/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.html
@@ -408,10 +408,16 @@
           }
         </ul>
       </div>
-      } @if (diditSessionId(); as sessionId) {
+      } @if (diditSessionIds().length > 0) {
       <div class="mb">
-        <div class="bolded mb-small">Didit session</div>
-        <div><app-copy-text [text]="sessionId"></app-copy-text></div>
+        <div class="bolded mb-small">
+          Didit session{{ diditSessionIds().length > 1 ? 's' : '' }}
+        </div>
+        @for (sessionId of diditSessionIds(); track sessionId) {
+        <div class="mb-small">
+          <app-copy-text [text]="sessionId"></app-copy-text>
+        </div>
+        }
       </div>
       } @if ( !GetIdentityStatusLabel() && GetCurrentlyDue().length === 0 &&
       GetPendingVerification().length === 0 && GetRequirementErrors().length ===

--- a/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.ts
+++ b/apps/web/src/app/features/account/connected-accounts/views/connected-account-detail/connected-account-detail.component.ts
@@ -108,7 +108,7 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
   availableBalance: WritableSignal<number> = signal(0);
   pendingBalance: WritableSignal<number> = signal(0);
   externalWallets: WritableSignal<ExternalWallet[]> = signal([]);
-  diditSessionId: WritableSignal<string | null> = signal(null);
+  diditSessionIds: WritableSignal<string[]> = signal([]);
   idCopied: WritableSignal<boolean> = signal(false);
   private idCopiedTimer?: ReturnType<typeof setTimeout>;
 
@@ -410,7 +410,7 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
     if (this.account()?.id === id) return;
 
     this.account.set(null);
-    this.diditSessionId.set(null);
+    this.diditSessionIds.set([]);
     this.activeTab.set('overview');
     this.detailPanel.set('main');
     this.moneyMovementTab.set('payouts');
@@ -431,7 +431,7 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
       await Promise.all([
         this.RefreshBalance(id),
         this.LoadWallets(id, account),
-        this.LoadLatestVerificationSession(id),
+        this.LoadVerificationSessions(id),
       ]);
     } finally {
       this.loading.set(false);
@@ -470,19 +470,26 @@ export class ConnectedAccountDetailViewComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async LoadLatestVerificationSession(
-    accountId: string
-  ): Promise<void> {
+  private async LoadVerificationSessions(accountId: string): Promise<void> {
     try {
-      const result = await this.identityService.ListVerificationSessions({
-        relatedAccount: accountId,
-        limit: 1,
-      });
-      this.diditSessionId.set(
-        result.data[0]?.provider_session_id?.trim() || null
-      );
+      const ids: string[] = [];
+      let startingAfter: string | undefined;
+      for (;;) {
+        const result = await this.identityService.ListVerificationSessions({
+          relatedAccount: accountId,
+          limit: 100,
+          startingAfter,
+        });
+        for (const session of result.data) {
+          const id = session.provider_session_id?.trim();
+          if (id) ids.push(id);
+        }
+        if (!result.has_more || result.data.length === 0) break;
+        startingAfter = result.data[result.data.length - 1].id;
+      }
+      this.diditSessionIds.set(ids);
     } catch {
-      this.diditSessionId.set(null);
+      this.diditSessionIds.set([]);
     }
   }
 

--- a/apps/web/src/app/features/account/settings/settings.component.ts
+++ b/apps/web/src/app/features/account/settings/settings.component.ts
@@ -44,6 +44,7 @@ import {
   GetIdentityDocumentTaskTitle,
   NeedsIdentityDocumentRemediation,
 } from '../connected-accounts/util/identity-requirements';
+import { IsRejectedAccountReason } from '@zoneless/shared-schemas';
 
 @Component({
   selector: 'app-settings',
@@ -118,11 +119,14 @@ export class SettingsComponent implements OnInit {
   identityVerificationStarting: WritableSignal<boolean> = signal(false);
   identityVerificationError: WritableSignal<string> = signal('');
 
-  readonly showIdentityTask = computed(
-    () =>
+  readonly showIdentityTask = computed(() => {
+    const account = this.accountService.account();
+    return (
       !this.authService.isPlatform() &&
-      NeedsIdentityDocumentRemediation(this.accountService.account())
-  );
+      !IsRejectedAccountReason(account?.requirements?.disabled_reason) &&
+      NeedsIdentityDocumentRemediation(account)
+    );
+  });
 
   readonly identityRepresentativeName = computed(() => {
     const personName = this.personService.GetFullName(


### PR DESCRIPTION
## Description

Shows a list of multiple verifications that the user has done via Didit. Also definitively hides the re-verification step in the connected account's dashboard if they have been rejected.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation

## How Was This Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] Self-reviewed my code
- [x] No new warnings
- [x] Existing tests still pass
- [x] Breaking changes are documented above
